### PR TITLE
Implement red/black road color scheme for trunk through tertiary

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -190,3 +190,4 @@ map.addControl(
   })
 );
 map.addControl(new maplibregl.NavigationControl(), "top-left");
+document.querySelector("#map canvas").focus();

--- a/style/americana.js
+++ b/style/americana.js
@@ -148,7 +148,9 @@ americanaLayers.push(
   lyrRoadLabel.primary,
   lyrRoadLabel.primaryHZ,
   lyrRoadLabel.secondary,
+  lyrRoadLabel.secondaryHZ,
   lyrRoadLabel.tertiary,
+  lyrRoadLabel.tertiaryHZ,
 
   lyrPark.label,
 

--- a/style/americana.js
+++ b/style/americana.js
@@ -51,30 +51,51 @@ americanaLayers.push(
 
   lyrRoad.motorway.casing(),
   lyrRoad.trunk.casing(),
+  lyrRoad.primary.casing(),
+  lyrRoad.secondary.casing(),
+  lyrRoad.tertiary.casing(),
 
   lyrRoad.motorwayLink.casing(),
   lyrRoad.trunkLink.casing(),
 
-  lyrRoad.motorway.fill(),
-  lyrRoad.trunk.fill(),
-
   lyrRoad.motorwayLink.fill(),
   lyrRoad.trunkLink.fill(),
+
+  lyrRoad.tertiary.fill(),
+  lyrRoad.secondary.fill(),
+  lyrRoad.primary.fill(),
+  lyrRoad.trunk.fill(),
+  lyrRoad.motorway.fill(),
 
   lyrOneway.road,
   lyrOneway.link
 );
 
 var bridgeLayers = [
-  lyrRoad.motorwayBridge.casing(),
-  lyrRoad.motorwayLinkBridge.casing(),
-  lyrRoad.motorwayBridge.fill(),
-  lyrRoad.motorwayLinkBridge.fill(),
+  lyrRoad.tertiaryBridge.casing(),
+  lyrRoad.tertiaryLinkBridge.casing(),
+  lyrRoad.tertiaryBridge.fill(),
+  lyrRoad.tertiaryLinkBridge.fill(),
+
+  lyrRoad.secondaryBridge.casing(),
+  lyrRoad.secondaryLinkBridge.casing(),
+  lyrRoad.secondaryBridge.fill(),
+  lyrRoad.secondaryLinkBridge.fill(),
+
+  lyrRoad.primaryBridge.casing(),
+  lyrRoad.primaryLinkBridge.casing(),
+  lyrRoad.primaryBridge.fill(),
+  lyrRoad.primaryLinkBridge.fill(),
 
   lyrRoad.trunkBridge.casing(),
   lyrRoad.trunkLinkBridge.casing(),
   lyrRoad.trunkBridge.fill(),
   lyrRoad.trunkLinkBridge.fill(),
+
+  lyrRoad.motorwayBridge.casing(),
+  lyrRoad.motorwayLinkBridge.casing(),
+  lyrRoad.motorwayBridge.fill(),
+  lyrRoad.motorwayLinkBridge.fill(),
 
   lyrOneway.bridge,
   lyrOneway.bridgeLink,
@@ -104,6 +125,11 @@ bridgeLayers.forEach((layer) =>
 americanaLayers.push(
   //The labels at the end of the list have the highest priority.
   lyrRoadLabel.motorway,
+  lyrRoadLabel.trunk,
+  lyrRoadLabel.primary,
+  lyrRoadLabel.primaryHZ,
+  lyrRoadLabel.secondary,
+  lyrRoadLabel.tertiary,
 
   lyrPark.label,
 
@@ -133,7 +159,8 @@ var style = {
   bearing: 0,
   sources: {
     openmaptiles: {
-      url: "https://api.maptiler.com/tiles/v3/tiles.json?key=" + mapTilerKey,
+      url: "http://localhost:8080/data/v3.json",
+      //      url: "https://api.maptiler.com/tiles/v3/tiles.json?key=" + mapTilerKey,
       type: "vector",
     },
   },
@@ -155,6 +182,11 @@ var map = new maplibregl.Map({
   zoom: 4, // starting zoom
   attributionControl: false,
 });
+
+map.on("styleimagemissing", function (e) {
+  Shield.missingIconLoader(map, e);
+});
+
 map.addControl(
   new maplibregl.AttributionControl({
     customAttribution:
@@ -162,4 +194,3 @@ map.addControl(
   })
 );
 map.addControl(new maplibregl.NavigationControl(), "top-left");
-document.querySelector("#map canvas").focus();

--- a/style/americana.js
+++ b/style/americana.js
@@ -183,10 +183,6 @@ var map = new maplibregl.Map({
   attributionControl: false,
 });
 
-map.on("styleimagemissing", function (e) {
-  Shield.missingIconLoader(map, e);
-});
-
 map.addControl(
   new maplibregl.AttributionControl({
     customAttribution:

--- a/style/americana.js
+++ b/style/americana.js
@@ -123,7 +123,7 @@ bridgeLayers.forEach((layer) =>
 );
 
 americanaLayers.push(
-  //The labels at the end of the list have the highest priority.
+  //The labels at the end of the list draw on top of the layers at the beginning.
   lyrRoadLabel.motorway,
   lyrRoadLabel.trunk,
   lyrRoadLabel.primary,

--- a/style/americana.js
+++ b/style/americana.js
@@ -159,8 +159,8 @@ var style = {
   bearing: 0,
   sources: {
     openmaptiles: {
-      url: "http://localhost:8080/data/v3.json",
-      //      url: "https://api.maptiler.com/tiles/v3/tiles.json?key=" + mapTilerKey,
+      // url: "http://localhost:8080/data/v3.json",
+      url: "https://api.maptiler.com/tiles/v3/tiles.json?key=" + mapTilerKey,
       type: "vector",
     },
   },

--- a/style/americana.js
+++ b/style/americana.js
@@ -67,6 +67,15 @@ americanaLayers.push(
   lyrRoad.trunk.fill(),
   lyrRoad.motorway.fill(),
 
+  lyrRoad.motorwayLink.surface(),
+  lyrRoad.trunkLink.surface(),
+
+  lyrRoad.tertiary.surface(),
+  lyrRoad.secondary.surface(),
+  lyrRoad.primary.surface(),
+  lyrRoad.trunk.surface(),
+  lyrRoad.motorway.surface(),
+
   lyrOneway.road,
   lyrOneway.link
 );
@@ -76,26 +85,36 @@ var bridgeLayers = [
   lyrRoad.tertiaryLinkBridge.casing(),
   lyrRoad.tertiaryBridge.fill(),
   lyrRoad.tertiaryLinkBridge.fill(),
+  lyrRoad.tertiaryBridge.surface(),
+  lyrRoad.tertiaryLinkBridge.surface(),
 
   lyrRoad.secondaryBridge.casing(),
   lyrRoad.secondaryLinkBridge.casing(),
   lyrRoad.secondaryBridge.fill(),
   lyrRoad.secondaryLinkBridge.fill(),
+  lyrRoad.secondaryBridge.surface(),
+  lyrRoad.secondaryLinkBridge.surface(),
 
   lyrRoad.primaryBridge.casing(),
   lyrRoad.primaryLinkBridge.casing(),
   lyrRoad.primaryBridge.fill(),
   lyrRoad.primaryLinkBridge.fill(),
+  lyrRoad.primaryBridge.surface(),
+  lyrRoad.primaryLinkBridge.surface(),
 
   lyrRoad.trunkBridge.casing(),
   lyrRoad.trunkLinkBridge.casing(),
   lyrRoad.trunkBridge.fill(),
   lyrRoad.trunkLinkBridge.fill(),
+  lyrRoad.trunkBridge.surface(),
+  lyrRoad.trunkLinkBridge.surface(),
 
   lyrRoad.motorwayBridge.casing(),
   lyrRoad.motorwayLinkBridge.casing(),
   lyrRoad.motorwayBridge.fill(),
   lyrRoad.motorwayLinkBridge.fill(),
+  lyrRoad.motorwayBridge.surface(),
+  lyrRoad.motorwayLinkBridge.surface(),
 
   lyrOneway.bridge,
   lyrOneway.bridgeLink,

--- a/style/js/util.js
+++ b/style/js/util.js
@@ -22,3 +22,12 @@ export function filteredClone(def, filterStep, idSuffix) {
   clone.filter.push(filterStep);
   return clone;
 }
+
+//Make a clone of a zoom-based value array
+export function zoomMultiply(arr, multiplier) {
+  var transformedArray = cp(arr);
+  for (var i = 0; i < transformedArray.length; i++) {
+    transformedArray[i][1] *= multiplier;
+  }
+  return transformedArray;
+}

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -243,7 +243,7 @@ class Trunk extends Road {
     this.link = false;
     this.hue = 0;
 
-    this.minZoomFill = 8;
+    this.minZoomFill = 7;
     this.minZoomCasing = 15;
 
     this.fillWidth = trunkFillWidth;

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -154,7 +154,6 @@ class Road {
       this.link
     );
     layer.filter.push(["==", "surface", "unpaved"]);
-    console.log(layer);
     layer.layout = layoutRoadSurface;
     layer.paint = roadSurfacePaint(this.surfaceColor, this.fillWidth);
     return layer;

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -250,7 +250,7 @@ class Trunk extends Road {
     this.fillWidth = trunkFillWidth;
     this.casingWidth = trunkCasingWidth;
 
-    this.fillColor = `hsl(${this.hue}, 95%, 50%)`;
+    this.fillColor = `hsl(${this.hue}, 77%, 50%)`;
     this.casingColor = `hsl(${this.hue}, 70%, 18%)`;
     this.surfaceColor = `hsl(${this.hue}, 95%, 80%)`;
   }

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -266,21 +266,20 @@ class Primary extends Road {
     this.minZoomCasing = 10;
 
     this.fillWidth = [
-      [9, 1],
-      [12, 4],
-      [14, 10],
-      [20, 18],
+      [14, 10], //First cased zoom
+      [16, 18],
     ];
 
     this.casingWidth = [
       [9, 1],
-      [12, 4],
-      [14, 11.5],
-      [20, 22],
+      [12, 5],
+      [13, 5.5], //Last stroked zoom
+      [14, 11], //First cased zoom
+      [16, 22],
     ];
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
-    this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+    this.casingColor = `hsl(${this.hue}, 0%, 23%)`;
     this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }
@@ -297,19 +296,20 @@ class Secondary extends Road {
     this.minZoomCasing = 11;
 
     this.fillWidth = [
-      [9, 0.5],
-      [12, 2],
-      [20, 9],
+      [15, 4], //First cased zoom
+      [16, 16],
     ];
 
     this.casingWidth = [
-      [9, 0.5],
-      [12, 3],
-      [20, 11],
+      [11, 1],
+      [12, 2.5],
+      [14, 4.5], //Last stroked zoom
+      [15, 5], //First cased zoom
+      [16, 18],
     ];
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
-    this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+    this.casingColor = `hsl(${this.hue}, 0%, 23%)`;
     this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }
@@ -326,17 +326,18 @@ class Tertiary extends Road {
     this.minZoomCasing = 12;
 
     this.fillWidth = [
-      [12, 1],
-      [20, 6],
+      [16, 4],
+      [17, 13],
     ];
 
     this.casingWidth = [
       [12, 1],
-      [20, 8],
+      [16, 5],
+      [17, 14],
     ];
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
-    this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+    this.casingColor = `hsl(${this.hue}, 0%, 23%)`;
     this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -266,8 +266,8 @@ class Primary extends Road {
     this.minZoomFill = 14;
     this.minZoomCasing = 10;
 
-    this.fillWidth = trunkFillWidth;
-    this.casingWidth = trunkCasingWidth;
+    this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.9);
+    this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.9);
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
     this.casingColor = `hsl(${this.hue}, 0%, 23%)`;
@@ -286,18 +286,8 @@ class Secondary extends Road {
     this.minZoomFill = 15;
     this.minZoomCasing = 11;
 
-    this.fillWidth = [
-      [15, 4], //First cased zoom
-      [20, 16],
-    ];
-
-    this.casingWidth = [
-      [11, 1],
-      [12, 2.5],
-      [14, 4.5], //Last stroked zoom
-      [15, 5], //First cased zoom
-      [20, 20],
-    ];
+    this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.6);
+    this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.6);
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
     this.casingColor = `hsl(${this.hue}, 0%, 23%)`;
@@ -316,16 +306,8 @@ class Tertiary extends Road {
     this.minZoomFill = 16;
     this.minZoomCasing = 12;
 
-    this.fillWidth = [
-      [16, 4],
-      [17, 13],
-    ];
-
-    this.casingWidth = [
-      [12, 1],
-      [16, 5],
-      [17, 14],
-    ];
+    this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.5);
+    this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.5);
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
     this.casingColor = `hsl(${this.hue}, 0%, 23%)`;
@@ -362,18 +344,8 @@ class TrunkLink extends Trunk {
     this.minZoomFill = 11;
     this.minZoomCasing = 15;
 
-    this.fillWidth = [
-      [7, 1],
-      [13, 1.5],
-      [14, 2.5],
-      [20, 11.5],
-    ];
-    this.casingWidth = [
-      [7, 2],
-      [13, 3],
-      [14, 4.0],
-      [20, 15],
-    ];
+    this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.5);
+    this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.5);
   }
 }
 
@@ -381,6 +353,9 @@ class PrimaryLink extends Primary {
   constructor() {
     super();
     this.link = true;
+
+    this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.45);
+    this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.45);
   }
 }
 
@@ -388,6 +363,9 @@ class SecondaryLink extends Secondary {
   constructor() {
     super();
     this.link = true;
+
+    this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.3);
+    this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.3);
   }
 }
 
@@ -395,6 +373,9 @@ class TertiaryLink extends Tertiary {
   constructor() {
     super();
     this.link = true;
+
+    this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.25);
+    this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.25);
   }
 }
 

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -19,12 +19,12 @@ let tunDashArray = [
 
 //Join styles for fill and casing
 let layoutRoadFill = {
-  "line-cap": "round",
+  "line-cap": "butt",
   "line-join": "round",
   visibility: "visible",
 };
 let layoutRoadCase = {
-  "line-cap": "round",
+  "line-cap": "butt",
   "line-join": "round",
   visibility: "visible",
 };

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -19,13 +19,18 @@ let tunDashArray = [
 
 //Join styles for fill and casing
 let layoutRoadFill = {
-  "line-cap": "round",
+  "line-cap": "butt",
   "line-join": "round",
   visibility: "visible",
 };
 let layoutRoadCase = {
   "line-cap": "butt",
   "line-join": "round",
+  visibility: "visible",
+};
+let layoutBridgeCase = {
+  "line-cap": "butt",
+  "line-join": "bevel",
   visibility: "visible",
 };
 
@@ -129,7 +134,7 @@ class Motorway extends Road {
     this.highwayClass = "motorway";
     this.brunnel = "surface";
     this.link = false;
-    this.hue = 354;
+    this.hue = 0;
 
     this.minZoomFill = 4;
     this.minZoomCasing = 4;
@@ -173,12 +178,12 @@ class Motorway extends Road {
     this.fillColor = [
       ...this.colorFillLowZoom,
       14,
-      `hsl(${this.hue}, 71%, 45%)`,
+      `hsl(${this.hue}, 71%, 35%)`,
     ];
     this.casingColor = [
       ...this.colorCasingLowZoom,
       14,
-      `hsl(${this.hue}, 71%, 23%)`,
+      `hsl(${this.hue}, 51%, 9%)`,
     ];
   }
 }
@@ -192,7 +197,7 @@ class Trunk extends Road {
     this.hue = 0;
 
     this.minZoomFill = 8;
-    this.minZoomCasing = 10;
+    this.minZoomCasing = 15;
 
     this.fillWidth = [
       [4, 0.5],
@@ -207,8 +212,92 @@ class Trunk extends Road {
       [20, 22],
     ];
 
-    this.fillColor = `hsl(${this.hue}, 70%, 28%)`;
+    this.fillColor = `hsl(${this.hue}, 95%, 50%)`;
     this.casingColor = `hsl(${this.hue}, 70%, 18%)`;
+  }
+}
+
+class Primary extends Road {
+  constructor() {
+    super();
+    this.highwayClass = "primary";
+    this.brunnel = "surface";
+    this.link = false;
+    this.hue = 0;
+
+    this.minZoomFill = 14;
+    this.minZoomCasing = 10;
+
+    this.fillWidth = [
+      [9, 1],
+      [12, 4],
+      [14, 10],
+      [20, 18],
+    ];
+
+    this.casingWidth = [
+      [9, 1],
+      [12, 4],
+      [14, 11.5],
+      [20, 22],
+    ];
+
+    this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
+    this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+  }
+}
+
+class Secondary extends Road {
+  constructor() {
+    super();
+    this.highwayClass = "secondary";
+    this.brunnel = "surface";
+    this.link = false;
+    this.hue = 0;
+
+    this.minZoomFill = 15;
+    this.minZoomCasing = 11;
+
+    this.fillWidth = [
+      [9, 0.5],
+      [12, 2],
+      [20, 9],
+    ];
+
+    this.casingWidth = [
+      [9, 0.5],
+      [12, 3],
+      [20, 11],
+    ];
+
+    this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
+    this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+  }
+}
+
+class Tertiary extends Road {
+  constructor() {
+    super();
+    this.highwayClass = "tertiary";
+    this.brunnel = "surface";
+    this.link = false;
+    this.hue = 0;
+
+    this.minZoomFill = 16;
+    this.minZoomCasing = 12;
+
+    this.fillWidth = [
+      [12, 1],
+      [20, 6],
+    ];
+
+    this.casingWidth = [
+      [12, 1],
+      [20, 8],
+    ];
+
+    this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
+    this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
   }
 }
 
@@ -239,7 +328,7 @@ class TrunkLink extends Trunk {
     super();
     this.link = true;
     this.minZoomFill = 11;
-    this.minZoomCasing = 11;
+    this.minZoomCasing = 15;
 
     this.fillWidth = [
       [7, 1],
@@ -253,6 +342,27 @@ class TrunkLink extends Trunk {
       [14, 4.0],
       [20, 15],
     ];
+  }
+}
+
+class PrimaryLink extends Primary {
+  constructor() {
+    super();
+    this.link=true;
+  }
+}
+
+class SecondaryLink extends Secondary {
+  constructor() {
+    super();
+    this.link=true;
+  }
+}
+
+class TertiaryLink extends Tertiary {
+  constructor() {
+    super();
+    this.link=true;
   }
 }
 
@@ -277,6 +387,30 @@ class TrunkBridge extends Trunk {
   }
 }
 
+class PrimaryBridge extends Primary {
+  constructor() {
+    //undifferentiated
+    super();
+    this.brunnel = "bridge";
+  }
+}
+
+class SecondaryBridge extends Secondary {
+  constructor() {
+    //undifferentiated
+    super();
+    this.brunnel = "bridge";
+  }
+}
+
+class TertiaryBridge extends Tertiary {
+  constructor() {
+    //undifferentiated
+    super();
+    this.brunnel = "bridge";
+  }
+}
+
 class MotorwayLinkBridge extends MotorwayLink {
   constructor() {
     super();
@@ -290,6 +424,30 @@ class TrunkLinkBridge extends TrunkLink {
     super();
     this.brunnel = "bridge";
     this.casingColor = `hsl(${this.hue}, 70%, 5%)`;
+  }
+}
+
+class PrimaryLinkBridge extends PrimaryLink {
+  constructor() {
+    super();
+    //Undifferentiated
+    this.brunnel = "bridge";
+  }
+}
+
+class SecondaryLinkBridge extends SecondaryLink {
+  constructor() {
+    super();
+    //Undifferentiated
+    this.brunnel = "bridge";
+  }
+}
+
+class TertiaryLinkBridge extends TertiaryLink {
+  constructor() {
+    //Undifferentiated
+    super();
+    this.brunnel = "bridge";
   }
 }
 
@@ -346,9 +504,15 @@ class TrunkLinkTunnel extends TrunkLink {
 
 export const motorway = new Motorway();
 export const trunk = new Trunk();
+export const primary = new Primary();
+export const secondary = new Secondary();
+export const tertiary = new Tertiary();
 
 export const motorwayBridge = new MotorwayBridge();
 export const trunkBridge = new TrunkBridge();
+export const primaryBridge = new PrimaryBridge();
+export const secondaryBridge = new SecondaryBridge();
+export const tertiaryBridge = new TertiaryBridge();
 
 export const motorwayTunnel = new MotorwayTunnel();
 export const trunkTunnel = new TrunkTunnel();
@@ -358,6 +522,9 @@ export const trunkLink = new TrunkLink();
 
 export const motorwayLinkBridge = new MotorwayLinkBridge();
 export const trunkLinkBridge = new TrunkLinkBridge();
+export const primaryLinkBridge = new PrimaryLinkBridge();
+export const secondaryLinkBridge = new SecondaryLinkBridge();
+export const tertiaryLinkBridge = new TertiaryLinkBridge();
 
 export const motorwayLinkTunnel = new MotorwayLinkTunnel();
 export const trunkLinkTunnel = new TrunkLinkTunnel();

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -19,12 +19,12 @@ let tunDashArray = [
 
 //Join styles for fill and casing
 let layoutRoadFill = {
-  "line-cap": "butt",
+  "line-cap": "round",
   "line-join": "round",
   visibility: "visible",
 };
 let layoutRoadCase = {
-  "line-cap": "butt",
+  "line-cap": "round",
   "line-join": "round",
   visibility: "visible",
 };
@@ -135,6 +135,9 @@ class Road {
       this.link
     );
     layer.layout = layoutRoadCase;
+    if (this.brunnel === "bridge") {
+      layer.layout = layoutBridgeCase;
+    }
     if (this.brunnel === "tunnel") {
       layer.paint = tunnelCasePaint(this.casingColor, this.casingWidth);
     } else {

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -19,12 +19,12 @@ let tunDashArray = [
 
 //Join styles for fill and casing
 let layoutRoadFill = {
-  "line-cap": "butt",
+  "line-cap": "round",
   "line-join": "round",
   visibility: "visible",
 };
 let layoutRoadCase = {
-  "line-cap": "butt",
+  "line-cap": "round",
   "line-join": "round",
   visibility: "visible",
 };
@@ -224,6 +224,18 @@ class Motorway extends Road {
   }
 }
 
+let trunkFillWidth = [
+  [4, 0.5],
+  [9, 1],
+  [12, 4],
+  [20, 18],
+];
+let trunkCasingWidth = [
+  [9, 1],
+  [12, 4],
+  [20, 22],
+];
+
 class Trunk extends Road {
   constructor() {
     super();
@@ -235,18 +247,8 @@ class Trunk extends Road {
     this.minZoomFill = 8;
     this.minZoomCasing = 15;
 
-    this.fillWidth = [
-      [4, 0.5],
-      [9, 1],
-      [12, 4],
-      [20, 18],
-    ];
-
-    this.casingWidth = [
-      [9, 1],
-      [12, 4],
-      [20, 22],
-    ];
+    this.fillWidth = trunkFillWidth;
+    this.casingWidth = trunkCasingWidth;
 
     this.fillColor = `hsl(${this.hue}, 95%, 50%)`;
     this.casingColor = `hsl(${this.hue}, 70%, 18%)`;
@@ -265,18 +267,8 @@ class Primary extends Road {
     this.minZoomFill = 14;
     this.minZoomCasing = 10;
 
-    this.fillWidth = [
-      [14, 10], //First cased zoom
-      [16, 18],
-    ];
-
-    this.casingWidth = [
-      [9, 1],
-      [12, 5],
-      [13, 5.5], //Last stroked zoom
-      [14, 11], //First cased zoom
-      [16, 22],
-    ];
+    this.fillWidth = trunkFillWidth;
+    this.casingWidth = trunkCasingWidth;
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
     this.casingColor = `hsl(${this.hue}, 0%, 23%)`;
@@ -297,7 +289,7 @@ class Secondary extends Road {
 
     this.fillWidth = [
       [15, 4], //First cased zoom
-      [16, 16],
+      [20, 16],
     ];
 
     this.casingWidth = [
@@ -305,7 +297,7 @@ class Secondary extends Road {
       [12, 2.5],
       [14, 4.5], //Last stroked zoom
       [15, 5], //First cased zoom
-      [16, 18],
+      [20, 20],
     ];
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -33,6 +33,11 @@ let layoutBridgeCase = {
   "line-join": "bevel",
   visibility: "visible",
 };
+let layoutRoadSurface = {
+  "line-cap": "butt",
+  "line-join": "round",
+  visibility: "visible",
+};
 
 /*
  Road style generation helper functions
@@ -58,6 +63,18 @@ function tunnelCasePaint(color, width) {
     },
     "line-opacity": 1,
     "line-dasharray": tunDashArray,
+  };
+}
+
+function roadSurfacePaint(color, width) {
+  return {
+    "line-dasharray": [4, 4],
+    "line-color": color,
+    "line-width": {
+      base: roadExp,
+      stops: width,
+    },
+    "line-blur": 0.5,
   };
 }
 
@@ -125,6 +142,20 @@ class Road {
     }
     return layer;
   };
+  surface = function () {
+    var layer = baseRoadLayer(
+      this.highwayClass,
+      "surface",
+      this.brunnel,
+      Math.min(this.minZoomCasing, this.minZoomFill),
+      this.link
+    );
+    layer.filter.push(["==", "surface", "unpaved"]);
+    console.log(layer);
+    layer.layout = layoutRoadSurface;
+    layer.paint = roadSurfacePaint(this.surfaceColor, this.fillWidth);
+    return layer;
+  };
 }
 
 //Highway class styles
@@ -185,6 +216,8 @@ class Motorway extends Road {
       14,
       `hsl(${this.hue}, 51%, 9%)`,
     ];
+
+    this.surfaceColor = `hsl(${this.hue}, 50%, 70%)`;
   }
 }
 
@@ -214,6 +247,7 @@ class Trunk extends Road {
 
     this.fillColor = `hsl(${this.hue}, 95%, 50%)`;
     this.casingColor = `hsl(${this.hue}, 70%, 18%)`;
+    this.surfaceColor = `hsl(${this.hue}, 95%, 80%)`;
   }
 }
 
@@ -244,6 +278,7 @@ class Primary extends Road {
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
     this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+    this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }
 
@@ -272,6 +307,7 @@ class Secondary extends Road {
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
     this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+    this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }
 
@@ -298,6 +334,7 @@ class Tertiary extends Road {
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
     this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+    this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }
 

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -348,21 +348,21 @@ class TrunkLink extends Trunk {
 class PrimaryLink extends Primary {
   constructor() {
     super();
-    this.link=true;
+    this.link = true;
   }
 }
 
 class SecondaryLink extends Secondary {
   constructor() {
     super();
-    this.link=true;
+    this.link = true;
   }
 }
 
 class TertiaryLink extends Tertiary {
   constructor() {
     super();
-    this.link=true;
+    this.link = true;
   }
 }
 

--- a/style/layer/road_label.js
+++ b/style/layer/road_label.js
@@ -75,7 +75,19 @@ export const secondary = {
   paint: textPaint,
   filter: ["all", ["==", "class", "secondary"]],
   minzoom: 12,
+  maxzoom: 16,
   layout: offsetLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};
+
+export const secondaryHZ = {
+  id: "secondary_label_hz",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "secondary"]],
+  minzoom: 16,
+  layout: centerLabelStyle,
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
@@ -86,7 +98,19 @@ export const tertiary = {
   paint: textPaint,
   filter: ["all", ["==", "class", "tertiary"]],
   minzoom: 13,
+  maxzoom: 17,
   layout: offsetLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};
+
+export const tertiaryHZ = {
+  id: "tertiary_label_hz",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "tertiary"]],
+  minzoom: 17,
+  layout: centerLabelStyle,
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };

--- a/style/layer/road_label.js
+++ b/style/layer/road_label.js
@@ -1,23 +1,92 @@
 "use strict";
 
+var offsetLabelStyle = {
+  "text-font": ["Metropolis Light"],
+  "text-size": 12,
+  "text-field": "{name:latin} {name:nonlatin}",
+  "text-anchor": "bottom",
+  "text-max-angle": 20,
+  "symbol-placement": "line",
+};
+
+var centerLabelStyle = {
+  "text-font": ["Metropolis Light"],
+  "text-size": 10,
+  "text-field": "{name:latin} {name:nonlatin}",
+  "text-anchor": "center",
+  "text-max-angle": 20,
+  "symbol-placement": "line",
+};
+
+var textPaint = {
+  "text-color": "#333",
+  "text-halo-color": "#fff",
+  "text-halo-blur": 0.5,
+  "text-halo-width": 1,
+};
+
 export const motorway = {
   id: "motorway_label",
   type: "symbol",
-  paint: {
-    "text-color": "#333",
-    "text-halo-color": "#fff",
-    "text-halo-blur": 0.5,
-    "text-halo-width": 1,
-  },
+  paint: textPaint,
   filter: ["all", ["==", "class", "motorway"]],
-  layout: {
-    "text-font": ["Metropolis Light"],
-    "text-size": 12,
-    "text-field": "{name:latin} {name:nonlatin}",
-    "text-anchor": "bottom",
-    "text-offset": [0, 0.2],
-    "symbol-placement": "line",
-  },
+  layout: offsetLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};
+
+export const trunk = {
+  id: "trunk_label",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "trunk"]],
+  minzoom: 10,
+  layout: offsetLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};
+
+export const primary = {
+  id: "primary_label",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "primary"]],
+  minzoom: 11,
+  maxzoom: 14,
+  layout: offsetLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};
+
+export const primaryHZ = {
+  id: "primary_label_hz",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "primary"]],
+  minzoom: 14,
+  layout: centerLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};
+
+export const secondary = {
+  id: "secondary_label",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "secondary"]],
+  minzoom: 12,
+  layout: offsetLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};
+
+export const tertiary = {
+  id: "tertiary_label",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "tertiary"]],
+  minzoom: 13,
+  layout: offsetLabelStyle,
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };


### PR DESCRIPTION
This is an initial implementation of a red/black roads color scheme for trunk through tertiary.  An initial roads implementation allows for highway shield development to proceed on lower-classification roads and helps promote community participation.

At the middle zooms, the scheme is:

`trunk`: thick red
`primary`: thick black
`secondary`: medium black
`tertiary`: thin black

At higher zooms, the lower classifications change to a white fill with black casing and inside labelling.  This PR implements that change as a progressive change, where primary through tertiary change to casing at progressively higher zooms.

**Unresolved issues**
* There is an issue with certain corner joins leaving undesired artifacts.  This is a somewhat complex problem and can't be easily solved without also causing undesired artifacts on bridge layering.  I'm leaving that issue as "good enough for now, can be resolved in a future bugfix.
* Bridges are undifferentiated for trunk through tertiary, and tunnels are not implemented.  This refinement can be worked in future PRs.
* At some zooms, we will show a combination of cased and stroked roads.  This is a somewhat unique approach as we weren't able to find examples of city-level maps that used both styles.  So we need to decide if this combination sufficiently meets an American design aesthetic, or if everything needs to flip over to cased at a single zoom level.  In the future, we would like to render "actual" road widths based on `width` and/or `lanes` tagging, but that data is not presently available in the vector tiles. 

### Screenshots

**Zoom 8**:
![image](https://user-images.githubusercontent.com/3254090/146709814-f6800703-ffe6-4b4e-aa9e-c79442eeaf1f.png)

**Zoom 9**:
![image](https://user-images.githubusercontent.com/3254090/146709886-be1e4004-6acc-47b4-9db3-a87d808e776a.png)

**Zoom 10**:
![image](https://user-images.githubusercontent.com/3254090/146710010-360c0f9e-5c41-4bf7-80d7-18a6e52e6d86.png)
![image](https://user-images.githubusercontent.com/3254090/146710083-7c118b1a-822d-4640-94b6-f8458e74e12c.png)
![image](https://user-images.githubusercontent.com/3254090/146710128-c56613a5-4f61-428a-bc10-8c8b3910b169.png)

**Zoom 11**:
![image](https://user-images.githubusercontent.com/3254090/146710200-76398410-5e94-406f-a96c-4ee31912c3ed.png)
![image](https://user-images.githubusercontent.com/3254090/146710239-139e48a1-6bc6-4442-9fb6-22fc03fbb87a.png)
![image](https://user-images.githubusercontent.com/3254090/146710328-15201ac3-206f-46eb-a1e7-d155c236eeb9.png)

**Zoom 12**
![image](https://user-images.githubusercontent.com/3254090/146710360-f53b22d6-03ee-4cf6-8dd2-20ace8d1604e.png)
![image](https://user-images.githubusercontent.com/3254090/146710432-f190b961-2441-4ef1-84f3-c4a46b363bda.png)
![image](https://user-images.githubusercontent.com/3254090/146710468-f09efc15-85f3-44b4-bce9-e719b506dc86.png)

**Zoom 13**
![image](https://user-images.githubusercontent.com/3254090/146710583-801e0942-e31d-410c-86ae-bab0e204a3e9.png)

**Zoom 14**
![image](https://user-images.githubusercontent.com/3254090/146710652-2bfd6fd6-9e1b-4cb8-9b22-4ec0b9812e9b.png)

**Zoom 15**
![image](https://user-images.githubusercontent.com/3254090/146710704-6281b7f6-2e66-44d3-9c88-5b67fde60917.png)

**Zoom 16**
![image](https://user-images.githubusercontent.com/3254090/146710751-e3d4d43e-8763-491e-ad06-a724680838d8.png)