### PR TITLE
Change prettier config to same-commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,6 @@ jobs:
           prettier_options: --write .
           # Setting only_changed to false picks up new files
           only_changed: false
+          same_commit: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,5 +24,6 @@ jobs:
           # Setting only_changed to false picks up new files
           only_changed: false
           same_commit: true
+          commit_options: --allow-empty
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/style/layers.js
+++ b/style/layers.js
@@ -6,7 +6,7 @@ var americanaLayers = [];
 americanaLayers.push(
   layerBackground,
 
-  layerWater,
+    layerWater,
 
   layerTunnelMotorwayCasing,
   layerTunnelMotorwayLinkCasing,

--- a/style/layers.js
+++ b/style/layers.js
@@ -6,7 +6,7 @@ var americanaLayers = [];
 americanaLayers.push(
   layerBackground,
 
-    layerWater,
+  layerWater,
 
   layerTunnelMotorwayCasing,
   layerTunnelMotorwayLinkCasing,


### PR DESCRIPTION
Hopefully this fixes the issue we're having with prettier completion not being detected by merge checks.  This will add a prettier action to the same commit in a PR, rather than create a subsequent one.