### PR TITLE
Make import links relative

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -1,16 +1,16 @@
 "use strict";
 
-import * as Util from "/js/util.js";
+import * as Util from "./js/util.js";
 
-import * as lyrBackground from "/layer/background.js";
-import * as lyrBoundary from "/layer/boundary.js";
-import * as lyrHighwayShield from "/layer/highway_shield.js";
-import * as lyrOneway from "/layer/oneway.js";
-import * as lyrPark from "/layer/park.js";
-import * as lyrPlace from "/layer/place.js";
-import * as lyrRoad from "/layer/road.js";
-import * as lyrRoadLabel from "/layer/road_label.js";
-import * as lyrWater from "/layer/water.js";
+import * as lyrBackground from "./layer/background.js";
+import * as lyrBoundary from "./layer/boundary.js";
+import * as lyrHighwayShield from "./layer/highway_shield.js";
+import * as lyrOneway from "./layer/oneway.js";
+import * as lyrPark from "./layer/park.js";
+import * as lyrPlace from "./layer/place.js";
+import * as lyrRoad from "./layer/road.js";
+import * as lyrRoadLabel from "./layer/road_label.js";
+import * as lyrWater from "./layer/water.js";
 
 /*
  This is a list of the layers in the Americana style, from bottom to top.

--- a/style/layer/boundary.js
+++ b/style/layer/boundary.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import * as Color from "/constants/color.js";
+import * as Color from "../constants/color.js";
 
 export const city = {
   id: "boundary_city",

--- a/style/layer/park.js
+++ b/style/layer/park.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import * as Color from "/constants/color.js";
+import * as Color from "../constants/color.js";
 
 export const fill = {
   id: "protected-area-fill",

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import * as Util from "/js/util.js";
+import * as Util from "../js/util.js";
 
 //At this zoom, render switches from unified to differentiated bridge/tunnel rendering
 let minzoomBrunnel = 11;

--- a/style/layer/water.js
+++ b/style/layer/water.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import * as Color from "/constants/color.js";
+import * as Color from "../constants/color.js";
 
 export const waterwayTunnel = {
   id: "waterway_tunnel",


### PR DESCRIPTION
This PR makes Javascript ES module imports use relative paths.  This is needed for the map to render when hosted under a subdirectory, including the published map at https://zelonewolf.github.io/openstreetmap-americana.

Hopefully I got them all :)