### PR TITLE
Shields of Kentucky

### DIFF
--- a/style/icons/shield40_us_ky_parkway.svg
+++ b/style/icons/shield40_us_ky_parkway.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="20"
+   height="20"
+   version="1.0"
+   id="svg1113"
+   sodipodi:docname="shield40_us_ky_parkway.svg"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1117" />
+  <sodipodi:namedview
+     id="namedview1115"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="31.35"
+     inkscape:cx="11.897927"
+     inkscape:cy="10"
+     inkscape:window-width="1383"
+     inkscape:window-height="855"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1113" />
+  <rect
+     width="20"
+     height="20"
+     rx="1.25"
+     ry="1.25"
+     fill="#003478"
+     stroke-width="0.625"
+     id="rect1107"
+     x="0"
+     y="-20"
+     transform="scale(1,-1)"
+     style="fill:#003f87" />
+  <use
+     transform="matrix(0.92938,0,0,-0.92938,19977,4810.8)"
+     width="300"
+     height="240"
+     fill="#ffffff"
+     stroke="#000000"
+     stroke-linejoin="round"
+     stroke-width="309"
+     xlink:href="#state_outline"
+     id="use1109"
+     x="0"
+     y="0" />
+  <rect
+     style="fill:#ffffff;stroke-width:0"
+     id="rect1727"
+     width="18"
+     height="14"
+     x="1"
+     y="1" />
+</svg>

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -227,7 +227,7 @@ export function missingIconLoader(map, e) {
     return;
   }
 
-  var network_ref = id.split("_")[1];
+  var network_ref = id.split("\n")[1];
   var network_ref_parts = network_ref.split("=");
   var network = network_ref_parts[0];
   var ref = network_ref_parts[1];

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -109,7 +109,7 @@ function textColor(shieldDef) {
   return "black";
 }
 
