### PR TITLE
Parse bridge layers separately

### DIFF
--- a/style/index.html
+++ b/style/index.html
@@ -32,6 +32,8 @@
     <script type="text/javascript" src="constants/color.js"></script>
     <script type="text/javascript" src="constants/line.js"></script>
 
+    <script type="text/javascript" src="js/util.js"></script>
+
     <script type="text/javascript" src="layer/background.js"></script>
     <script type="text/javascript" src="layer/water.js"></script>
     <script type="text/javascript" src="layer/road_casing.js"></script>

--- a/style/js/util.js
+++ b/style/js/util.js
@@ -1,0 +1,9 @@
+//Utility functions
+
+//Limit the specified definition to a single numbered layer
+function restrictLayer(def, layer) {
+  var layerClone = JSON.parse(JSON.stringify(def));
+  layerClone.filter.push(["==", "layer", layer]);
+  layerClone.id = layerClone.id + "_layer_" + layer;
+  return layerClone;
+}

--- a/style/layers.js
+++ b/style/layers.js
@@ -1,41 +1,47 @@
 /*
  This is a list of the layers in the Americana style, from bottom to top.  They're defined in the layer/ folder
 */
-var americanaLayers = [
-  layerBackground,
+var americanaLayers = [];
 
-  layerWater,
+americanaLayers.push(layerBackground);
 
-  layerTunnelMotorwayCasing,
-  layerTunnelMotorwayLinkCasing,
-  layerTunnelMotorway,
-  layerTunnelMotorwayLink,
-  layerTunnelOneway,
-  layerTunnelOnewayLink,
+americanaLayers.push(layerWater);
 
-  layerMotorwayCasing,
-  layerMotorwayLinkCasing,
-  layerMotorway,
-  layerMotorwayLink,
-  layerRoadOneway,
-  layerRoadOnewayLink,
+americanaLayers.push(layerTunnelMotorwayCasing);
+americanaLayers.push(layerTunnelMotorwayLinkCasing);
+americanaLayers.push(layerTunnelMotorway);
+americanaLayers.push(layerTunnelMotorwayLink);
+americanaLayers.push(layerTunnelOneway);
+americanaLayers.push(layerTunnelOnewayLink);
 
-  layerBridgeMotorwayCasing,
-  layerBridgeMotorwayLinkCasing,
-  layerBridgeMotorway,
-  layerBridgeMotorwayLink,
-  layerBridgeOneway,
-  layerBridgeOnewayLink,
+americanaLayers.push(layerMotorwayCasing);
 
-  layerMotorwayLabel,
+americanaLayers.push(layerMotorwayLinkCasing);
+americanaLayers.push(layerMotorway);
+americanaLayers.push(layerMotorwayLink);
+americanaLayers.push(layerRoadOneway);
+americanaLayers.push(layerRoadOnewayLink);
 
-  layerHighwayShieldInterstate,
+//One layer at a time to handle stacked bridges
+for (let i = 1; i <= 5; i++) {
+  [
+    layerBridgeMotorwayCasing,
+    layerBridgeMotorwayLinkCasing,
+    layerBridgeMotorway,
+    layerBridgeMotorwayLink,
+    layerBridgeOneway,
+    layerBridgeOnewayLink,
+  ].forEach((layer) => americanaLayers.push(restrictLayer(layer, i)));
+}
 
-  layerPlaceCity,
-  layerPlaceState,
-  layerPlaceCountryOther,
-  layerPlaceCountry3,
-  layerPlaceCountry2,
-  layerPlaceCountry1,
-  layerPlaceContinent,
-];
+americanaLayers.push(layerMotorwayLabel);
+
+americanaLayers.push(layerHighwayShieldInterstate);
+
+americanaLayers.push(layerPlaceCity);
+americanaLayers.push(layerPlaceState);
+americanaLayers.push(layerPlaceCountryOther);
+americanaLayers.push(layerPlaceCountry3);
+americanaLayers.push(layerPlaceCountry2);
+americanaLayers.push(layerPlaceCountry1);
+americanaLayers.push(layerPlaceContinent);

