### PR TITLE
Set shield pitch alignment to viewport

### DIFF
--- a/style/layer/highway_shield.js
+++ b/style/layer/highway_shield.js
@@ -24,6 +24,7 @@ let shieldLayout = {
   "text-letter-spacing": 0.7,
   "symbol-placement": "line",
   "text-max-angle": 180,
+  "text-pitch-alignment": "viewport",
 };
 
 let baseShield = {


### PR DESCRIPTION
Resolves #111.  Turns out this issue is trivial to fix with the `text-pitch-alignment` property.

As noted in #108 and maplibre/maplibre-gl-js#716, this has an unfortunate side effect. At certain screen pixel densities when the map is flat, shields can look rather pixelated and bad.  Hopefully this issue can be fixed in MapLibre.  See further explanation in https://github.com/ZeLonewolf/openstreetmap-americana/pull/108#issuecomment-1024806194 and https://github.com/maplibre/maplibre-gl-js/pull/716#issuecomment-995943188

