### PR TITLE
Disable map rotation and pitch

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -233,7 +233,13 @@ var map = (window.map = new maplibregl.Map({
   center: [-94, 40.5], // starting position [lng, lat]
   zoom: 4, // starting zoom
   attributionControl: false,
+  pitchWithRotate: false,
+  dragRotate: false,
+  touchPitch: false,
 }));
+
+map.touchZoomRotate.disableRotation();
+map.keyboard.disableRotation();
 
 map.on("styledata", function () {
   ShieldDef.loadShields(map.style.imageManager.images);

--- a/style/index.html
+++ b/style/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Display a map</title>
+    <title>OSM Americana</title>
     <meta
       name="viewport"
       content="initial-scale=1,maximum-scale=1,user-scalable=no"


### PR DESCRIPTION
The method of shield drawing we are using doesn't play well with rotating or pitching the map, so I'm suggesting we disable those features for now.  If and when there is more movement on https://github.com/maplibre/maplibre-gl-js/pull/716#issuecomment-995193918 then we can probably re-enable them.

<img width="612" alt="Screenshot from 2022-01-27 19-59-10" src="https://user-images.githubusercontent.com/281482/151482483-543ce6ed-2a2d-4d63-9afc-a27c387488c4.png">

<img width="612" alt="Screen Shot 2022-01-27 at 8 58 40 PM" src="https://user-images.githubusercontent.com/281482/151482588-6d806b43-7b93-4934-b4b7-a59beba07374.png">

