### PR TITLE
Change place & park layers to prefer english names where available

### DIFF
--- a/style/layer/park.js
+++ b/style/layer/park.js
@@ -2,6 +2,14 @@
 
 import * as Color from "../constants/color.js";
 
+// Name fields in order of preference
+const name_en = [
+  "coalesce", 
+  ["get", "name:en"], 
+  ["get", "name:latin"], 
+  ["get", "name"],
+]
+
 export const fill = {
   id: "protected-area-fill",
   type: "fill",
@@ -42,7 +50,7 @@ export const label = {
   },
   layout: {
     visibility: "visible",
-    "text-field": "{name}",
+    "text-field": name_en,
     "text-font": ["Metropolis Bold"],
     "text-size": 10,
     "symbol-sort-key": ["get", "rank"],

--- a/style/layer/park.js
+++ b/style/layer/park.js
@@ -4,11 +4,11 @@ import * as Color from "../constants/color.js";
 
 // Name fields in order of preference
 const name_en = [
-  "coalesce", 
-  ["get", "name:en"], 
-  ["get", "name:latin"], 
+  "coalesce",
+  ["get", "name:en"],
+  ["get", "name:latin"],
   ["get", "name"],
-]
+];
 
 export const fill = {
   id: "protected-area-fill",

--- a/style/layer/place.js
+++ b/style/layer/place.js
@@ -2,11 +2,11 @@
 
 // Name fields in order of preference
 const name_en = [
-  "coalesce", 
-  ["get", "name:en"], 
-  ["get", "name:latin"], 
+  "coalesce",
+  ["get", "name:en"],
+  ["get", "name:latin"],
   ["get", "name"],
-]
+];
 
 export const city = {
   id: "place_city",

--- a/style/layer/place.js
+++ b/style/layer/place.js
@@ -1,5 +1,13 @@
 "use strict";
 
+// Name fields in order of preference
+const name_en = [
+  "coalesce", 
+  ["get", "name:en"], 
+  ["get", "name:latin"], 
+  ["get", "name"],
+]
+
 export const city = {
   id: "place_city",
   type: "symbol",
@@ -49,7 +57,7 @@ export const city = {
         [11, 0.9],
       ],
     },
-    "text-field": "{name}",
+    "text-field": name_en,
     "text-anchor": "bottom",
     "text-variable-anchor": [
       "bottom",
@@ -89,7 +97,7 @@ export const state = {
         [6, 14],
       ],
     },
-    "text-field": "{name}",
+    "text-field": name_en,
     "text-padding": 1,
     "text-transform": "uppercase",
     "text-letter-spacing": 0.04,
@@ -128,7 +136,7 @@ export const countryOther = {
         [7, 15],
       ],
     },
-    "text-field": "{name}",
+    "text-field": name_en,
     "text-max-width": 6.25,
     "text-transform": "none",
   },
@@ -158,7 +166,7 @@ export const country3 = {
         [7, 17],
       ],
     },
-    "text-field": "{name}",
+    "text-field": name_en,
     "text-max-width": 6.25,
     "text-transform": "none",
   },
@@ -188,7 +196,7 @@ export const country2 = {
         [5, 17],
       ],
     },
-    "text-field": "{name}",
+    "text-field": name_en,
     "text-max-width": 6.25,
     "text-transform": "none",
   },
@@ -219,7 +227,7 @@ export const country1 = {
         [6, 19],
       ],
     },
-    "text-field": "{name}",
+    "text-field": name_en,
     "text-max-width": ["step", ["zoom"], 6.25, 3, 12],
     "text-transform": "none",
     "text-offset": [
@@ -245,7 +253,7 @@ export const continent = {
   layout: {
     "text-font": ["Metropolis Light"],
     "text-size": 13,
-    "text-field": "{name}",
+    "text-field": name_en,
     "text-justify": "center",
     "text-transform": "uppercase",
   },


### PR DESCRIPTION
This changes the park and place layers to prefer the `name:en` field whenever it is availabe rather than simply using the `name` field which will be in the local language of the place.  Since `name:en` is not always availabe the coalesce function is used to fall back to using `name:latin` or `name` in those cases.  

There has been discussion of adding a language switching feature (a major benefit of client side vector rendering), but for now it make most sense to have the map in English for the benefit of the primarily English speaking style developers.

