### PR TITLE
Recover from exceptions loading shields

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -240,7 +240,7 @@ map.on("styledata", function () {
 });
 
 map.on("styleimagemissing", function (e) {
-  Shield.missingIconLoader(map, e);
+  Shield.missingIconHandler(map, e);
 });
 
 map.addControl(

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -190,6 +190,14 @@ function drawShield(network, ref) {
   return ctx;
 }
 
+export function missingIconHandler(map, e) {
+  try {
+    missingIconLoader(map, e);
+  } catch (err) {
+    console.error(`Exception while loading image ‘${e?.id}’:\n`, err);
+  }
+}
+
 export function missingIconLoader(map, e) {
   var id = e.id;
 


### PR DESCRIPTION
Log the exception to the console, but allow the tile to continue
rendering without the missing image.