### PR TITLE
Add building layer

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -15,6 +15,7 @@ import * as lyrPlace from "./layer/place.js";
 import * as lyrRoad from "./layer/road.js";
 import * as lyrRoadLabel from "./layer/road_label.js";
 import * as lyrWater from "./layer/water.js";
+import * as lyrBuilding from "./layer/building.js";
 
 import * as maplibregl from "maplibre-gl";
 import "maplibre-gl/maplibre-gl.css";
@@ -144,6 +145,8 @@ americanaLayers.push(
   lyrOneway.link
 );
 
+americanaLayers.push(lyrBuilding.building);
+
 var bridgeLayers = [
   lyrRoad.smallServiceBridge.casing(),
   lyrRoad.smallServiceBridge.fill(),
@@ -271,6 +274,11 @@ var style = {
       url: config.OPENMAPTILES_URL,
       type: "vector",
     },
+  },
+  light: {
+    anchor: "viewport",
+    color: "white",
+    intensity: 0.12,
   },
   version: 8,
 };

--- a/style/layer/building.js
+++ b/style/layer/building.js
@@ -1,0 +1,18 @@
+"use strict";
+
+export const building = {
+  id: "building",
+  type: "fill-extrusion",
+  paint: {
+    "fill-extrusion-color": "hsl(0, 0%, 80%)",
+    "fill-extrusion-base": 3,
+    "fill-extrusion-opacity": 0.85,
+  },
+  // filter: ["all", ["!=", "intermittent", 1], ["!=", "brunnel", "tunnel"]],
+  layout: {
+    visibility: "visible",
+  },
+  source: "openmaptiles",
+  metadata: {},
+  "source-layer": "building",
+};


### PR DESCRIPTION
PR to fix #170 .

Extrusion is fixed for now to keep the map mostly flat-looking.

Color (gray 80%) was picked to just barely stand out from background. 
Might need to be darkened slightly if landuse/landcover is much darker 
than 85% as the contrast between the may be too low.

85% opacity alows tunnels and highways to show through just enough for 
continuity.

Light intensity was chosen to make the extrusion subtle, but still 
visible at pedestrian scales.

z13 - Newark, NJ:
![z13 Newark](https://user-images.githubusercontent.com/25242/154735189-f745b19e-d92e-4350-a888-c38b6e2933b8.png)

z16 - Lincoln Tunnel:
![z16 Lincoln Tunnel](https://user-images.githubusercontent.com/25242/154735204-de144080-72b5-4778-8dc0-006ee505e7b6.png)

z13 Boston:
![z13 Boston](https://user-images.githubusercontent.com/25242/154735220-554fdf19-dacf-4cd8-b722-03c134c6133d.png)

Buildings on parks, to show the color-consistency even with a bit of opacity.
![buildings on parks](https://user-images.githubusercontent.com/25242/154735230-e411bad0-05f7-450d-8a17-720298b148a4.png)

