### PR TITLE
Low zoom roads

### DIFF
--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -243,7 +243,7 @@ class Trunk extends Road {
     this.link = false;
     this.hue = 0;
 
-    this.minZoomFill = 7;
+    this.minZoomFill = 5;
     this.minZoomCasing = 15;
 
     this.fillWidth = trunkFillWidth;
@@ -264,7 +264,7 @@ class Primary extends Road {
     this.hue = 0;
 
     this.minZoomFill = 14;
-    this.minZoomCasing = 10;
+    this.minZoomCasing = 7;
 
     this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.9);
     this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.9);
@@ -284,7 +284,7 @@ class Secondary extends Road {
     this.hue = 0;
 
     this.minZoomFill = 15;
-    this.minZoomCasing = 11;
+    this.minZoomCasing = 9;
 
     this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.6);
     this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.6);
@@ -304,7 +304,7 @@ class Tertiary extends Road {
     this.hue = 0;
 
     this.minZoomFill = 16;
-    this.minZoomCasing = 12;
+    this.minZoomCasing = 11;
 
     this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.5);
     this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.5);

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -270,7 +270,17 @@ class Primary extends Road {
     this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.9);
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
-    this.casingColor = `hsl(${this.hue}, 0%, 23%)`;
+    // Casing color gets interpolated as a fade from light to dark between this
+    // level's introduction and next road-level introduction.
+    this.casingColor = [
+      "interpolate",
+      ["exponential", roadExp],
+      ["zoom"],
+      7,
+      `hsl(${this.hue}, 0%, 75%)`,
+      9,
+      `hsl(${this.hue}, 0%, 23%)`,
+    ];
     this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }
@@ -290,7 +300,17 @@ class Secondary extends Road {
     this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.6);
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
-    this.casingColor = `hsl(${this.hue}, 0%, 23%)`;
+    // Casing color gets interpolated as a fade from light to dark between this
+    // level's introduction and next road-level introduction.
+    this.casingColor = [
+      "interpolate",
+      ["exponential", roadExp],
+      ["zoom"],
+      9,
+      `hsl(${this.hue}, 0%, 75%)`,
+      11,
+      `hsl(${this.hue}, 0%, 23%)`,
+    ];
     this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }
@@ -310,7 +330,17 @@ class Tertiary extends Road {
     this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.5);
 
     this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
-    this.casingColor = `hsl(${this.hue}, 0%, 23%)`;
+    // Casing color gets interpolated as a fade from light to dark between this
+    // level's introduction and next road-level introduction.
+    this.casingColor = [
+      "interpolate",
+      ["exponential", roadExp],
+      ["zoom"],
+      11,
+      `hsl(${this.hue}, 0%, 75%)`,
+      13,
+      `hsl(${this.hue}, 0%, 23%)`,
+    ];
     this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
   }
 }


### PR DESCRIPTION
Introduce roads at lower zooms (when they first become available in OMT).

1. d2c21277 introduces roads at lower zooms, maintaining the same styling...
2. 80af93fc interpolates the luminosity of the casing color between a road's introduction and the zoom at which the next level is introduced. This lets the road fade in with less visual weight initially, then get fully black as the next level fades in.

Introducing `trunk` earlier is vital for remote regions like Canada, much of the rural US, and other places without a contiguous motorway network.

For lower levels, without this earlier introduction many zooms in rural areas show very few roads, not enough for usable context at the current zoom. See [this directory with screen-shots](https://drive.google.com/drive/folders/1-5L4eektpgZzPnQptwPJ3lIDza8qSVqP?usp=sharing) of both rural (northern New England) and urban (NYC) before at each of these two commits.

### Example, New England z5
Before:
![NE-z5-A-before](https://user-images.githubusercontent.com/25242/147376005-9b6335b7-b8a1-42bc-b2ab-400b5387fc3a.png)

After:
![NE-z5-B-after](https://user-images.githubusercontent.com/25242/147376012-b3c29bd4-6804-45ab-855f-dab29d6eac80.png)

### Example, New England z9
Before:
![NE-z9-A-before](https://user-images.githubusercontent.com/25242/147375900-9fa2eb5f-1c34-4f1a-a94b-50efc0f6134e.png)

After (single color):
![NE-z9-B-after](https://user-images.githubusercontent.com/25242/147375922-20e3d27d-b176-49cc-afe1-953a41d349c5.png)

After (with color interpolation):
![NE-z9-C-after-interpolation](https://user-images.githubusercontent.com/25242/147375931-bc27eee6-d20b-42ff-a260-7fe18003f19e.png)

### Example, NYC z9
Before:
![NYC-z9-A-before](https://user-images.githubusercontent.com/25242/147375950-dee1508d-7f5d-4868-a0be-ecf56237e1e6.png)

After (single color):
![NYC-z9-B-after](https://user-images.githubusercontent.com/25242/147375951-ec12783b-dcc2-4f31-a7aa-5c573cbf2f2b.png)

After (with color interpolati
![NYC-z9-C-after-interpolation](https://user-images.githubusercontent.com/25242/147375954-8069a4eb-c9cc-47ef-8918-8cc11c877ccb.png)
on):

