### PR TITLE
Road surface

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -67,6 +67,15 @@ americanaLayers.push(
   lyrRoad.trunk.fill(),
   lyrRoad.motorway.fill(),
 
+  lyrRoad.motorwayLink.surface(),
+  lyrRoad.trunkLink.surface(),
+
+  lyrRoad.tertiary.surface(),
+  lyrRoad.secondary.surface(),
+  lyrRoad.primary.surface(),
+  lyrRoad.trunk.surface(),
+  lyrRoad.motorway.surface(),
+
   lyrOneway.road,
   lyrOneway.link
 );
@@ -76,26 +85,36 @@ var bridgeLayers = [
   lyrRoad.tertiaryLinkBridge.casing(),
   lyrRoad.tertiaryBridge.fill(),
   lyrRoad.tertiaryLinkBridge.fill(),
+  lyrRoad.tertiaryBridge.surface(),
+  lyrRoad.tertiaryLinkBridge.surface(),
 
   lyrRoad.secondaryBridge.casing(),
   lyrRoad.secondaryLinkBridge.casing(),
   lyrRoad.secondaryBridge.fill(),
   lyrRoad.secondaryLinkBridge.fill(),
+  lyrRoad.secondaryBridge.surface(),
+  lyrRoad.secondaryLinkBridge.surface(),
 
   lyrRoad.primaryBridge.casing(),
   lyrRoad.primaryLinkBridge.casing(),
   lyrRoad.primaryBridge.fill(),
   lyrRoad.primaryLinkBridge.fill(),
+  lyrRoad.primaryBridge.surface(),
+  lyrRoad.primaryLinkBridge.surface(),
 
   lyrRoad.trunkBridge.casing(),
   lyrRoad.trunkLinkBridge.casing(),
   lyrRoad.trunkBridge.fill(),
   lyrRoad.trunkLinkBridge.fill(),
+  lyrRoad.trunkBridge.surface(),
+  lyrRoad.trunkLinkBridge.surface(),
 
   lyrRoad.motorwayBridge.casing(),
   lyrRoad.motorwayLinkBridge.casing(),
   lyrRoad.motorwayBridge.fill(),
   lyrRoad.motorwayLinkBridge.fill(),
+  lyrRoad.motorwayBridge.surface(),
+  lyrRoad.motorwayLinkBridge.surface(),
 
   lyrOneway.bridge,
   lyrOneway.bridgeLink,

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -217,7 +217,7 @@ class Motorway extends Road {
       `hsl(${this.hue}, 51%, 9%)`,
     ];
 
-    this.surfaceColor = `hsl(${this.hue}, 50%, 80%)`;
+    this.surfaceColor = `hsl(${this.hue}, 50%, 70%)`;
   }
 }
 

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -33,6 +33,11 @@ let layoutBridgeCase = {
   "line-join": "bevel",
   visibility: "visible",
 };
