### PR TITLE
Fix the map crashing when zoomed into Pittsburgh

### DIFF
--- a/style/js/shield_canvas_draw.js
+++ b/style/js/shield_canvas_draw.js
@@ -40,6 +40,9 @@ export function paBelt(ref) {
     case "Blue Belt":
       ctx.fillStyle = "#003882";
       break;
+    case "Purple Belt":
+      ctx.fillStyle = "#bd0063";
+      break;
     default:
       return null;
   }


### PR DESCRIPTION
Add handling for Purple Belt, color from Wikimedia

Note that the shield style for this should technically be different, and
of course it would be good if shield crashes could be recovered from.