### PR TITLE
Lower-zoom roads

### DIFF
--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -232,8 +232,8 @@ class Trunk extends Road {
     this.link = false;
     this.hue = 0;
 
-    this.minZoomFill = 8;
-    this.minZoomCasing = 15;
+    this.minZoomFill = 4;
+    this.minZoomCasing = 9;
 
     this.fillWidth = [
       [4, 0.5],
@@ -262,10 +262,11 @@ class Primary extends Road {
     this.link = false;
     this.hue = 0;
 
-    this.minZoomFill = 14;
-    this.minZoomCasing = 10;
+    this.minZoomFill = 10;
+    this.minZoomCasing = 7;
 
     this.fillWidth = [
+      [4, 0.5],
       [9, 1],
       [12, 4],
       [14, 10],
@@ -294,7 +295,7 @@ class Secondary extends Road {
     this.hue = 0;
 
     this.minZoomFill = 15;
-    this.minZoomCasing = 11;
+    this.minZoomCasing = 9;
 
     this.fillWidth = [
       [9, 0.5],
@@ -323,9 +324,10 @@ class Tertiary extends Road {
     this.hue = 0;
 
     this.minZoomFill = 16;
-    this.minZoomCasing = 12;
+    this.minZoomCasing = 11;
 
     this.fillWidth = [
+      [9, 0.5],
       [12, 1],
       [20, 6],
     ];

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -237,14 +237,15 @@ class Trunk extends Road {
 
     this.fillWidth = [
       [4, 0.5],
-      [9, 1],
+      [7, 1],
+      [9, 1.5],
       [12, 4],
       [20, 18],
     ];
 
     this.casingWidth = [
-      [9, 1],
-      [12, 4],
+      [9, 1.5],
+      [12, 5],
       [20, 22],
     ];
 
@@ -266,7 +267,6 @@ class Primary extends Road {
     this.minZoomCasing = 7;
 
     this.fillWidth = [
-      [4, 0.5],
       [9, 1],
       [12, 4],
       [14, 10],
@@ -274,6 +274,7 @@ class Primary extends Road {
     ];
 
     this.casingWidth = [
+      [7, 0.5],
       [9, 1],
       [12, 4],
       [14, 11.5],


### PR DESCRIPTION
Introduce roads at lower zooms to provide context. trunk-tertiary roads are introduced as soon as they are available in OMT, with widths tweaked so that they appear more fine than already displayed roads.

Before z=7:
![road_layer-z7](https://user-images.githubusercontent.com/25242/147158982-a13d18b7-525c-4dd8-a88d-52fe5060c525.png)

After z=7:
![lower-zoom-roads-z7](https://user-images.githubusercontent.com/25242/147159018-7267e74e-ff4a-4df7-9e80-0eed5fed16c6.png)

