### PR TITLE
Remove duplication in banner definitions

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -3,6 +3,7 @@
 import * as ShieldDraw from "./shield_canvas_draw.js";
 import * as ShieldText from "./shield_text.js";
 import * as Gfx from "./screen_gfx.js";
+import * as Util from "./util.js";
 
 //Height of modifier banners
 export const bannerSizeH = 8 * Gfx.getPixelRatio();
@@ -52,6 +53,13 @@ function roundedRectShield(
     maxFontSize: 16,
     textColor: textColor,
   };
+}
+
+function banneredShield(baseDef, modifiers) {
+  let newShield = Util.cp(baseDef);
+  newShield.backgroundImage = baseDef.backgroundImage;
+  newShield.modifiers = modifiers;
+  return newShield;
 }
 
 export function loadShields(shieldImages) {
@@ -130,47 +138,16 @@ export function loadShields(shieldImages) {
     padding: padding_us_us,
   };
 
-  shields["US:US:Truck"] = {
-    backgroundImage: shield_us_us,
-    textColor: "black",
-    padding: padding_us_us,
-    modifiers: ["TRK"],
-  };
-
-  shields["US:US:Spur"] = {
-    backgroundImage: shield_us_us,
-    textColor: "black",
-    padding: padding_us_us,
-    modifiers: ["SPUR"],
-  };
-
-  shields["US:US:Bypass"] = {
-    backgroundImage: shield_us_us,
-    textColor: "black",
-    padding: padding_us_us,
-    modifiers: ["BYP"],
-  };
-
-  shields["US:US:Business"] = {
-    backgroundImage: shield_us_us,
-    textColor: "black",
-    padding: padding_us_us,
-    modifiers: ["BUS"],
-  };
-
-  shields["US:US:Alternate"] = {
-    backgroundImage: shield_us_us,
-    textColor: "black",
-    padding: padding_us_us,
-    modifiers: ["ALT"],
-  };
-
-  shields["US:US:Alternate:Truck:Business"] = {
-    backgroundImage: shield_us_us,
-    textColor: "black",
-    padding: padding_us_us,
-    modifiers: ["ALT", "TRK", "BUS"],
-  };
+  shields["US:US:Truck"] = banneredShield(shields["US:US"], ["TRK"]);
+  shields["US:US:Spur"] = banneredShield(shields["US:US"], ["SPUR"]);
+  shields["US:US:Bypass"] = banneredShield(shields["US:US"], ["BYP"]);
+  shields["US:US:Business"] = banneredShield(shields["US:US"], ["BUS"]);
+  shields["US:US:Alternate"] = banneredShield(shields["US:US"], ["ALT"]);
+  shields["US:US:Alternate:Truck:Business"] = banneredShield(shields["US:US"], [
+    "ALT",
+    "TRK",
+    "BUS",
+  ]);
 
   shields["US:US:Historic"] = {
     backgroundImage: shield_us_us,
@@ -365,29 +342,8 @@ export function loadShields(shieldImages) {
     },
   };
 
-  shields["US:PA:Business"] = {
-    backgroundImage: shieldImages.shield40_us_pa,
-    textColor: "black",
-    padding: {
-      left: 10,
-      right: 10,
-      top: 0,
-      bottom: 10,
-    },
-    modifiers: ["BUS"],
-  };
-
-  shields["US:PA:Truck"] = {
-    backgroundImage: shieldImages.shield40_us_pa,
-    textColor: "black",
-    padding: {
-      left: 10,
-      right: 10,
-      top: 0,
-      bottom: 10,
-    },
-    modifiers: ["TRK"],
-  };
+  shields["US:PA:Business"] = banneredShield(shields["US:PA"], ["BUS"]);
+  shields["US:PA:Truck"] = banneredShield(shields["US:PA"], ["TRK"]);
 
   shields["US:PA:Turnpike"] = {
     backgroundImage: shieldImages.shield40_us_pa_turnpike,


### PR DESCRIPTION
This PR eliminates the duplication in defining "bannered" routes by adding a `banneredShield()` function that creates a bannered version of a base shield.

Seems to still be working after this change:
![image](https://user-images.githubusercontent.com/3254090/153608602-7e2f6c9e-b172-4bed-b267-ed3a5d70116f.png)
![image](https://user-images.githubusercontent.com/3254090/153609096-cc04687f-f71f-4311-9433-21024f61c8d0.png)
