### PR TITLE
Fix bug in half-ellipse layout

### DIFF
--- a/style/js/shield_text.js
+++ b/style/js/shield_text.js
@@ -30,8 +30,9 @@ export function ellipseTextConstraint(spaceBounds, textBounds) {
 export function southHalfellipseTextConstraint(spaceBounds, textBounds) {
   return {
     scale: ellipseScale(spaceBounds, {
-      width: textBounds.width / 2,
-      height: textBounds.height,
+      //Turn ellipse 90 degrees
+      height: textBounds.width / 2,
+      width: textBounds.height,
     }),
     valign: VerticalAlignment.Top,
   };


### PR DESCRIPTION
This fixes a bug in half-ellipse text layout code.

Before:
![image](https://user-images.githubusercontent.com/3254090/151727808-1abc7521-2b71-4c36-9510-a87ab91a2c13.png)

After:
![image](https://user-images.githubusercontent.com/3254090/151727845-c99108c6-2fb4-4f10-af29-300b83177fc5.png)
