### PR TITLE
Fixes for SVG shield manipulation code

### DIFF
--- a/style/layer/highway_shield.js
+++ b/style/layer/highway_shield.js
@@ -1,26 +1,26 @@
-var layerHighwayShieldInterstate12 = {
-  id: "highway-shield-us-interstate-12",
+var layerHighwayShieldInterstate = {
+  id: "highway-shield-us-interstate",
   type: "symbol",
   paint: {
     "text-color": "rgba(255, 255, 255, 1)",
   },
   filter: [
     "all",
-    ["<=", "ref_length", 2],
+    ["<=", "ref_length", 6],
     ["==", "$type", "LineString"],
     ["in", "network", "us-interstate"],
   ],
   layout: {
-    "icon-size": 5.0,
+    "icon-size": 2.0,
     "text-font": ["Open Sans Bold"],
+    "text-size": 10.5,
     "text-anchor": "center",
-    "text-offset": [0, 0.08],
+    "text-field": "{ref}",
+    "text-offset": [0, 0],
     "icon-image": "us_interstate",
     "icon-text-fit": "both",
-    "icon-padding": 30,
-    "icon-text-fit-padding": [3, 17.5, 0, 17.5],
-
-    "text-field": "{ref}",
+    "icon-padding": 0,
+    "icon-text-fit-padding": [2.5, 0.6, 0, 0.5],
     "symbol-spacing": {
       stops: [
         [7, 150],
@@ -29,100 +29,6 @@ var layerHighwayShieldInterstate12 = {
       ],
     },
 
-    "symbol-placement": {
-      base: 1,
-      stops: [
-        [7, "point"],
-        [7, "line"],
-        [8, "line"],
-      ],
-    },
-    "symbol-avoid-edges": true,
-    "icon-rotation-alignment": "viewport",
-    "text-rotation-alignment": "viewport",
-  },
-  source: "openmaptiles",
-  minzoom: 7,
-  "source-layer": "transportation_name",
-};
-
-var layerHighwayShieldInterstate3 = {
-  id: "highway-shield-us-interstate-3",
-  type: "symbol",
-  paint: {
-    "text-color": "rgba(255, 255, 255, 1)",
-  },
-  filter: [
-    "all",
-    ["==", "ref_length", 3],
-    ["==", "$type", "LineString"],
-    ["in", "network", "us-interstate"],
-  ],
-  layout: {
-    "icon-size": 5.0,
-    "text-font": ["Open Sans Bold"],
-    "text-anchor": "center",
-    "text-offset": [0, 0.08],
-    "icon-image": "us_interstate",
-    "icon-text-fit": "both",
-    "icon-padding": 30,
-    "icon-text-fit-padding": [3, 17.5, 0, 17.5],
-    "text-field": "{ref}",
-    "symbol-spacing": {
-      stops: [
-        [7, 150],
-        [13, 300],
-        [16, 800],
-      ],
-    },
-
-    "symbol-placement": {
-      base: 1,
-      stops: [
-        [7, "point"],
-        [7, "line"],
-        [8, "line"],
-      ],
-    },
-    "symbol-avoid-edges": true,
-    "icon-rotation-alignment": "viewport",
-    "text-rotation-alignment": "viewport",
-  },
-  source: "openmaptiles",
-  minzoom: 7,
-  "source-layer": "transportation_name",
-};
-
-var layerHighwayShieldInterstate4 = {
-  id: "highway-shield-us-interstate-4",
-  type: "symbol",
-  paint: {
-    "text-color": "rgba(255, 255, 255, 1)",
-  },
-  filter: [
-    "all",
-    ["==", "ref_length", 4],
-    ["==", "$type", "LineString"],
-    ["in", "network", "us-interstate"],
-  ],
-  layout: {
-    "icon-size": 5.0,
-    "text-font": ["Open Sans Semibold"],
-    "text-size": 18,
-    "text-anchor": "center",
-    "text-offset": [0, 0.08],
-    "icon-image": "us_interstate",
-    "icon-text-fit": "both",
-    "icon-padding": 30,
-    "icon-text-fit-padding": [3, 17.5, 0, 17.5],
-    "text-field": "{ref}",
-    "symbol-spacing": {
-      stops: [
-        [7, 150],
-        [13, 300],
-        [16, 800],
-      ],
-    },
     "symbol-placement": {
       base: 1,
       stops: [

--- a/style/layers.js
+++ b/style/layers.js
@@ -27,9 +27,8 @@ var americanaLayers = [
   layerBridgeOneway,
   layerBridgeOnewayLink,
 
+  layerMotorwayExit,
   layerMotorwayLabel,
 
-  layerHighwayShieldInterstate12,
-  layerHighwayShieldInterstate3,
-  layerHighwayShieldInterstate4,
+  layerHighwayShieldInterstate,
 ];

--- a/style/layers.js
+++ b/style/layers.js
@@ -27,7 +27,6 @@ var americanaLayers = [
   layerBridgeOneway,
   layerBridgeOnewayLink,
 
-  layerMotorwayExit,
   layerMotorwayLabel,
 
   layerHighwayShieldInterstate,

--- a/style/scripts/import_rebusurance.sh
+++ b/style/scripts/import_rebusurance.sh
@@ -7,17 +7,44 @@ done
 
 for i in $( ls build/rebusurance-v1.0.0/image2d/ | grep [A-Z] );
 do
+  svg="build/rebusurance-v1.0.0/image2d/$i"
+
   #Remove text placeholder from shields
-  sed -i 's/<text.*\/text>//g' "build/rebusurance-v1.0.0/image2d/$i"
-
   #Scale shields to a reasonable size for rasterization
-  sed -i 's/transform=""/transform="scale(0.35,0.35)"/g' "build/rebusurance-v1.0.0/image2d/$i"
+  xmlstarlet ed -L -N x=http://www.w3.org/2000/svg \
+    -u "//x:svg/@height" \
+    --value 50 \
+    -u "//x:svg/@width" \
+    --value 60 \
+    -d "//x:svg/x:text" \
+    -d "//x:svg/x:path/@transform" \
+    -a "//x:svg/x:path" -t attr -n transform \
+    --value "scale(0.5,0.5)" \
+    -d "//x:svg/x:rect/@transform" \
+    -a "//x:svg/x:rect" -t attr -n transform \
+    --value "scale(0.5,0.5)" \
+    -d "//x:svg/x:g/@transform" \
+    -a "//x:svg/x:g" -t attr -n transform \
+    --value "scale(0.5,0.5)" "$svg"
 
-  cp "build/rebusurance-v1.0.0/image2d/$i" icons/us_`echo "$i" | tr 'A-Z' 'a-z'`
+  #Copy files to icons folder, converting space to underscore and lowercase letters
+  cp "$svg" icons/us_`echo "$i" | tr 'A-Z' 'a-z'`
 done
 
 
 #Customizations
 
 #Make the crown on US Interstate highway shields pointier
-xmlstarlet ed -L -N x=http://www.w3.org/2000/svg -u "//x:svg/x:path[@id='interstate-crown']/@transform" --value "scale(0.35,0.70) translate(0,10)" icons/us_interstate.svg
+xmlstarlet ed -L -N x=http://www.w3.org/2000/svg \
+  -u "//x:svg/@height" \
+  --value 70 \
+  -u "//x:svg/x:path[@id='interstate-crown']/@transform" \
+  --value "scale(0.50,1.5) translate(0,18)" \
+  icons/us_interstate.svg
+
+#Fix resizing of Florida state outline
+xmlstarlet ed -L -N x=http://www.w3.org/2000/svg \
+  -u "//x:svg/x:path[@id='florida-state']/@transform" \
+  --value "scale(0.5, 0.5) translate(-17,-39)" \
+  icons/us_florida.svg
+


### PR DESCRIPTION
Fixes #15 

This fixes a number of issues with the SVG import.
1. We're now using xmlstarlet in all cases and eliminated sed hacking, which is unreliable and breaks under different CR/LF situations.  Since xmlstarlet is XML-aware, we'll avoid that problem.
2. Set the icon sizes for each shield so they don't take up so much space in the sprite sheet.  This also fixes the issue where the icons were artificially enlarged and thus reducing the frequency of shield placement by mapLibre.
3. Eliminated separate 2,3,4 digit shield styles and switched to dynamically-resizing icons.
4. Slightly reduced the size of the rendered icons.

![image](https://user-images.githubusercontent.com/3254090/120228094-74d43500-c218-11eb-8b81-a75ec66db710.png)