### PR TITLE
Add support for bridges without layer tag

### DIFF
--- a/style/js/util.js
+++ b/style/js/util.js
@@ -2,8 +2,13 @@
 
 //Limit the specified definition to a single numbered layer
 function restrictLayer(def, layer) {
+  return filteredClone(def, ["==", "layer", layer], "_layer_" + layer);
+}
+
+//Make a clone of a layer definition, with a filter added
+function filteredClone(def, filterStep, idSuffix) {
   var layerClone = JSON.parse(JSON.stringify(def));
-  layerClone.filter.push(["==", "layer", layer]);
-  layerClone.id = layerClone.id + "_layer_" + layer;
+  layerClone.filter.push(filterStep);
+  layerClone.id = layerClone.id + idSuffix;
   return layerClone;
 }

--- a/style/layers.js
+++ b/style/layers.js
@@ -24,17 +24,26 @@ americanaLayers.push(
   layerRoadOnewayLink
 );
 
-//One layer at a time to handle stacked bridges
-for (let i = 1; i <= 5; i++) {
-  [
+var bridgeLayers =  [
     layerBridgeMotorwayCasing,
     layerBridgeMotorwayLinkCasing,
     layerBridgeMotorway,
     layerBridgeMotorwayLink,
     layerBridgeOneway,
     layerBridgeOnewayLink,
-  ].forEach((layer) => americanaLayers.push(restrictLayer(layer, i)));
+  ];
+
+//Render bridge without layer on the lowest bridge layer
+bridgeLayers.forEach((layer) => americanaLayers.push(filteredClone(layer, ["!has", "layer"], "_layer_bottom")));
+
+//One layer at a time to handle stacked bridges
+for (let i = 1; i <= 4; i++) {
+  bridgeLayers.forEach((layer) => americanaLayers.push(restrictLayer(layer, i)));
 }
+
+//If layer is more than 5, just give up and render on a single layer.
+bridgeLayers.forEach((layer) => americanaLayers.push(filteredClone(layer, [">=", "layer", 5], "_layer_top")));
+
 
 americanaLayers.push(
   layerMotorwayLabel,

--- a/style/layers.js
+++ b/style/layers.js
@@ -24,26 +24,31 @@ americanaLayers.push(
   layerRoadOnewayLink
 );
 
-var bridgeLayers =  [
-    layerBridgeMotorwayCasing,
-    layerBridgeMotorwayLinkCasing,
-    layerBridgeMotorway,
-    layerBridgeMotorwayLink,
-    layerBridgeOneway,
-    layerBridgeOnewayLink,
-  ];
+var bridgeLayers = [
+  layerBridgeMotorwayCasing,
+  layerBridgeMotorwayLinkCasing,
+  layerBridgeMotorway,
+  layerBridgeMotorwayLink,
+  layerBridgeOneway,
+  layerBridgeOnewayLink,
+];
 
 //Render bridge without layer on the lowest bridge layer
-bridgeLayers.forEach((layer) => americanaLayers.push(filteredClone(layer, ["!has", "layer"], "_layer_bottom")));
+bridgeLayers.forEach((layer) =>
+  americanaLayers.push(filteredClone(layer, ["!has", "layer"], "_layer_bottom"))
+);
 
 //One layer at a time to handle stacked bridges
 for (let i = 1; i <= 4; i++) {
-  bridgeLayers.forEach((layer) => americanaLayers.push(restrictLayer(layer, i)));
+  bridgeLayers.forEach((layer) =>
+    americanaLayers.push(restrictLayer(layer, i))
+  );
 }
 
 //If layer is more than 5, just give up and render on a single layer.
-bridgeLayers.forEach((layer) => americanaLayers.push(filteredClone(layer, [">=", "layer", 5], "_layer_top")));
-
+bridgeLayers.forEach((layer) =>
+  americanaLayers.push(filteredClone(layer, [">=", "layer", 5], "_layer_top"))
+);
 
 americanaLayers.push(
   layerMotorwayLabel,


### PR DESCRIPTION
Fixes #34

This makes two changes to bridge layering:
1. The lowest level is now "bridges with no layer tag" which catches bridges where nobody bothered to set it, as well as bridges at lower zoom which are stripped of their layer tag by OpenMapTiles.
2. Bridges at layer 5 or above are now grouped together in a single layer.  It's doubtful that there's any cases in reality of a bridge stack of 6 or more, so this is a reasonable optimization.

Render sample from New Orleans at zoom 7:
![image](https://user-images.githubusercontent.com/3254090/125376507-2a86bd80-e359-11eb-85e4-9ac5253593f4.png)
