### PR TITLE
Revert "Merge branch 'openmapsamples-135'"

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -19,9 +19,6 @@ import * as lyrWater from "./layer/water.js";
 import * as maplibregl from "maplibre-gl";
 import "maplibre-gl/maplibre-gl.css";
 
-import SampleControl from "openmapsamples-maplibre/OpenMapSamplesControl";
-import { default as OpenMapTilesSamples } from "openmapsamples/samples/OpenMapTiles";
-
 /*
  This is a list of the layers in the Americana style, from bottom to top.
 */
@@ -269,12 +266,4 @@ map.addControl(
   })
 );
 map.addControl(new maplibregl.NavigationControl(), "top-left");
-
-// Add our sample data.
-let sampleControl = new SampleControl({ permalinks: true });
-OpenMapTilesSamples.forEach((sample, i) => {
-  sampleControl.addSample(sample);
-});
-map.addControl(sampleControl, "bottom-left");
-
 map.getCanvas().focus();

--- a/style/index.html
+++ b/style/index.html
@@ -24,9 +24,6 @@
         bottom: 10px;
         z-index: 100;
       }
-      .openmapsamples-control-container {
-        margin-left: 70px !important;
-      }
     </style>
     <script type="module" src="americana.js"></script>
   </head>

--- a/style/package-lock.json
+++ b/style/package-lock.json
@@ -12,7 +12,6 @@
       },
       "devDependencies": {
         "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5/maplibre-gl.tar.gz",
-        "openmapsamples-maplibre": "github:adamfranco/OpenMapSamples-MapLibre",
         "parcel": "^2.3.0",
         "prettier": "2.3.2"
       },
@@ -2357,15 +2356,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/geojson-validation": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/geojson-validation/-/geojson-validation-1.0.2.tgz",
-      "integrity": "sha512-K5jrJ4wFvORn2pRKeg181LL0QPYuEKn2KHPvfH1m2QtFlAXFLKdseqt0XwBM3ELOY7kNM1fglRQ6ZwUQZ5S00A==",
-      "dev": true,
-      "bin": {
-        "gjv": "bin/gjv"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -3173,25 +3163,6 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/openmapsamples": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/adamfranco/OpenMapSamples.git#2bfb8f85d187e65c66b92b588935cf9af3a84af3",
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "dependencies": {
-        "geojson-validation": "^1.0.2"
-      }
-    },
-    "node_modules/openmapsamples-maplibre": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/adamfranco/OpenMapSamples-MapLibre.git#07c135dd5ff55e8de784c300a8b70ae020eff55d",
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "dependencies": {
-        "maplibre-gl": "^2.0",
-        "openmapsamples": "github:adamfranco/OpenMapSamples"
       }
     },
     "node_modules/ordered-binary": {
@@ -6048,12 +6019,6 @@
         "wide-align": "^1.1.2"
       }
     },
-    "geojson-validation": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/geojson-validation/-/geojson-validation-1.0.2.tgz",
-      "integrity": "sha512-K5jrJ4wFvORn2pRKeg181LL0QPYuEKn2KHPvfH1m2QtFlAXFLKdseqt0XwBM3ELOY7kNM1fglRQ6ZwUQZ5S00A==",
-      "dev": true
-    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -6624,23 +6589,6 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "openmapsamples": {
-      "version": "git+ssh://git@github.com/adamfranco/OpenMapSamples.git#2bfb8f85d187e65c66b92b588935cf9af3a84af3",
-      "dev": true,
-      "from": "openmapsamples@github:adamfranco/OpenMapSamples",
-      "requires": {
-        "geojson-validation": "^1.0.2"
-      }
-    },
-    "openmapsamples-maplibre": {
-      "version": "git+ssh://git@github.com/adamfranco/OpenMapSamples-MapLibre.git#07c135dd5ff55e8de784c300a8b70ae020eff55d",
-      "dev": true,
-      "from": "openmapsamples-maplibre@github:adamfranco/OpenMapSamples-MapLibre",
-      "requires": {
-        "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5/maplibre-gl.tar.gz",
-        "openmapsamples": "github:adamfranco/OpenMapSamples"
       }
     },
     "ordered-binary": {

--- a/style/package.json
+++ b/style/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5/maplibre-gl.tar.gz",
-    "openmapsamples-maplibre": "github:adamfranco/OpenMapSamples-MapLibre",
     "parcel": "^2.3.0",
     "prettier": "2.3.2"
   },


### PR DESCRIPTION
This reverts commit 4f7e3923fd1a151caba13613355e3a1db6868c07, reversing
changes made to 1ee28c1aecd720b6c3cfbda42e74573351265c46.

Pull the pin to undo the merge of openmapsamples-135, which broke the build.