### PR TITLE
Ohio township road shields

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -254,6 +254,7 @@ americanaLayers.push(
   lyrHighwayShield.primary,
   lyrHighwayShield.secondary,
   lyrHighwayShield.tertiary,
+  lyrHighwayShield.minor,
 
   lyrHighwayExit.exits,
 

--- a/style/icons/shield40_us_oh_tus_salem.svg
+++ b/style/icons/shield40_us_oh_tus_salem.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="25" height="19.999" version="1.0" xmlns="http://www.w3.org/2000/svg">
+ <path d="m0.5 0.5v16h10v3h7v-3h5v-6h0.79657c0.15824 0.0038 2.6283-4.5431 0.0588-3.5-1.1452 0.63936-2.3402-2.5807-0.85537-2.5l-4.7e-5 -4z" fill="#facf08" stroke="#003f87" stroke-linecap="round" stroke-linejoin="round" stroke-width=".96147"/>
+</svg>

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -422,6 +422,8 @@ export function loadShields(shieldImages) {
   shields["US:OH:Bypass"] = banneredShield(shields["US:OH"], ["BYP"]);
   shields["US:OH:Business"] = banneredShield(shields["US:OH"], ["BUS"]);
 
+  // Ohio county and township roads
+
   ["COL", "JEF", "MAH", "OTT", "SEN", "STA", "SUM", "TUS"].forEach(
     // Yellow on blue pentagon
     (county) => (shields[`US:OH:${county}`] = usMUTCDCountyShield)
@@ -437,10 +439,24 @@ export function loadShields(shieldImages) {
     "WAS",
     "WIL",
     "WYA",
+    "COS:Jackson",
+    "FAI:Greenfield",
+    "JEF:Knox",
+    "LOG:Bokescreek",
+    "LOG:Pleasant",
+    "LOG:Washington",
+    "MED:Sharon",
+    "MRG:York",
+    "MRW:Bennington",
+    "MRW:Chester",
+    "MRW:Franklin",
+    "PER:Bearfield",
+    "PER:Hopewell",
+    "WAY:East_Union",
   ].forEach(
     // White on green rectangle
-    (county) =>
-      (shields[`US:OH:${county}`] = roundedRectShield(
+    (countyOrTownship) =>
+      (shields[`US:OH:${countyOrTownship}`] = roundedRectShield(
         "#006747",
         "white",
         "white",
@@ -449,10 +465,10 @@ export function loadShields(shieldImages) {
         null
       ))
   );
-  ["MED", "NOB"].forEach(
+  ["MED", "NOB", "WAY:Paint", "WAY:Salt_Creek"].forEach(
     // White on blue rectangle
-    (county) =>
-      (shields[`US:OH:${county}`] = roundedRectShield(
+    (countyOrTownship) =>
+      (shields[`US:OH:${countyOrTownship}`] = roundedRectShield(
         "#003f87",
         "white",
         "white",
@@ -461,10 +477,10 @@ export function loadShields(shieldImages) {
         null
       ))
   );
-  ["TRU", "VIN"].forEach(
+  ["TRU", "VIN", "COS:Adams"].forEach(
     // Black on yellow rectangle
-    (county) =>
-      (shields[`US:OH:${county}`] = roundedRectShield(
+    (countyOrTownship) =>
+      (shields[`US:OH:${countyOrTownship}`] = roundedRectShield(
         "#ffcd00",
         "black",
         "black",
@@ -496,6 +512,86 @@ export function loadShields(shieldImages) {
       bottom: 6,
     },
   };
+  shields["US:OH:HOC:Falls"] = roundedRectShield(
+    "white",
+    "#006747",
+    "black",
+    2,
+    1,
+    null
+  );
+  shields["US:OH:PER:Monday_Creek"] = roundedRectShield(
+    "#006747",
+    "black",
+    "black",
+    2,
+    1,
+    null
+  );
+  shields["US:OH:TUS:Salem"] = {
+    backgroundImage: [shieldImages.shield40_us_oh_tus_salem],
+    textColor: "black",
+    padding: {
+      left: 1,
+      right: 4,
+      top: 1,
+      bottom: 4,
+    },
+  };
+
+  // If a township's road shields have the same shape and colors as the surrounding county's road shields,
+  // add a banner to distinguish the township road shields from the more prominent county road shields.
+
+  [
+    ["ASD", "TWP"],
+    ["ATH", "Trimble"],
+    ["MED", "York"],
+    ["PAU", "Latty"],
+    ["PAU", "Washington"],
+    ["WAS", "Aurelius"],
+    ["WAS", "Salem"],
+  ].forEach(
+    (countyAndTownship) =>
+      (shields[`US:OH:${countyAndTownship[0]}:${countyAndTownship[1]}`] =
+        banneredShield(shields[`US:OH:${countyAndTownship[0]}`], ["TWP"]))
+  );
+  [
+    ["FAI", "Violet"],
+    ["HOL", "Berlin"],
+    ["HOL", "Clark"],
+    ["HOL", "Knox"],
+    ["HOL", "Monroe"], // No black border in reality, but a border is needed for contrast.
+    ["HOL", "Paint"],
+    ["HOL", "Salt_Creek"],
+    ["KNO", "Liberty"],
+    ["KNO", "Milford"],
+    ["LIC", "Jersey"],
+    ["LOG", "Harrison"],
+    ["LOG", "Jefferson"],
+    ["LOG", "Lake"],
+    ["LOG", "Liberty"],
+    ["LOG", "McArthur"],
+    ["LOG", "Miami"],
+    ["LOG", "Monroe"],
+    ["LOG", "Perry"],
+    ["LOG", "Richland"],
+    ["LOG", "Rushcreek"],
+    ["LOG", "Stokes"],
+    ["LOG", "Union"],
+    ["MRW", "Canaan"],
+    ["MRW", "Harmony"],
+    ["MRW", "South_Bloomfield"],
+    ["MRW", "Westfield"],
+    ["PER", "Coal"],
+  ].forEach(
+    // Black on white rectangle, not defined for the county since it is normally a fallback
+    (countyAndTownship) =>
+      (shields[`US:OH:${countyAndTownship[0]}:${countyAndTownship[1]}`] =
+        banneredShield(
+          roundedRectShield("white", "black", "black", 2, 1, null),
+          ["TWP"]
+        ))
+  );
 
   shields["US:OR"] = {
     backgroundImage: [

--- a/style/layer/highway_shield.js
+++ b/style/layer/highway_shield.js
@@ -73,3 +73,4 @@ export const trunk = shieldLayer("trunk", 8);
 export const primary = shieldLayer("primary", 10);
 export const secondary = shieldLayer("secondary", 11);
 export const tertiary = shieldLayer("tertiary", 12);
+export const minor = shieldLayer("minor", 14);


### PR DESCRIPTION
Hot on the heels of #174, this PR adds shields for [many townships in Ohio](https://commons.wikimedia.org/wiki/Category:Diagrams_of_Ohio_township_route_markers) that are known to signpost their township roads with shields. It includes some nonstandard shields that double as street name signs or township limit signs, but it excludes “blade”-style street name signs, such as sign D3-H6b in the [OMUTCD](https://wiki.openstreetmap.org/wiki/MUTCD/Ohio).

Townships that post the standard black text on white rectangle have also been omitted because that is already the fallback for unrecognized networks. However, if the county posts a sign with the same shape and colors as the surrounding county, it is included in this PR with a “TWP” banner on top. This is common in some counties because the OMUTCD specifies nearly identical shields for county routes (M1-H6a) as for township routes (M1-H6b), but it also happens in some counties that have chosen other background colors.

[<img src="https://user-images.githubusercontent.com/1231218/154824997-7ee37ed6-8183-46f1-b7aa-cc1e19da38df.png" width="400" alt="Salt Creek–Salt Creek">](https://zelonewolf.github.io/openstreetmap-americana/#14.1/40.66604/-81.8229)<br>_Salt Creek townships in Wayne (top) and Holmes (bottom) counties_

[<img src="https://user-images.githubusercontent.com/1231218/154825175-9834589a-d297-4d8a-87ac-1104c5a5febb.png" width="400" alt="Perry">](https://zelonewolf.github.io/openstreetmap-americana/#13/40.85431/-82.13199)<br>_Perry Township in Ashland County (left) and Chester Township in Wayne County (right)_

There may well be more townships that post these signs or their own unique creations. We can easily add them over time as we discover more in Mapillary and KartaView’s superb coverage of rural county and township roads. Not all of these township networks have been mapped with route relations yet, but the `network` pattern is predictable enough that we can add support for them ahead of time as an incentive to mappers.

In general, township roads in Ohio are tagged `highway=unclassified` or `highway=residential`, which requires a new layer for shields on `minor` roads. Fortunately, the townships that post shields tend to be rural and sparse, so clutter isn’t as much of a concern. This layer also exposes quite a bit of [cargo cult tagging](https://en.wikipedia.org/wiki/Cargo_cult_programming) in Ohio, in which mappers [assumed](https://www.openstreetmap.org/changeset/74104851) every road number in TIGER data represents a signposted route, even municipal alley inventory numbers. This layer will therefore help us track the deletion of these spurious route relations.

[<img src="https://user-images.githubusercontent.com/1231218/154825346-288c4e7d-97fb-4b70-881b-a5f9d047bf49.png" width="400" alt="Rio Grande">](https://zelonewolf.github.io/openstreetmap-americana/#16.05/38.880495/-82.377448)<br>_Rio Grande_

Neighboring townships with different shield designs can be slightly disorienting, since there tend to be similar county road shields in the same area. I think the distribution of shield types will become more intuitive once township boundaries render on the map: #40.

[<img src="https://user-images.githubusercontent.com/1231218/154824895-40b4b809-b09b-48da-997d-b6c0cd7149b0.png" width="400" alt="Washington–Harrison">](https://zelonewolf.github.io/openstreetmap-americana/#13.99/40.39749/-83.86577)<br>_Washington (left) and Harrison (right) townships in Logan County_
