### PR TITLE
Half ellipse text constraint

### DIFF
--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -122,11 +122,13 @@ function drawShield(network, ref) {
       width: ctx.canvas.width,
       height: ctx.canvas.height,
     };
-    padding = {
-      left: 2,
-      right: 2,
-      top: 4,
-      bottom: 5,
+    shieldDef = {
+      padding: {
+        left: 2,
+        right: 2,
+        top: 4,
+        bottom: 5,
+      },
     };
   } else {
     bannerCount = ShieldDef.getBannerCount(shieldDef);
@@ -159,10 +161,7 @@ function drawShield(network, ref) {
   }
 
   if (!isValidRef(ref)) {
-    if (
-      shieldDef != null &&
-      ("norefImage" in shieldDef || "backgroundDraw" in shieldDef)
-    ) {
+    if ("norefImage" in shieldDef || "backgroundDraw" in shieldDef) {
       //Valid shield with no ref to draw
       return ctx;
     }
@@ -170,7 +169,7 @@ function drawShield(network, ref) {
     return null;
   }
 
-  if (shieldDef != null && shieldDef.notext == true) {
+  if (shieldDef.notext == true) {
     //If the shield definition says not to draw a ref, ignore ref
     return ctx;
   }

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -126,9 +126,10 @@ function drawShield(network, ref) {
       padding: {
         left: 2,
         right: 2,
-        top: 4,
-        bottom: 5,
+        top: 1,
+        bottom: 2,
       },
+      maxFontSize: 16,
     };
   } else {
     bannerCount = ShieldDef.getBannerCount(shieldDef);

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -85,12 +85,7 @@ function getRasterShieldBlank(network, ref) {
       shieldArtwork = shieldDef.backgroundImage[i];
 
       bounds = compoundShieldSize(shieldArtwork.data, bannerCount);
-      textLayout = ShieldText.layoutShieldText(
-        ref,
-        shieldDef.padding,
-        bounds,
-        textLayoutFunc
-      );
+      textLayout = ShieldText.layoutShieldTextFromDef(ref, shieldDef, bounds);
       if (textLayout.fontPx > Gfx.fontSizeThreshold * Gfx.getPixelRatio()) {
         break;
       }
@@ -181,36 +176,11 @@ function drawShield(network, ref) {
   }
 
   //The ref is valid and we're supposed to draw it
-
-  var textLayoutFunc = ShieldText.rectTextConstraint;
-
-  if (
-    shieldDef != null &&
-    typeof shieldDef.textLayoutConstraint != "undefined"
-  ) {
-    textLayoutFunc = shieldDef.textLayoutConstraint;
-  }
-
-  var textLayout = ShieldText.layoutShieldText(
+  var textLayout = ShieldText.layoutShieldTextFromDef(
     ref,
-    padding,
-    shieldBounds,
-    textLayoutFunc
+    shieldDef,
+    shieldBounds
   );
-
-  //If size-to-fill shield text is too big, shrink it
-  if (shieldDef != null && typeof shieldDef.maxFontSize != "undefined") {
-    let maxFontSize = shieldDef.maxFontSize * PXR;
-    if (textLayout.fontPx > maxFontSize) {
-      var shrinkFactor = maxFontSize / textLayout.fontPx;
-      var y0 = shieldBounds.height - padding.top - padding.bottom;
-      var gap = y0 - textLayout.yBaseline + padding.top;
-      var tx = y0 - 2 * gap;
-      var txNew = shrinkFactor * tx;
-      textLayout.yBaseline -= (tx - txNew) / 2;
-      textLayout.fontPx = maxFontSize;
-    }
-  }
 
   textLayout.yBaseline += bannerCount * ShieldDef.bannerSizeH;
 

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -54,11 +54,12 @@ export function loadShields(shieldImages) {
       shieldImages.shield40_us_interstate_2,
       shieldImages.shield40_us_interstate_3,
     ],
+    textLayoutConstraint: ShieldText.southHalfellipseTextConstraint,
     textColor: "white",
     padding: {
       left: 3,
       right: 3,
-      top: 5,
+      top: 4.5,
       bottom: 5,
     },
   };
@@ -68,6 +69,7 @@ export function loadShields(shieldImages) {
       shieldImages.shield40_us_interstate_business_2,
       shieldImages.shield40_us_interstate_business_3,
     ],
+    textLayoutConstraint: ShieldText.southHalfellipseTextConstraint,
     textColor: "white",
     padding: {
       left: 3,
@@ -364,6 +366,7 @@ export function loadShields(shieldImages) {
 
   shields["US:VA"] = {
     backgroundImage: shieldImages.shield40_us_va,
+    textLayoutConstraint: ShieldText.southHalfellipseTextConstraint,
     textColor: "black",
     padding: {
       left: 2,

--- a/style/js/shield_text.js
+++ b/style/js/shield_text.js
@@ -87,7 +87,21 @@ function layoutShieldText(text, padding, bounds, textLayoutFunc, maxFontSize) {
   metrics = ctx.measureText(text);
   textHeight = metrics.actualBoundingBoxDescent;
 
-  var yBaseline = padTop + (availHeight - textHeight) / 2;
+  var yBaseline;
+
+  switch (textConstraint.valign) {
+    case VerticalAlignment.Middle:
+      yBaseline = padTop + (availHeight - textHeight) / 2;
+      break;
+    case VerticalAlignment.Top:
+      yBaseline = padTop;
+      break;
+    case VerticalAlignment.Bottom:
+      yBaseline = padTop + availHeight - textHeight;
+      break;
+    default:
+      return null; //Code error, should never happen
+  }
 
   return {
     xBaseline: xBaseline,

--- a/style/js/shield_text.js
+++ b/style/js/shield_text.js
@@ -96,6 +96,15 @@ const defaultDefForLayout = {
   },
 };
 
+/**
+ * Determines the position and font size to draw text so that it fits within
+ * a bounding box.
+ *
+ * @param {*} text - text to draw
+ * @param {*} def - shield definition
+ * @param {*} bounds - size of the overall graphics area
+ * @returns JOSN object containing (X,Y) draw position and font size
+ */
 export function layoutShieldTextFromDef(text, def, bounds) {
   if (def == null) {
     def = defaultDefForLayout;

--- a/style/js/shield_text.js
+++ b/style/js/shield_text.js
@@ -9,16 +9,31 @@ const VerticalAlignment = {
   Bottom: "bottom",
 };
 
-export function ellipseTextConstraint(spaceBounds, textBounds) {
+function ellipseScale(spaceBounds, textBounds) {
+  //Math derived from https://mathworld.wolfram.com/Ellipse-LineIntersection.html
   var a = spaceBounds.height;
   var b = spaceBounds.width;
 
   var x0 = textBounds.width;
   var y0 = textBounds.height;
 
+  return (a * b) / Math.sqrt(a * a * y0 * y0 + b * b * x0 * x0);
+}
+
+export function ellipseTextConstraint(spaceBounds, textBounds) {
   return {
-    scale: (a * b) / Math.sqrt(a * a * y0 * y0 + b * b * x0 * x0),
+    scale: ellipseScale(spaceBounds, textBounds),
     valign: VerticalAlignment.Middle,
+  };
+}
+
+export function southHalfellipseTextConstraint(spaceBounds, textBounds) {
+  return {
+    scale: ellipseScale(spaceBounds, {
+      width: textBounds.width / 2,
+      height: textBounds.height,
+    }),
+    valign: VerticalAlignment.Top,
   };
 }
 


### PR DESCRIPTION
Closes #114 

This PR implements a half-ellipse text constraint, for shields that are closer to a semi-circle in shape than a rectangle.  This allows for improved text scaling for variable-length shield refs.  This also simplifies the code for "max font size" constraints in the shield definitions, which was a pre-requisite for centralizing all of the text scaling code into shield_text.js functions.

Before/After Virginia:
![image](https://user-images.githubusercontent.com/3254090/151671609-89e2b32a-2847-4d51-a325-79599688cc35.png)
![image](https://user-images.githubusercontent.com/3254090/151671640-33205cc7-c493-4faa-af6b-dc05cd6573bc.png)


Before/After I-H201:
![image](https://user-images.githubusercontent.com/3254090/151671423-9d6cf22b-3cf8-4fbd-824e-e71719ccaa09.png)
![image](https://user-images.githubusercontent.com/3254090/151671450-0a717681-3925-4d72-9891-1c0c4be2288d.png)
