### PR TITLE
Allow banners to be added to drawn shields

### DIFF
--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -141,8 +141,16 @@ function drawShield(network, ref) {
 
     if (shieldArtwork == null) {
       if (typeof shieldDef.backgroundDraw != "undefined") {
-        ctx = shieldDef.backgroundDraw(ref);
-        compoundBounds = compoundShieldSize(ctx, bannerCount);
+        let drawnShieldCtx = shieldDef.backgroundDraw(ref);
+        compoundBounds = compoundShieldSize(drawnShieldCtx.canvas, bannerCount);
+        ctx = Gfx.getGfxContext(compoundBounds);
+
+        ctx.drawImage(
+          drawnShieldCtx.canvas,
+          0,
+          bannerCount * ShieldDef.bannerSizeH
+        );
+
         shieldBounds = {
           width: ctx.canvas.width,
           height: ctx.canvas.height,

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -152,8 +152,8 @@ function drawShield(network, ref) {
         );
 
         shieldBounds = {
-          width: ctx.canvas.width,
-          height: ctx.canvas.height,
+          width: drawnShieldCtx.canvas.width,
+          height: drawnShieldCtx.canvas.height,
         };
       } else {
         return null;

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -187,10 +187,9 @@ export function loadShields(shieldImages) {
 
   shields["US:CA:CR"] = usMUTCDCountyShield;
   shields["US:DE"] = circleShield("white", "black");
-  shields["US:DE:Truck"] = banneredShield(shields["US:DE"], ["TRK"]);
   shields["US:DE:Business"] = banneredShield(shields["US:DE"], ["BUS"]);
   shields["US:DE:Alternate"] = banneredShield(shields["US:DE"], ["ALT"]);
-  
+
   shields["US:GA"] = {
     backgroundImage: [
       shieldImages.shield40_us_ga_2,

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -187,7 +187,10 @@ export function loadShields(shieldImages) {
 
   shields["US:CA:CR"] = usMUTCDCountyShield;
   shields["US:DE"] = circleShield("white", "black");
-
+  shields["US:DE:Truck"] = banneredShield(shields["US:DE"], ["TRK"]);
+  shields["US:DE:Business"] = banneredShield(shields["US:DE"], ["BUS"]);
+  shields["US:DE:Alternate"] = banneredShield(shields["US:DE"], ["ALT"]);
+  
   shields["US:GA"] = {
     backgroundImage: [
       shieldImages.shield40_us_ga_2,


### PR DESCRIPTION
Fixes #163 

This adds missing code to handle adding banners atop drawn shields (generic circles, rectangles, etc).  In addition, this adds support for `US:DE:Alternate` and `US:DE:Business` as proposed in #161, which both have confirmed examples on the map.

![image](https://user-images.githubusercontent.com/3254090/154193697-8df72588-8581-4072-acfe-0161ccdd4dc5.png)
![image](https://user-images.githubusercontent.com/3254090/154193714-9fab888e-f24c-4531-a7a4-5aad02961940.png)
