### PR TITLE
Ignore prettier on dist output

### DIFF
--- a/style/.prettierignore
+++ b/style/.prettierignore
@@ -1,3 +1,4 @@
 build
 sprites
 js/maplibre-gl.js
+dist


### PR DESCRIPTION
This PR adds `dist/` to the prettier ignore list.  We should not need to run prettier on minified code :)