### PR TITLE
Fix build and deploy action with parcel by updating Node version.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
-      - name: Use Node.js 16.x
+      - name: Use Node.js 17.x
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 17.x
       - name: Install and Build 🔧
         run: |
           cd style


### PR DESCRIPTION
After merging #137 I saw that [build and deploy](https://github.com/ZeLonewolf/openstreetmap-americana/runs/5151994151?check_suite_focus=true) failed due to using Node 16.x rather than Node 17 (with npm 8.3.0+) that we are now requiring. 
<img width="1197" alt="Screen Shot 2022-02-11 at 12 27 09 AM" src="https://user-images.githubusercontent.com/25242/153541901-e3a63760-90ca-4361-b558-a6502dc5df46.png">
 
I'm hoping that these changes to the workflow will fix the deployment.