### PR TITLE
Set up git ignored file for config variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,9 @@ jobs:
           sudo apt install -y xmlstarlet
           cd style
           npm install
-          echo 'var mapTilerKey = "hJFMGrd2JszhwfJx5M2k"; //This key only allows requests from zelonewolf.github.io' > key.js
+          sed 's/<your MapTiler key>/53iZvB2drcamS0Ge0xiD/g' config.default.js > config.js
           make sprites
+        # MapTiler key 53iZvB2drcamS0Ge0xiD only allows requests from zelonewolf.github.io
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/style/.gitignore
+++ b/style/.gitignore
@@ -3,4 +3,4 @@ sprites
 build
 rebusurance.zip
 .DS_Store
-
+config.js

--- a/style/CONTRIBUTE.md
+++ b/style/CONTRIBUTE.md
@@ -13,22 +13,22 @@ The repository is organized as follows:
 
 ## Config File
 
-Environment specific settings go in the untracked file `config.js`.  Copy the template
-`config.default.js` and rename it `config.js`.  The variables in this file can then 
+Environment specific settings go in the untracked file `config.js`. Copy the template
+`config.default.js` and rename it `config.js`. The variables in this file can then
 be changed without the risk of accidentally comitting to the main repo.
 
 ### MapTiler API Key
 
 By default this project is set up to use vector tiles provided by MapTiler.
-For this to work, you must create an account and obtain a free key from 
-[MapTiler Cloud][20]. This key should be pasted into the `MAPTILER_KEY` variable of 
+For this to work, you must create an account and obtain a free key from
+[MapTiler Cloud][20]. This key should be pasted into the `MAPTILER_KEY` variable of
 the `config.js` file.
 
 ### Custom OpenMapTiles URL
 
 For testing upcoming features of the [OpenMapTiles schema][21] or for fresher data than
 MapTiler Cloud provides, a custom vector tile url can be set in the `OPENMAPTILES_URL`
-variable of the `config.js` file.  However, this requires setting up a custom OpenMapTiles
+variable of the `config.js` file. However, this requires setting up a custom OpenMapTiles
 server which is beyond the scope of this guide.
 
 [20]: https://cloud.maptiler.com/maps/

--- a/style/CONTRIBUTE.md
+++ b/style/CONTRIBUTE.md
@@ -7,16 +7,32 @@ The repository is organized as follows:
 - **layer/** - Individual style layers, organized by subject area
 - **icons/** - SVG icons, which get converted into PNG stylesheets
 - **constants/** - Style elements that are frequently re-used
-- **key.js** - Put your MapTiler API key here (see below)
-- **layers.js** - OpenMapTiles loader with layer ordering
+- **config.js** - Configuration settings (MapTiler API key, OpenMapTiles URL, etc)
+- **americana.js** - OpenMapTiles loader with layer ordering
 - **index.html** - Demonstration map HTML page
 
-## MapTiler API Key
+## Config File
 
-In order to run the style, you must create an account to obtain a free key from
-[MapTiler Cloud][20]. This key should be pasted into the `key.js` file.
+Environment specific settings go in the untracked file `config.js`.  Copy the template
+`config.default.js` and rename it `config.js`.  The variables in this file can then 
+be changed without the risk of accidentally comitting to the main repo.
+
+### MapTiler API Key
+
+By default this project is set up to use vector tiles provided by MapTiler.
+For this to work, you must create an account and obtain a free key from 
+[MapTiler Cloud][20]. This key should be pasted into the `MAPTILER_KEY` variable of 
+the `config.js` file.
+
+### Custom OpenMapTiles URL
+
+For testing upcoming features of the [OpenMapTiles schema][21] or for fresher data than
+MapTiler Cloud provides, a custom vector tile url can be set in the `OPENMAPTILES_URL`
+variable of the `config.js` file.  However, this requires setting up a custom OpenMapTiles
+server which is beyond the scope of this guide.
 
 [20]: https://cloud.maptiler.com/maps/
+[21]: https://openmaptiles.org/schema/
 
 ## Install Pre-requisites
 

--- a/style/Makefile
+++ b/style/Makefile
@@ -14,8 +14,11 @@ sprites: build/rebusurance-v1.0.0
 	npx spritezero sprites/sprite@2x icons/ --retina
 	npx spritezero sprites/sprite icons/
 
+config.js:
+	cp config.default.js config.js
+
 code_format:
 	npx prettier --write .
 
-run: sprites
+run: sprites config.js
 	npx browser-sync -w --port 1776

--- a/style/americana.js
+++ b/style/americana.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import config from "./config.js";
+
 import * as Util from "./js/util.js";
 
 import * as lyrBackground from "./layer/background.js";
@@ -180,8 +182,7 @@ var style = {
   bearing: 0,
   sources: {
     openmaptiles: {
-      // url: "http://localhost:8080/data/v3.json",
-      url: "https://api.maptiler.com/tiles/v3/tiles.json?key=" + mapTilerKey,
+      url: config.OPENMAPTILES_URL,
       type: "vector",
     },
   },

--- a/style/config.default.js
+++ b/style/config.default.js
@@ -1,4 +1,5 @@
 "use strict";
+
 /*
 This style requires a vector tile server to run, and is designed to work with the MapTiler service
 
@@ -7,5 +8,11 @@ https://cloud.maptiler.com/maps/
 
 Go to Account->Keys and create a key to paste here:
 */
+const MAPTILER_KEY = "<your MapTiler key>";
 
-var mapTilerKey = "<your MapTiler key>"; //
+const OPENMAPTILES_URL = `https://api.maptiler.com/tiles/v3/tiles.json?key=${MAPTILER_KEY}`;
+
+export default {
+  MAPTILER_KEY,
+  OPENMAPTILES_URL,
+};

--- a/style/index.html
+++ b/style/index.html
@@ -30,10 +30,6 @@
         z-index: 100;
       }
     </style>
-
-    <!-- This file needs to be modified with your MapTiler Cloud key -->
-    <script type="text/javascript" src="key.js"></script>
-
     <script type="module" src="americana.js"></script>
   </head>
 


### PR DESCRIPTION
This is an alternative approach to resolving #64 that doesn't use [dotenv](https://www.npmjs.com/package/dotenv).

I started looking into dotenv, but it seems that a node.js server or build process would need to be added to the project if we want to use it.  At the moment neither of these is present and all JS is executing client side in the browser.  In this context, dotenv doesn't appear to work.

In the mean time I think we can get most of the same benefits without this library by setting up a git ignored JS config file.  This PR adds `style/config.default.js` as a template to be copied to `style/config.js` (a git ignored location) where you modify the variables.  This file is imported as a module and then variables can be accessed as `config.VAR_NAME`. 

Does this approach seem sufficient for now, or should we be looking into a build process so we can use the dotenv library?
