### PR TITLE
Standardize padding on circle shields

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -16,8 +16,8 @@ function circleShield(fillColor, strokeColor) {
     padding: {
       left: 2,
       right: 2,
-      top: 4,
-      bottom: 5,
+      top: 2,
+      bottom: 2,
     },
   };
 }


### PR DESCRIPTION
Make circle shields have a consistent padding.  Since we're using circular text layout constraints, the text will scale to fit.  This means that 1-digit shields have text that's a bit too large, however, that can be addressed in the future by limiting the max size of shield text.

![image](https://user-images.githubusercontent.com/3254090/151097976-773fa80b-1527-409e-8489-82ff9b92bada.png)
