### PR TITLE
Relativize URLs and switch fonts to https

### DIFF
--- a/style/index.html
+++ b/style/index.html
@@ -56,9 +56,9 @@
         zoom: 1,
         pitch: 0,
         center: [0, 0],
-        glyphs: "http://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
+        glyphs: "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
         layers: americanaLayers,
-        sprite: new URL("/sprites/sprite", window.location.origin).href,
+        sprite: new URL("sprites/sprite", window.location.origin).href,
         bearing: 0,
         sources: {
           openmaptiles: {


### PR DESCRIPTION
Updates to the index.html to support hosting on github pages.  Since github pages uses https, we need to change any http links to https, and the links to sprites needs to be relativized since the html files are in a subdirectory.