### PR TITLE
Add protected area rendering

### DIFF
--- a/style/constants/color.js
+++ b/style/constants/color.js
@@ -1,3 +1,9 @@
+var colorTransparent = "hsla(0, 0%, 0%, 0)";
+
+var colorWaterFill = "hsl(211, 42%, 70%)";
+var colorWaterLine = "hsl(211, 73%, 78%)";
+var colorWaterIntermittent = "hsl(205, 89%, 83%)";
+
 var colorMotorway = "hsla(354, 71%, 40%, 1)";
 var colorMotorwayCasing = "hsla(354, 71%, 20%, 1)";
 var colorMotorwayTunnel = "hsla(354, 71%, 90%, 1)";
@@ -7,6 +13,6 @@ var colorBridgeCasing = "black";
 var colorBorder = "rgba(123, 119, 119, 1)";
 var colorBorderCasing = "rgba(224, 207, 232, 1)";
 
-var colorParkFill = "hsla(136, 41%, 89%, 1)";
-var colorParkOutline = "hsla(136, 41%, 79%, 1)";
-var colorParkLabel = "hsla(136, 71%, 29%, 1)";
+var colorParkFill = "hsl(136, 41%, 89%)";
+var colorParkOutline = "hsl(136, 41%, 79%)";
+var colorParkLabel = "hsl(136, 71%, 29%)";

--- a/style/constants/color.js
+++ b/style/constants/color.js
@@ -6,3 +6,7 @@ var colorBridgeCasing = "black";
 
 var colorBorder = "rgba(123, 119, 119, 1)";
 var colorBorderCasing = "rgba(224, 207, 232, 1)";
+
+var colorParkFill = "hsla(136, 41%, 89%, 1)";
+var colorParkOutline = "hsla(136, 41%, 79%, 1)";
+var colorParkLabel = "hsla(136, 71%, 29%, 1)";

--- a/style/index.html
+++ b/style/index.html
@@ -50,6 +50,7 @@
     <script type="text/javascript" src="layer/oneway.js"></script>
     <script type="text/javascript" src="layer/place.js"></script>
     <script type="text/javascript" src="layer/boundary.js"></script>
+    <script type="text/javascript" src="layer/park.js"></script>
 
     <script type="text/javascript" src="layers.js"></script>
   </head>

