### PR TITLE
Fix broken build target in Makefile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           cd style
           npm install
           sed 's/<your MapTiler key>/53iZvB2drcamS0Ge0xiD/g' config.default.js > config.js
-          make sprites js/maplibre-gl-js
+          make sprites js/maplibre-gl.js
         # MapTiler key 53iZvB2drcamS0Ge0xiD only allows requests from zelonewolf.github.io
 
       - name: Deploy 🚀


### PR DESCRIPTION
Fixes a typo in #77 that caused github actions to build the wrong target.