--- a/style/layers.js
+++ b/style/layers.js
@@ -9,7 +9,7 @@ americanaLayers.push(
   layerWater,
 
   layerTunnelMotorwayCasing,
-  laerrTunnelMotorwayLinkCasing,
+  layerTunnelMotorwayLinkCasing,
   layerTunnelMotorway,
   layerTunnelMotorwayLink,
   layerTunnelOneway,

--- a/style/layers.js
+++ b/style/layers.js
@@ -3,24 +3,26 @@
 */
 var americanaLayers = [];
 
-americanaLayers.push(layerBackground);
+americanaLayers.push(
+  layerBackground,
 
-americanaLayers.push(layerWater);
+  layerWater,
 
-americanaLayers.push(layerTunnelMotorwayCasing);
-americanaLayers.push(layerTunnelMotorwayLinkCasing);
-americanaLayers.push(layerTunnelMotorway);
-americanaLayers.push(layerTunnelMotorwayLink);
-americanaLayers.push(layerTunnelOneway);
-americanaLayers.push(layerTunnelOnewayLink);
+  layerTunnelMotorwayCasing,
+  laerrTunnelMotorwayLinkCasing,
+  layerTunnelMotorway,
+  layerTunnelMotorwayLink,
+  layerTunnelOneway,
+  layerTunnelOnewayLink,
 
-americanaLayers.push(layerMotorwayCasing);
+  layerMotorwayCasing,
 
-americanaLayers.push(layerMotorwayLinkCasing);
-americanaLayers.push(layerMotorway);
-americanaLayers.push(layerMotorwayLink);
-americanaLayers.push(layerRoadOneway);
-americanaLayers.push(layerRoadOnewayLink);
+  layerMotorwayLinkCasing,
+  layerMotorway,
+  layerMotorwayLink,
+  layerRoadOneway,
+  layerRoadOnewayLink
+);
 
 //One layer at a time to handle stacked bridges
 for (let i = 1; i <= 5; i++) {
@@ -34,14 +36,16 @@ for (let i = 1; i <= 5; i++) {
   ].forEach((layer) => americanaLayers.push(restrictLayer(layer, i)));
 }
 
-americanaLayers.push(layerMotorwayLabel);
+americanaLayers.push(
+  layerMotorwayLabel,
 
-americanaLayers.push(layerHighwayShieldInterstate);
+  layerHighwayShieldInterstate,
 
-americanaLayers.push(layerPlaceCity);
-americanaLayers.push(layerPlaceState);
-americanaLayers.push(layerPlaceCountryOther);
-americanaLayers.push(layerPlaceCountry3);
-americanaLayers.push(layerPlaceCountry2);
-americanaLayers.push(layerPlaceCountry1);
-americanaLayers.push(layerPlaceContinent);
+  layerPlaceCity,
+  layerPlaceState,
+  layerPlaceCountryOther,
+  layerPlaceCountry3,
+  layerPlaceCountry2,
+  layerPlaceCountry1,
+  layerPlaceContinent
+);


### PR DESCRIPTION
This PR fixes an issue identified by @zekefarwell in which overlapping bridges render as if they're intersecting, ignoring the `layer` key.  Since the layers are defined in javascript, we can define individual layers and programmatically create a copy of each bridge layer for each layer.

We use 5 layers as the upper limit for this processing, based on the [High Five Interchange](https://en.wikipedia.org/wiki/High_Five_Interchange) in Dallas, TX, however, we may need to investigate whether there are more complex intersections that require a higher upper bound.

This assumes that above-ground layers are numbered starting at 1 and increment by 1 and therefore this is a reasonable limit.

Results:
![image](https://user-images.githubusercontent.com/3254090/125012967-08c7c680-e039-11eb-82d8-24aa8793b326.png)
