### PR TITLE
Fix custom maplibre deployment

### DIFF
--- a/style/index.html
+++ b/style/index.html
@@ -7,9 +7,7 @@
       name="viewport"
       content="initial-scale=1,maximum-scale=1,user-scalable=no"
     />
-    <script
-      src="https://zelonewolf.github.io/maplibre-gl-js/maplibre-gl.js"
-    ></script>
+    <script src="https://zelonewolf.github.io/maplibre-gl-js/maplibre-gl.js"></script>
     <link
       href="https://zelonewolf.github.io/maplibre-gl-js/maplibre-gl.css"
       rel="stylesheet"

--- a/style/index.html
+++ b/style/index.html
@@ -7,9 +7,11 @@
       name="viewport"
       content="initial-scale=1,maximum-scale=1,user-scalable=no"
     />
-    <script src="https://zelonewolf.github.io/openstreetmap-americana/js/maplibre-gl-custom-shields.js"></script>
+    <script
+      src="https://zelonewolf.github.io/maplibre-gl-js/maplibre-gl.js"
+    ></script>
     <link
-      href="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.css"
+      href="https://zelonewolf.github.io/maplibre-gl-js/maplibre-gl.css"
       rel="stylesheet"
     />
     <style>


### PR DESCRIPTION
I've built a deploying maplibre fork with the changes need for upright shields at https://github.com/ZeLonewolf/maplibre-gl-js/tree/gh-pages

Once the gh-pages site is updated on the https, this PR changes the maplibre links to:

* https://zelonewolf.github.io/maplibre-gl-js/maplibre-gl.js
* https://zelonewolf.github.io/maplibre-gl-js/maplibre-gl.css

Posting as draft until we can confirm this works.