### PR TITLE
Refactor max font size code to improve maintainability / extensibility

### DIFF
--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -85,12 +85,7 @@ function getRasterShieldBlank(network, ref) {
       shieldArtwork = shieldDef.backgroundImage[i];
 
       bounds = compoundShieldSize(shieldArtwork.data, bannerCount);
-      textLayout = ShieldText.layoutShieldText(
-        ref,
-        shieldDef.padding,
-        bounds,
-        textLayoutFunc
-      );
+      textLayout = ShieldText.layoutShieldTextFromDef(ref, shieldDef, bounds);
       if (textLayout.fontPx > Gfx.fontSizeThreshold * Gfx.getPixelRatio()) {
         break;
       }
@@ -181,36 +176,11 @@ function drawShield(network, ref) {
   }
 
   //The ref is valid and we're supposed to draw it
-
-  var textLayoutFunc = ShieldText.rectTextConstraint;
-
-  if (
-    shieldDef != null &&
-    typeof shieldDef.textLayoutConstraint != "undefined"
-  ) {
-    textLayoutFunc = shieldDef.textLayoutConstraint;
-  }
-
-  var textLayout = ShieldText.layoutShieldText(
+  var textLayout = ShieldText.layoutShieldTextFromDef(
     ref,
-    padding,
-    shieldBounds,
-    textLayoutFunc
+    shieldDef,
+    shieldBounds
   );
-
-  //If size-to-fill shield text is too big, shrink it
-  if (shieldDef != null && typeof shieldDef.maxFontSize != "undefined") {
-    let maxFontSize = shieldDef.maxFontSize * PXR;
-    if (textLayout.fontPx > maxFontSize) {
-      var shrinkFactor = maxFontSize / textLayout.fontPx;
-      var y0 = shieldBounds.height - padding.top - padding.bottom;
-      var gap = y0 - textLayout.yBaseline + padding.top;
-      var tx = y0 - 2 * gap;
-      var txNew = shrinkFactor * tx;
-      textLayout.yBaseline -= (tx - txNew) / 2;
-      textLayout.fontPx = maxFontSize;
-    }
-  }
 
   textLayout.yBaseline += bannerCount * ShieldDef.bannerSizeH;
 

--- a/style/js/shield_text.js
+++ b/style/js/shield_text.js
@@ -96,6 +96,15 @@ const defaultDefForLayout = {
   },
 };
 
+/**
+ * Determines the position and font size to draw text so that it fits within
+ * a bounding box.
+ *
+ * @param {*} text - text to draw
+ * @param {*} def - shield definition
+ * @param {*} bounds - size of the overall graphics area
+ * @returns JOSN object containing (X,Y) draw position and font size
+ */
 export function layoutShieldTextFromDef(text, def, bounds) {
   if (def == null) {
     def = defaultDefForLayout;


### PR DESCRIPTION
This PR refactors the code that enforces a maximum font size when drawing shield text.  The previous code included a bunch of math that I figured out on the back of a napkin that's essentially incomprehensible.  I removed this in favor of a more-understandable `Math.min()` function to limit the font size.  This is a needed step to support additional text layout improvements including vertical alignment and half-elliptical layout constraints, which will improve the text layout appearance of half-rounded shields such interstate and Virginia state route shields.

This PR should have no impact on rendering or performance.