--- a/style/layer/park.js
+++ b/style/layer/park.js
@@ -3,7 +3,20 @@ var layerParkFill = {
   type: "fill",
   paint: {
     "fill-color": colorParkFill,
-    "fill-outline-color": colorParkOutline,
+  },
+  layout: {
+    visibility: "visible",
+  },
+  source: "openmaptiles",
+  metadata: {},
+  "source-layer": "park",
+};
+
+var layerParkOutline = {
+  id: "protected-area-outline",
+  type: "line",
+  paint: {
+    "line-color": colorParkOutline,
   },
   layout: {
     visibility: "visible",

--- a/style/layer/park.js
+++ b/style/layer/park.js
@@ -1,0 +1,36 @@
+var layerParkFill = {
+  id: "protected-area-fill",
+  type: "fill",
+  paint: {
+    "fill-color": colorParkFill,
+    "fill-outline-color": colorParkOutline,
+  },
+  layout: {
+    visibility: "visible",
+  },
+  source: "openmaptiles",
+  metadata: {},
+  "source-layer": "park",
+};
+
+var layerParkLabel = {
+  id: "protected-area-label",
+  type: "symbol",
+  filter: ["has", "rank"],
+  paint: {
+    "text-color": colorParkLabel,
+    "text-halo-blur": 1,
+    "text-halo-color": "rgba(255, 255, 255, 1)",
+    "text-halo-width": 1,
+  },
+  layout: {
+    visibility: "visible",
+    "text-field": "{name}",
+    "text-font": ["Metropolis Bold"],
+    "text-size": 10,
+    "symbol-sort-key": ["get", "rank"],
+  },
+  source: "openmaptiles",
+  metadata: {},
+  "source-layer": "park",
+};

--- a/style/layer/water.js
+++ b/style/layer/water.js
@@ -2,7 +2,7 @@ var layerwaterwayTunnel = {
   id: "waterway_tunnel",
   type: "line",
   paint: {
-    "line-color": "#a0c8f0",
+    "line-color": colorWaterLine,
     "line-width": {
       base: 1.3,
       stops: [
@@ -26,7 +26,7 @@ var layerWaterwayRiver = {
   id: "waterway_river",
   type: "line",
   paint: {
-    "line-color": "#a0c8f0",
+    "line-color": colorWaterLine,
     "line-width": {
       base: 1.2,
       stops: [
@@ -53,7 +53,7 @@ var layerWaterwayRiverIntermittent = {
   id: "waterway_river_intermittent",
   type: "line",
   paint: {
-    "line-color": "#a0c8f0",
+    "line-color": colorWaterLine,
     "line-width": {
       base: 1.2,
       stops: [
@@ -80,7 +80,7 @@ var layerWaterwayOther = {
   id: "waterway_other",
   type: "line",
   paint: {
-    "line-color": "#a0c8f0",
+    "line-color": colorWaterLine,
     "line-width": {
       base: 1.3,
       stops: [
@@ -108,7 +108,7 @@ var layerWaterwayOtherIntermittent = {
   id: "waterway_other_intermittent",
   type: "line",
   paint: {
-    "line-color": "#a0c8f0",
+    "line-color": colorWaterLine,
     "line-width": {
       base: 1.3,
       stops: [
@@ -137,7 +137,7 @@ var layerWaterIntermittent = {
   id: "water_intermittent",
   type: "fill",
   paint: {
-    "fill-color": "rgba(172, 218, 251, 1)",
+    "fill-color": colorWaterIntermittent,
     "fill-opacity": 0.85,
   },
   filter: ["all", ["==", "intermittent", 1]],
@@ -153,7 +153,7 @@ var layerWater = {
   id: "water",
   type: "fill",
   paint: {
-    "fill-color": "rgba(134, 204, 250, 1)",
+    "fill-color": colorWaterFill,
   },
   filter: ["all", ["!=", "intermittent", 1], ["!=", "brunnel", "tunnel"]],
   layout: {

--- a/style/layers.js
+++ b/style/layers.js
@@ -6,13 +6,15 @@ var americanaLayers = [];
 americanaLayers.push(
   layerBackground,
 
+  layerParkFill,
+
   layerBoundaryCountyBg,
   layerBoundaryStateBg,
   layerBoundaryCountryBg,
 
   layerWater,
 
-  layerParkFill,
+  layerParkOutline,
 
   layerBoundaryCity,
   layerBoundaryCounty,

--- a/style/layers.js
+++ b/style/layers.js
@@ -12,6 +12,8 @@ americanaLayers.push(
 
   layerWater,
 
+  layerParkFill,
+
   layerBoundaryCity,
   layerBoundaryCounty,
   layerBoundaryState,
@@ -60,7 +62,11 @@ bridgeLayers.forEach((layer) =>
 );
 
 americanaLayers.push(
+  //The labels at the end of the list have the highest priority.
+
   layerMotorwayLabel,
+
+  layerParkLabel,
 
   layerHighwayShieldInterstate,
 


### PR DESCRIPTION
This PR adds rendering for protected areas, specifically those areas rendered in the OpenMapTiles [park layer](https://openmaptiles.org/schema/#park).  Of note, this does not include `leisure=park` (that's in the land cover layer), however, since we're mostly working on the low zoom layers at this point, that can be dealt with separately.

Note that OpenMapTiles is limited to zoom 6+ for protected areas, but we would like to bring this as low as zoom 4-5.

Screen shots:

Zoom 6:
![image](https://user-images.githubusercontent.com/3254090/126886245-dd2df82d-c0d6-4d62-ba5c-5a4285a5b45f.png)

Zoom 7:
![image](https://user-images.githubusercontent.com/3254090/126886236-c656623e-280c-460e-992f-9cb42183413e.png)
