### PR TITLE
Remove unnecessary export of Maptiler key

### DIFF
--- a/style/config.default.js
+++ b/style/config.default.js
@@ -13,6 +13,5 @@ const MAPTILER_KEY = "<your MapTiler key>";
 const OPENMAPTILES_URL = `https://api.maptiler.com/tiles/v3/tiles.json?key=${MAPTILER_KEY}`;
 
 export default {
-  MAPTILER_KEY,
   OPENMAPTILES_URL,
 };


### PR DESCRIPTION
The default config file exports the Maptiler API key.  However, this is not necessary; the key is added to the tile server URL's querystring, and the API key is not needed outside of the tile server URL.

This PR removes this export.