-function drawShield(network, ref) {
+function drawShield(network, ref, wayName) {
   var shieldDef = ShieldDef.shields[network];
   var ctx = null;
   var bannerCount = 0;
@@ -136,6 +136,10 @@ function drawShield(network, ref) {
   } else {
     bannerCount = ShieldDef.getBannerCount(shieldDef);
     padding = shieldDef.padding;
+
+    if (shieldDef.refsByWayName) {
+      ref = shieldDef.refsByWayName[wayName];
+    }
 
     var shieldArtwork = getRasterShieldBlank(network, ref);
     var compoundBounds = null;
@@ -231,10 +235,11 @@ export function missingIconLoader(map, e) {
   var network_ref_parts = network_ref.split("=");
   var network = network_ref_parts[0];
   var ref = network_ref_parts[1];
+  var wayName = id.split("\n")[2];
 
   var colorLighten = ShieldDef.shieldLighten(network, ref);
 
-  var ctx = drawShield(network, ref);
+  var ctx = drawShield(network, ref, wayName);
 
   if (ctx == null) {
     //Does not meet the criteria to draw a shield

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -194,6 +194,20 @@ export function loadShields(shieldImages) {
       bottom: 6,
     },
   };
+  shields["US:KY:Parkway"] = Object.assign(
+    {
+      refsByWayName: {
+        "Audobon Parkway": "AU",
+        "Bluegrass Pkwy": "BG",
+        "Cumberland Pkwy": "LN",
+        "Hal Rogers Pkwy": "HR",
+        "Mountain Pkwy": "MP",
+        "Purchase Pkwy": "JC",
+        "Western Kentucky Pkwy": "WK",
+      },
+    },
+    shields["US:KY:AA"]
+  );
 
   shields["US:MI"] = diamondShield;
 

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -184,6 +184,16 @@ export function loadShields(shieldImages) {
   };
 
   shields["US:KY"] = circleShield("white", "black");
+  shields["US:KY:AA"] = {
+    backgroundImage: shieldImages.shield40_us_ky_parkway,
+    textColor: "#003f87",
+    padding: {
+      left: 2,
+      right: 2,
+      top: 2,
+      bottom: 6,
+    },
+  };
 
   shields["US:MI"] = diamondShield;
 

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -183,6 +183,8 @@ export function loadShields(shieldImages) {
     },
   };
 
+  shields["US:KY"] = circleShield("white", "black");
+
   shields["US:MI"] = diamondShield;
 
   shields["US:MN"] = {

--- a/style/layer/highway_shield.js
+++ b/style/layer/highway_shield.js
@@ -6,7 +6,7 @@ function routeConcurrency(num) {
   return [
     "case",
     ["!=", ["get", "route_" + num], null],
-    ["image", ["concat", "shield_", ["get", "route_" + num]]],
+    ["image", ["concat", "shield\n", ["get", "route_" + num]]],
     ["literal", ""],
   ];
 }

--- a/style/layer/highway_shield.js
+++ b/style/layer/highway_shield.js
@@ -6,7 +6,10 @@ function routeConcurrency(num) {
   return [
     "case",
     ["!=", ["get", "route_" + num], null],
-    ["image", ["concat", "shield\n", ["get", "route_" + num]]],
+    [
+      "image",
+      ["concat", "shield\n", ["get", "route_" + num], "\n", ["get", "name"]],
+    ],
     ["literal", ""],
   ];
 }


### PR DESCRIPTION
Added shields for Kentucky state highways and parkways.

<img src="https://user-images.githubusercontent.com/1231218/151683155-8c2aef30-bf5d-4911-920b-9027f3a8d671.png" width="300" alt="BG at KY 555">

For now, the state highway shield is a circle for simplicity. As tail work, it should be replaced by an ellipse or the rounded rectangle that KYTC posts on signs: https://github.com/ZeLonewolf/openstreetmap-americana/issues/117#issuecomment-1025013060.

The parkways are more complex. Each of the parkways uses a standardized shield that bears the state tourism logo and the road’s entire official name. Unfortunately, most screens don’t come with enough pixel density to legibly display the namesake’s middle initial in a small shield. Each parkway has an official two-letter initialisms and four-digit route number that is used only in KYTC publications, so we can’t tag them as refs in OSM. Even so, I think users would recognize the initialisms on a map, because they’re derived from the road name’s initials (or the namesake’s first and last initials). Some of the routes, like the [Western Kentucky Parkway](https://www.openstreetmap.org/relation/1648091) (WK), used to bear these initialisms on their shields.

[![Western Kentucky Parkway](https://upload.wikimedia.org/wikipedia/commons/a/a6/BluegrassPkwyWest-Exit1AB-Int65nsSplit_%2838035267226%29.jpg)](https://commons.wikimedia.org/wiki/File:BluegrassPkwyWest-Exit1AB-Int65nsSplit_%2838035267226%29.jpg)
_The shield is so poorly designed that KYTC has to stick alt text next to it._

In order to display shields for the parkways, I had to plumb the way name through to the shield definition and map way names to hard-coded display refs. In general, it’s a very bad idea to conflate route shields with road names, but I don’t think we really have a choice with Kentucky’s parkway system. To head off abuse of this mechanism, I’ve made it so that it can only map way names to refs, not background images. In theory, we could hard-code logic in OpenMapTiles to expose the Kentucky parkway route relations’ `short_name`s in the `route_*` properties. However, it’s my understanding that OpenMapTiles would prefer to avoid such regionally targeted logic.

As a special case, the AA Highway has a shield that resembles the parkway shield, but it does have a signposted ref of “AA” along with a unique `network` tag. The `network=US:KY:AA` tag was introduced [less than a month ago](https://www.openstreetmap.org/changeset/115738030), so it hasn’t propagated to OpenMapTiles yet. For now, it’ll render as a lettered state highway shield, but here’s a jury-rigged preview:

<img src="https://user-images.githubusercontent.com/1231218/151683554-88203ba7-8181-48cb-8f51-2a1e3d7729fc.png" width="350" alt="AA before"> <img src="https://user-images.githubusercontent.com/1231218/151683585-fff6532c-feb5-4397-a44a-f9aced19553e.png" width="350" alt="AA after">
