### PR TITLE
Building extrusion adjustment

### DIFF
--- a/style/layer/building.js
+++ b/style/layer/building.js
@@ -13,7 +13,7 @@ export const building = {
       16,
       `hsl(0, 0%, 80%)`,
     ],
-    "fill-extrusion-base": 3,
+    "fill-extrusion-height": 3,
     "fill-extrusion-opacity": 0.85,
   },
   // filter: ["all", ["!=", "intermittent", 1], ["!=", "brunnel", "tunnel"]],


### PR DESCRIPTION
The extruded buildings intruduced in #173 were looking a little odd to me so I played with the extrusion properties.  Currently with `fill-extrusion-base: 3` when you tilt the map the buildings look like they have walls and no roofs.

<img width="1121" alt="Screen Shot 2022-02-19 at 11 11 52 AM" src="https://user-images.githubusercontent.com/281482/154809128-47ab79c0-559a-4c9b-9233-7a5499e65b4e.png">

Changing it to `fill-extrusion-height: 3` gives the result I expect we want.

<img width="1124" alt="Screen Shot 2022-02-19 at 11 12 13 AM" src="https://user-images.githubusercontent.com/281482/154809129-1beb00a5-d514-4c4c-9cd8-e8176ccb0a12.png">
 