### PR TITLE
Use pre-built maplibre

### DIFF
--- a/style/Makefile
+++ b/style/Makefile
@@ -21,16 +21,5 @@ config.js:
 code_format:
 	npx prettier --write .
 
-build/maplibre-js:
-	mkdir -p build/maplibre-js
-	git clone https://github.com/wipfli/maplibre-gl-js build/maplibre-js
-
-build/maplibre-js/dist/maplibre-gl.js: build/maplibre-js
-	cd build/maplibre-js; git checkout 270a47f473ba51375a7df4076ee271777cc04467; \
-          npm ci && npm run build-prod-min;
-
-js/maplibre-gl.js: build/maplibre-js/dist/maplibre-gl.js
-	cp build/maplibre-js/dist/maplibre-gl.js js/maplibre-gl.js
-
 run: sprites config.js js/maplibre-gl.js
 	npx browser-sync -w --port 1776

--- a/style/index.html
+++ b/style/index.html
@@ -7,7 +7,7 @@
       name="viewport"
       content="initial-scale=1,maximum-scale=1,user-scalable=no"
     />
-    <script src="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.js"></script>
+    <script src="https://zelonewolf.github.io/openstreetmap-americana/js/maplibre-gl-custom-shields.js"></script>
     <link
       href="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.css"
       rel="stylesheet"


### PR DESCRIPTION
I've posted a pre-built development version of maplibre in gh-pages.  This PR eliminates the need to build maplibre and instead just points index.html to that location.  I used the fully-qualified URL so that it would work in a development context as well.