### PR TITLE
More shields in more places

### DIFF
--- a/style/layer/highway_shield.js
+++ b/style/layer/highway_shield.js
@@ -23,6 +23,7 @@ let shieldLayout = {
   "text-anchor": "center",
   "text-letter-spacing": 0.7,
   "symbol-placement": "line",
+  "text-max-angle": 180,
 };
 
 let baseShield = {


### PR DESCRIPTION
I noticed that although shields for trunk roads are supposed to start showing up at zoom 8, in quite a few places no shield is getting placed.  In this screenshot US 4, VT 103, VT 9, NH 9, and NH 101 are all missing shields:

![before-less-shields](https://user-images.githubusercontent.com/281482/151668908-2f12f9da-d03b-4da0-82fc-cfd7fea4812d.png)

I tried a variety of layout properties to see what I could do to improve this situation and found that increasing [`text-max-angle`](https://maplibre.org/maplibre-gl-js-docs/style-spec/layers/#layout-symbol-text-max-angle) did the trick.  I think the issue is that at lower zooms highway lines are simplified and windy sections of road can become sharp angles.  Since the shields are layed out as text characters along this line, MapLibre will not display a shield in a spot where the "text"  line would make too sharp of angle.  Increasing `text-max-angle` too much with normal text will look very bad, but since the shields are all displayed upright anway it doesn't really seem to matter.  `text-max-angle` defaults to 45 degrees and this PR increases it to 180 resulting in many more shields showing up in previously blank spots on the map:

![after-more-shields](https://user-images.githubusercontent.com/281482/151669064-e2a8cc11-89d0-408a-8b47-879d83768abb.png)