+let layoutRoadSurface = {
+  "line-cap": "butt",
+  "line-join": "round",
+  visibility: "visible",
+};
 
 /*
  Road style generation helper functions
@@ -58,6 +63,18 @@ function tunnelCasePaint(color, width) {
     },
     "line-opacity": 1,
     "line-dasharray": tunDashArray,
+  };
+}
+
+function roadSurfacePaint(color, width) {
+  return {
+    "line-dasharray": [4, 4],
+    "line-color": color,
+    "line-width": {
+      base: roadExp,
+      stops: width,
+    },
+    "line-blur": 0.5,
   };
 }
 
@@ -125,6 +142,20 @@ class Road {
     }
     return layer;
   };
+  surface = function () {
+    var layer = baseRoadLayer(
+      this.highwayClass,
+      "surface",
+      this.brunnel,
+      Math.min(this.minZoomCasing, this.minZoomFill),
+      this.link
+    );
+    layer.filter.push(["==", "surface", "unpaved"]);
+    console.log(layer);
+    layer.layout = layoutRoadSurface;
+    layer.paint = roadSurfacePaint(this.surfaceColor, this.fillWidth);
+    return layer;
+  };
 }
 
 //Highway class styles
@@ -185,6 +216,8 @@ class Motorway extends Road {
       14,
       `hsl(${this.hue}, 51%, 9%)`,
     ];
+
+    this.surfaceColor = `hsl(${this.hue}, 50%, 80%)`;
   }
 }
 
@@ -214,6 +247,7 @@ class Trunk extends Road {
 
     this.fillColor = `hsl(${this.hue}, 95%, 50%)`;
     this.casingColor = `hsl(${this.hue}, 70%, 18%)`;
+    this.surfaceColor = `hsl(${this.hue}, 95%, 80%)`;
   }
 }
 
@@ -244,6 +278,7 @@ class Primary extends Road {
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
     this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+    this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }
 
@@ -272,6 +307,7 @@ class Secondary extends Road {
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
     this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+    this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }
 
@@ -298,6 +334,7 @@ class Tertiary extends Road {
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
     this.casingColor = `hsl(${this.hue}, 0%, 20%)`;
+    this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }
 


### PR DESCRIPTION
This PR suggests an option for distinguishing road surface by overlaying a lighter version of the fill color over roads when they have [OMT surface=unpaved](https://openmaptiles.org/schema/#transportation). 

Dashed fill was chosen because this is a common way of indicating surface in various American print maps and doesn't overly distract from the other meanings of the road symbology.

Still to do:
- [x] Validate unpaved bridge rendering. _The style doesn't seem to render bridge wings, but this PR doesn't seem to break anything_
- [ ] Validate tunnel rendering. _The style doesn't support primary-tertiary tunnels yet..._
- [x] Find motorway/_link example and validate unpaved rendering.
- [x] Fix z<12 rendering if possible.

### Example renderings:

Motorway:
_I haven't yet found an example of an unpaved motorway, but I'd imagine that cases could exist, such as motorways where construction is underway for a long time and paving hasn't yet completed._

Brazil: unpaved motorway_link:
http://localhost:1776/#16.83/-21.316703/-48.374253
https://www.openstreetmap.org/way/492811562#map=17/-21.31731/-48.37384
![Screen Shot 2021-12-20 at 5 48 18 PM](https://user-images.githubusercontent.com/25242/146842928-17eedd2e-a9d6-4de3-aab5-2db55ad47856.png)


Tanzania: unpaved trunk and primary:
http://localhost:1776/#12.53/-5.11778/31.03149
https://www.openstreetmap.org/#map=13/-5.1178/31.0315
![Screen Shot 2021-12-20 at 4 18 57 PM](https://user-images.githubusercontent.com/25242/146835327-b84c4ad9-2703-48c7-9ef4-2688743a9e61.png)
Note that this dashed overlay isn't working at z=11 and lower. I'm not sure why... OMT or something I'm doing wrong?
![Screen Shot 2021-12-20 at 4 32 56 PM](https://user-images.githubusercontent.com/25242/146835498-c8d3798e-7b08-4377-aa78-37baa1e797e2.png)


Peru: unpaved primary road:
http://localhost:1776/#13.07/-9.85917/-76.1688
https://www.openstreetmap.org/#map=14/-9.8592/-76.1688
![Screen Shot 2021-12-20 at 3 40 19 PM](https://user-images.githubusercontent.com/25242/146835639-dc82678a-21bf-42c9-beba-f33bd699a446.png)


Maine: unpaved secondary road:
http://localhost:1776/#12.99/45.68226/-69.7658
https://www.openstreetmap.org/#map=15/45.6812/-69.7739
![Screen Shot 2021-12-20 at 3 25 29 PM](https://user-images.githubusercontent.com/25242/146835704-c6f595fd-2fda-4dbb-9ec6-3e234ca8a548.png)
Zooming in -- note that the lighter dashes work on both the solid version and the white-with-casing version.
![Screen Shot 2021-12-20 at 3 26 07 PM](https://user-images.githubusercontent.com/25242/146835724-96c1ee00-4e2a-4c21-b417-51fbb989722d.png)


Vermont: unpaved tertiary road:
http://localhost:1776/#14.38/44.09141/-72.94351
https://www.openstreetmap.org/#map=15/44.0896/-72.9384
![Screen Shot 2021-12-20 at 3 33 12 PM](https://user-images.githubusercontent.com/25242/146835674-6944a49b-b957-47b8-b674-35606634b251.png)

