### PR TITLE
Fix the recolored shields that I broke

### DIFF
--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -244,12 +244,18 @@ export function missingIconLoader(map, e) {
   //Add modifier plaques above shields
   drawBanners(ctx, network);
 
+  // Swap black with a different color for certain shields.
+  // The secondary canvas is necessary here for some reason. Without it,
+  // the recolored shield gets an opaque instead of transparent background.
   if (colorLighten != null) {
-    ctx.globalCompositeOperation = "lighten";
-    ctx.fillStyle = colorLighten;
-    ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-    ctx.globalCompositeOperation = "destination-atop";
-    ctx.drawImage(ctx.canvas, 0, 0);
+    let colorCtx = Gfx.getGfxContext(ctx.canvas);
+    colorCtx.drawImage(ctx.canvas, 0, 0);
+    colorCtx.globalCompositeOperation = "lighten";
+    colorCtx.fillStyle = colorLighten;
+    colorCtx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    colorCtx.globalCompositeOperation = "destination-atop";
+    colorCtx.drawImage(ctx.canvas, 0, 0);
+    ctx = colorCtx;
   }
 
   var imgData = ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height);


### PR DESCRIPTION
While refactoring in the lead up to #72 getting merged, I removed something that appeared redundant.  This broke the recoloring of shields by adding an opaque background where it should be transparent.  This PR fixes that.

Current broken rendering:
![Screen Shot 2022-01-27 at 4 55 56 PM](https://user-images.githubusercontent.com/281482/151450878-21a000bc-f50b-409b-a0dc-f6e4312e5ef4.png)

Fixed rendering:
![Screen Shot 2022-01-27 at 4 57 22 PM](https://user-images.githubusercontent.com/281482/151451260-e5df97e6-fe2e-4e92-bbf8-b613fd022a38.png)

