### PR TITLE
Minor roads

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -64,6 +64,7 @@ americanaLayers.push(
   lyrRoad.secondary.casing(),
   lyrRoad.tertiaryExpressway.casing(),
   lyrRoad.tertiary.casing(),
+  lyrRoad.minor.casing(),
 
   lyrRoad.motorwayLink.casing(),
   lyrRoad.trunkLink.casing(),
@@ -71,6 +72,7 @@ americanaLayers.push(
   lyrRoad.motorwayLink.fill(),
   lyrRoad.trunkLink.fill(),
 
+  lyrRoad.minor.fill(),
   lyrRoad.tertiary.fill(),
   lyrRoad.tertiaryExpressway.fill(),
   lyrRoad.secondary.fill(),
@@ -85,6 +87,7 @@ americanaLayers.push(
   lyrRoad.motorwayLink.surface(),
   lyrRoad.trunkLink.surface(),
 
+  lyrRoad.minor.surface(),
   lyrRoad.tertiary.surface(),
   lyrRoad.tertiaryExpressway.surface(),
   lyrRoad.secondary.surface(),
@@ -100,6 +103,9 @@ americanaLayers.push(
 );
 
 var bridgeLayers = [
+  lyrRoad.minorBridge.casing(),
+  lyrRoad.minorBridge.fill(),
+
   lyrRoad.tertiaryBridge.casing(),
   lyrRoad.tertiaryExpresswayBridge.casing(),
   lyrRoad.tertiaryLinkBridge.casing(),
@@ -179,6 +185,8 @@ americanaLayers.push(
   lyrRoadLabel.secondaryHZ,
   lyrRoadLabel.tertiary,
   lyrRoadLabel.tertiaryHZ,
+  lyrRoadLabel.minor,
+  lyrRoadLabel.minorHZ,
 
   lyrPark.label,
 

--- a/style/americana.js
+++ b/style/americana.js
@@ -65,6 +65,8 @@ americanaLayers.push(
   lyrRoad.tertiaryExpressway.casing(),
   lyrRoad.tertiary.casing(),
   lyrRoad.minor.casing(),
+  lyrRoad.service.casing(),
+  lyrRoad.smallService.casing(),
 
   lyrRoad.motorwayLink.casing(),
   lyrRoad.trunkLink.casing(),
@@ -72,6 +74,8 @@ americanaLayers.push(
   lyrRoad.motorwayLink.fill(),
   lyrRoad.trunkLink.fill(),
 
+  lyrRoad.smallService.fill(),
+  lyrRoad.service.fill(),
   lyrRoad.minor.fill(),
   lyrRoad.tertiary.fill(),
   lyrRoad.tertiaryExpressway.fill(),
@@ -87,6 +91,8 @@ americanaLayers.push(
   lyrRoad.motorwayLink.surface(),
   lyrRoad.trunkLink.surface(),
 
+  lyrRoad.smallService.surface(),
+  lyrRoad.service.surface(),
   lyrRoad.minor.surface(),
   lyrRoad.tertiary.surface(),
   lyrRoad.tertiaryExpressway.surface(),
@@ -103,6 +109,12 @@ americanaLayers.push(
 );
 
 var bridgeLayers = [
+  lyrRoad.smallServiceBridge.casing(),
+  lyrRoad.smallServiceBridge.fill(),
+
+  lyrRoad.serviceBridge.casing(),
+  lyrRoad.serviceBridge.fill(),
+
   lyrRoad.minorBridge.casing(),
   lyrRoad.minorBridge.fill(),
 
@@ -187,6 +199,9 @@ americanaLayers.push(
   lyrRoadLabel.tertiaryHZ,
   lyrRoadLabel.minor,
   lyrRoadLabel.minorHZ,
+  lyrRoadLabel.service,
+  lyrRoadLabel.smallService,
+  lyrRoadLabel.serviceHZ,
 
   lyrPark.label,
 

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -479,6 +479,52 @@ class Minor extends Road {
   }
 }
 
+class Service extends Road {
+  constructor() {
+    super();
+    this.highwayClass = "service";
+    this.brunnel = "surface";
+    this.link = false;
+    this.hue = 0;
+
+    this.minZoomFill = 16;
+    this.minZoomCasing = 13;
+
+    this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.2);
+    this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.2);
+
+    this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
+    // Casing color gets interpolated as a fade from light to dark between this
+    // level's introduction and next road-level introduction.
+    this.casingColor = [
+      "interpolate",
+      ["exponential", roadExp],
+      ["zoom"],
+      11,
+      `hsl(${this.hue}, 0%, 75%)`,
+      13,
+      `hsl(${this.hue}, 0%, 23%)`,
+    ];
+    this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
+
+    this.constraints = ["!in", "service", "parking_aisle", "driveway"];
+  }
+}
+
+class SmallService extends Service {
+  constructor() {
+    super();
+
+    this.minZoomFill = 16;
+    this.minZoomCasing = 15;
+
+    this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.15);
+    this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.15);
+
+    this.constraints = ["in", "service", "parking_aisle", "driveway"];
+  }
+}
+
 class MotorwayLink extends Motorway {
   constructor() {
     super();
@@ -644,6 +690,22 @@ class MinorBridge extends Minor {
   }
 }
 
+class ServiceBridge extends Service {
+  constructor() {
+    //undifferentiated
+    super();
+    this.brunnel = "bridge";
+  }
+}
+
+class SmallServiceBridge extends SmallService {
+  constructor() {
+    //undifferentiated
+    super();
+    this.brunnel = "bridge";
+  }
+}
+
 class MotorwayLinkBridge extends MotorwayLink {
   constructor() {
     super();
@@ -754,6 +816,8 @@ export const secondaryExpressway = new SecondaryExpressway();
 export const tertiary = new Tertiary();
 export const tertiaryExpressway = new TertiaryExpressway();
 export const minor = new Minor();
+export const service = new Service();
+export const smallService = new SmallService();
 
 export const motorwayBridge = new MotorwayBridge();
 export const trunkBridge = new TrunkBridge();
@@ -765,6 +829,8 @@ export const secondaryExpresswayBridge = new SecondaryExpresswayBridge();
 export const tertiaryBridge = new TertiaryBridge();
 export const tertiaryExpresswayBridge = new TertiaryExpresswayBridge();
 export const minorBridge = new MinorBridge();
+export const serviceBridge = new ServiceBridge();
+export const smallServiceBridge = new SmallServiceBridge();
 
 export const motorwayTunnel = new MotorwayTunnel();
 export const trunkTunnel = new TrunkTunnel();

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -168,6 +168,9 @@ class Road {
       this.constraints
     );
     layer.filter.push(["==", "surface", "unpaved"]);
+    if (this.constraints != null) {
+      layer.filter.push(this.constraints);
+    }
     layer.layout = layoutRoadSurface;
     layer.paint = roadSurfacePaint(this.surfaceColor, this.fillWidth);
     return layer;

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -473,9 +473,9 @@ class Minor extends Road {
       "interpolate",
       ["exponential", roadExp],
       ["zoom"],
-      11,
-      `hsl(${this.hue}, 0%, 75%)`,
-      13,
+      12,
+      `hsl(${this.hue}, 0%, 65%)`,
+      15,
       `hsl(${this.hue}, 0%, 23%)`,
     ];
     this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
@@ -503,9 +503,9 @@ class Service extends Road {
       "interpolate",
       ["exponential", roadExp],
       ["zoom"],
-      11,
-      `hsl(${this.hue}, 0%, 75%)`,
       13,
+      `hsl(${this.hue}, 0%, 65%)`,
+      18,
       `hsl(${this.hue}, 0%, 23%)`,
     ];
     this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
@@ -523,6 +523,18 @@ class SmallService extends Service {
 
     this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.15);
     this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.15);
+
+    // Casing color gets interpolated as a fade from light to dark between this
+    // level's introduction and next road-level introduction.
+    this.casingColor = [
+      "interpolate",
+      ["exponential", roadExp],
+      ["zoom"],
+      15,
+      `hsl(${this.hue}, 0%, 65%)`,
+      19,
+      `hsl(${this.hue}, 0%, 23%)`,
+    ];
 
     this.constraints = ["in", "service", "parking_aisle", "driveway"];
   }

--- a/style/layer/road.js
+++ b/style/layer/road.js
@@ -449,6 +449,36 @@ class TertiaryExpressway extends Tertiary {
   }
 }
 
+class Minor extends Road {
+  constructor() {
+    super();
+    this.highwayClass = "minor";
+    this.brunnel = "surface";
+    this.link = false;
+    this.hue = 0;
+
+    this.minZoomFill = 16;
+    this.minZoomCasing = 12;
+
+    this.fillWidth = Util.zoomMultiply(trunkFillWidth, 0.3);
+    this.casingWidth = Util.zoomMultiply(trunkCasingWidth, 0.3);
+
+    this.fillColor = `hsl(${this.hue}, 100%, 100%)`;
+    // Casing color gets interpolated as a fade from light to dark between this
+    // level's introduction and next road-level introduction.
+    this.casingColor = [
+      "interpolate",
+      ["exponential", roadExp],
+      ["zoom"],
+      11,
+      `hsl(${this.hue}, 0%, 75%)`,
+      13,
+      `hsl(${this.hue}, 0%, 23%)`,
+    ];
+    this.surfaceColor = `hsl(${this.hue}, 0%, 80%)`;
+  }
+}
+
 class MotorwayLink extends Motorway {
   constructor() {
     super();
@@ -606,6 +636,14 @@ class TertiaryExpresswayBridge extends TertiaryExpressway {
   }
 }
 
+class MinorBridge extends Minor {
+  constructor() {
+    //undifferentiated
+    super();
+    this.brunnel = "bridge";
+  }
+}
+
 class MotorwayLinkBridge extends MotorwayLink {
   constructor() {
     super();
@@ -715,6 +753,7 @@ export const secondary = new Secondary();
 export const secondaryExpressway = new SecondaryExpressway();
 export const tertiary = new Tertiary();
 export const tertiaryExpressway = new TertiaryExpressway();
+export const minor = new Minor();
 
 export const motorwayBridge = new MotorwayBridge();
 export const trunkBridge = new TrunkBridge();
@@ -725,6 +764,7 @@ export const secondaryBridge = new SecondaryBridge();
 export const secondaryExpresswayBridge = new SecondaryExpresswayBridge();
 export const tertiaryBridge = new TertiaryBridge();
 export const tertiaryExpresswayBridge = new TertiaryExpresswayBridge();
+export const minorBridge = new MinorBridge();
 
 export const motorwayTunnel = new MotorwayTunnel();
 export const trunkTunnel = new TrunkTunnel();

--- a/style/layer/road_label.js
+++ b/style/layer/road_label.js
@@ -137,3 +137,39 @@ export const minorHZ = {
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
+
+export const service = {
+  id: "service_label",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "service"], ["!in", "service", "parking_aisle", "driveway"]],
+  minzoom: 14,
+  maxzoom: 17,
+  layout: offsetLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};
+
+
+export const serviceHZ = {
+  id: "service_label_hz",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "service"]],
+  minzoom: 17,
+  layout: centerLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};
+
+export const smallService = {
+  id: "small_service_label",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "service"], ["in", "service", "parking_aisle", "driveway"]],
+  minzoom: 15,
+  maxzoom: 17,
+  layout: offsetLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};

--- a/style/layer/road_label.js
+++ b/style/layer/road_label.js
@@ -142,14 +142,17 @@ export const service = {
   id: "service_label",
   type: "symbol",
   paint: textPaint,
-  filter: ["all", ["==", "class", "service"], ["!in", "service", "parking_aisle", "driveway"]],
+  filter: [
+    "all",
+    ["==", "class", "service"],
+    ["!in", "service", "parking_aisle", "driveway"],
+  ],
   minzoom: 14,
   maxzoom: 17,
   layout: offsetLabelStyle,
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
-
 
 export const serviceHZ = {
   id: "service_label_hz",
@@ -166,7 +169,11 @@ export const smallService = {
   id: "small_service_label",
   type: "symbol",
   paint: textPaint,
-  filter: ["all", ["==", "class", "service"], ["in", "service", "parking_aisle", "driveway"]],
+  filter: [
+    "all",
+    ["==", "class", "service"],
+    ["in", "service", "parking_aisle", "driveway"],
+  ],
   minzoom: 15,
   maxzoom: 17,
   layout: offsetLabelStyle,

--- a/style/layer/road_label.js
+++ b/style/layer/road_label.js
@@ -114,3 +114,26 @@ export const tertiaryHZ = {
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
+
+export const minor = {
+  id: "minor_label",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "minor"]],
+  minzoom: 13,
+  maxzoom: 17,
+  layout: offsetLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};
+
+export const minorHZ = {
+  id: "minor_label_hz",
+  type: "symbol",
+  paint: textPaint,
+  filter: ["all", ["==", "class", "minor"]],
+  minzoom: 17,
+  layout: centerLabelStyle,
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+};


### PR DESCRIPTION
Add minor and service roads.

Before:
<img width="1234" alt="Screen Shot 2022-02-09 at 10 10 32 AM" src="https://user-images.githubusercontent.com/25242/153229686-6ea33095-060b-421e-917f-310645c60649.png">

After:
<img width="1234" alt="Screen Shot 2022-02-09 at 3 17 13 AM" src="https://user-images.githubusercontent.com/25242/153154249-e3b8aa3b-ea19-4fd6-b869-ecbf018b7521.png">

Minor roads (unclassified & residential) are introduced at z12 slightly smaller than tertiary. 

Service roads are broken into two classes:
1. Plain service and `service=alley`. (introduced at z=13)
2. `service=driveway` and `service=parking_aisle` (Smaller, introduced at z15)

All 3 layers use the same minZoomFill of 16 as does tertiary, so that tertiary on down switch to fill at the same time.

<img width="1233" alt="z15" src="https://user-images.githubusercontent.com/25242/153154272-09188ce9-8ea1-41c1-85f3-8a92111a6452.png">
<img width="1233" alt="z16" src="https://user-images.githubusercontent.com/25242/153154275-95f6f705-a857-44dd-85b1-362a93c25c7a.png">
<img width="1232" alt="z19" src="https://user-images.githubusercontent.com/25242/153154265-44022f6e-e3ff-4180-b5b9-cba7382ad176.png">
