### PR TITLE
Add maxsize parameter to shield definitons

### DIFF
--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -200,8 +200,8 @@ function drawShield(network, ref) {
 
   //If size-to-fill shield text is too big, shrink it
   if (shieldDef != null && typeof shieldDef.maxFontSize != "undefined") {
-    if (textLayout.fontPx > shieldDef.maxFontSize) {
-      let maxFontSize = shieldDef.maxFontSize * PXR;
+    let maxFontSize = shieldDef.maxFontSize * PXR;
+    if (textLayout.fontPx > maxFontSize) {
       var shrinkFactor = maxFontSize / textLayout.fontPx;
       var y0 = shieldBounds.height - padding.top - padding.bottom;
       var gap = y0 - textLayout.yBaseline + padding.top;

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -201,7 +201,7 @@ function drawShield(network, ref) {
   //If size-to-fill shield text is too big, shrink it
   if (shieldDef != null && typeof shieldDef.maxFontSize != "undefined") {
     if (textLayout.fontPx > shieldDef.maxFontSize) {
-      let maxFontSize = shieldDef.maxFontSize * PXR
+      let maxFontSize = shieldDef.maxFontSize * PXR;
       var shrinkFactor = maxFontSize / textLayout.fontPx;
       var y0 = shieldBounds.height - padding.top - padding.bottom;
       var gap = y0 - textLayout.yBaseline + padding.top;

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -197,6 +197,20 @@ function drawShield(network, ref) {
     shieldBounds,
     textLayoutFunc
   );
+
+  //If size-to-fill shield text is too big, shrink it
+  if (shieldDef != null && typeof shieldDef.maxFontSize != "undefined") {
+    if (textLayout.fontPx > shieldDef.maxFontSize) {
+      var shrinkFactor = shieldDef.maxFontSize / textLayout.fontPx;
+      var y0 = shieldBounds.height - padding.top - padding.bottom;
+      var gap = y0 - textLayout.yBaseline + padding.top;
+      var tx = y0 - 2 * gap;
+      var txNew = shrinkFactor * tx;
+      textLayout.yBaseline -= (tx - txNew) / 2;
+      textLayout.fontPx = shieldDef.maxFontSize;
+    }
+  }
+
   textLayout.yBaseline += bannerCount * ShieldDef.bannerSizeH;
 
   ctx.fillStyle = textColor(shieldDef);

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -201,13 +201,14 @@ function drawShield(network, ref) {
   //If size-to-fill shield text is too big, shrink it
   if (shieldDef != null && typeof shieldDef.maxFontSize != "undefined") {
     if (textLayout.fontPx > shieldDef.maxFontSize) {
-      var shrinkFactor = shieldDef.maxFontSize / textLayout.fontPx;
+      let maxFontSize = shieldDef.maxFontSize * PXR
+      var shrinkFactor = maxFontSize / textLayout.fontPx;
       var y0 = shieldBounds.height - padding.top - padding.bottom;
       var gap = y0 - textLayout.yBaseline + padding.top;
       var tx = y0 - 2 * gap;
       var txNew = shrinkFactor * tx;
       textLayout.yBaseline -= (tx - txNew) / 2;
-      textLayout.fontPx = shieldDef.maxFontSize;
+      textLayout.fontPx = maxFontSize;
     }
   }
 

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -19,6 +19,7 @@ function circleShield(fillColor, strokeColor) {
       top: 2,
       bottom: 2,
     },
+    maxFontSize: 32,
   };
 }
 

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -19,7 +19,7 @@ function circleShield(fillColor, strokeColor) {
       top: 2,
       bottom: 2,
     },
-    maxFontSize: 32,
+    maxFontSize: 16,
   };
 }
 


### PR DESCRIPTION
Closes #102 

Shield definitions can now include a maximum font size parameter.  This PR also sets the max size of circle shield fonts to 32px.  Note the subtle difference between the two screen shot in the rendering of DE-1.  Please take special care to sanity check that this doesn't break under various screen/resolution conditions.

After this PR (circles set to max font size = 32):
![image](https://user-images.githubusercontent.com/3254090/151264311-05711638-ad1a-410a-a67d-11dfe595c5cc.png)

Prior behavior:
![image](https://user-images.githubusercontent.com/3254090/151264339-f677e5d2-eb84-4591-9caa-c193a946f8f5.png)
