### PR TITLE
Build custom maplibre-gl-js on the fly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           cd style
           npm install
           sed 's/<your MapTiler key>/53iZvB2drcamS0Ge0xiD/g' config.default.js > config.js
-          make sprites
+          make sprites js/maplibre-gl-js
         # MapTiler key 53iZvB2drcamS0Ge0xiD only allows requests from zelonewolf.github.io
 
       - name: Deploy 🚀

--- a/style/Makefile
+++ b/style/Makefile
@@ -23,7 +23,7 @@ code_format:
 
 build/maplibre-js:
 	mkdir -p build/maplibre-js
-	git clone git@github.com:wipfli/maplibre-gl-js.git build/maplibre-js
+	git clone https://github.com/wipfli/maplibre-gl-js build/maplibre-js
 
 build/maplibre-js/dist/maplibre-gl.js: build/maplibre-js
 	cd build/maplibre-js; git checkout 270a47f473ba51375a7df4076ee271777cc04467; \

--- a/style/Makefile
+++ b/style/Makefile
@@ -1,5 +1,6 @@
 clean:
 	rm -rf sprites build icons/us_* rebusurance.zip
+	rm -rf build
 
 rebusurance.zip:
 	curl -s -L https://github.com/1ec5/rebusurance/releases/download/v1.0.0/rebusurance-v1.0.0.zip --output rebusurance.zip
@@ -20,5 +21,16 @@ config.js:
 code_format:
 	npx prettier --write .
 
-run: sprites config.js
+build/maplibre-js:
+	mkdir -p build/maplibre-js
+	git clone git@github.com:wipfli/maplibre-gl-js.git build/maplibre-js
+
+build/maplibre-js/dist/maplibre-gl.js: build/maplibre-js
+	cd build/maplibre-js; git checkout 270a47f473ba51375a7df4076ee271777cc04467; \
+          npm ci && npm run build-prod-min;
+
+js/maplibre-gl.js: build/maplibre-js/dist/maplibre-gl.js
+	cp build/maplibre-js/dist/maplibre-gl.js js/maplibre-gl.js
+
+run: sprites config.js js/maplibre-gl.js
 	npx browser-sync -w --port 1776


### PR DESCRIPTION
This PR builds a custom version of maplibre-gl-js which supports upright highway shields.  This is intended to ensure that #72 will be able to use a deployed maplibre-gl-js on the gh-pages branch.  This PR intentionally does not change the version of maplibre that index.html is pointing to, in case the github actions don't work properly - this is only intended to pre-stage the modified maplibre build to ensure that it can deploy.