### PR TITLE
Generate taginfo project file

### DIFF
--- a/style/CONTRIBUTE.md
+++ b/style/CONTRIBUTE.md
@@ -153,7 +153,10 @@ npm run build
 
 These commands will build a minified/bundled version of the Americana demo with
 all assets in `dist/`. The contents of `dist/` can then be copied to a webserver
-for distribution.
+for distribution. A [taginfo project file][taginfo] will also be generated based on the
+boilerplate in `scripts/taginfo_template.json`.
+
+[taginfo]: https://wiki.openstreetmap.org/wiki/Taginfo/Projects
 
 ## Before submitting a PR
 

--- a/style/js/screen_gfx.js
+++ b/style/js/screen_gfx.js
@@ -20,5 +20,5 @@ export function getGfxContext(bounds) {
  * So this function will always return 1 or 2 as appropriate based on DPR.
  */
 export function getPixelRatio() {
-  return window.devicePixelRatio > 1 ? 2 : 1;
+  return (typeof window !== "undefined" && window.devicePixelRatio) > 1 ? 2 : 1;
 }

--- a/style/package.json
+++ b/style/package.json
@@ -13,8 +13,9 @@
     "clean": "rm -rf dist .parcel-cache",
     "presprites": "rm -rf dist/sprites",
     "sprites": "mkdir -p dist/sprites && npx spritezero dist/sprites/sprite@2x icons/ --retina && npx spritezero dist/sprites/sprite icons/",
+    "taginfo": "node scripts/taginfo.js",
     "start": "npm run clean && npm run sprites && npx parcel index.html --open --port 1776",
-    "build": "npm run clean && npm run sprites && npx parcel build index.html --public-url ./"
+    "build": "npm run clean && npm run sprites && npx parcel build index.html --public-url ./ && npm run taginfo"
   },
   "dependencies": {
     "@beyondtracks/spritezero-cli": "^2.3.0"

--- a/style/package.json
+++ b/style/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf dist .parcel-cache",
     "presprites": "rm -rf dist/sprites",
     "sprites": "mkdir -p dist/sprites && npx spritezero dist/sprites/sprite@2x icons/ --retina && npx spritezero dist/sprites/sprite icons/",
-    "taginfo": "node scripts/taginfo.js",
+    "taginfo": "npm run sprites && node scripts/taginfo.js",
     "start": "npm run clean && npm run sprites && npx parcel index.html --open --port 1776",
     "build": "npm run clean && npm run sprites && npx parcel build index.html --public-url ./ && npm run taginfo"
   },

--- a/style/scripts/taginfo.js
+++ b/style/scripts/taginfo.js
@@ -1,0 +1,59 @@
+"use strict";
+
+import * as fs from "fs";
+import * as ShieldDef from "../js/shield_defs.js";
+
+/**
+ * Adds documentation about network=* tags to a project description object, modifying it in place.
+ *
+ * @param {*} project - The project description object to modify.
+ * @param {*} sprites - Sprite metadata object parsed from a JSON spritesheet.
+ */
+function addNetworkTags(project, sprites) {
+  // Inject a map of each sprite ID to an absolute image URL instead of the usual sprite metadata.
+  let shieldImageURLs = Object.fromEntries(
+    Object.keys(sprites).map((sprite) => [
+      sprite,
+      `https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/style/icons/${sprite}.svg`,
+    ])
+  );
+  let shields = ShieldDef.loadShields(shieldImageURLs);
+
+  // Convert each shield's rendering metadata to an entry that taginfo understands.
+  let tags = Object.entries(shields).map((entry) => {
+    let network = entry[0],
+      definition = entry[1];
+
+    let description = `Roads carrying routes in this network are marked by shields`;
+    if (definition.modifiers && definition.modifiers.length > 0) {
+      description += ` modified by ${definition.modifiers.join(", ")} banners`;
+    }
+    description += ".";
+
+    let icon = definition.backgroundImage;
+    if (Array.isArray(icon)) {
+      icon = icon[0];
+    }
+
+    return {
+      key: "network",
+      value: network,
+      object_types: ["relation"],
+      description: description,
+      icon_url: icon,
+    };
+  });
+  project.tags.push(...tags);
+}
+
+let project = JSON.parse(
+  fs.readFileSync(`${process.cwd()}/scripts/taginfo_template.json`)
+);
+let sprites = JSON.parse(
+  fs.readFileSync(`${process.cwd()}/sprites/sprite.json`)
+);
+addNetworkTags(project, sprites);
+fs.writeFileSync(
+  `${process.cwd()}/dist/taginfo.json`,
+  JSON.stringify(project, null, 2)
+);

--- a/style/scripts/taginfo.js
+++ b/style/scripts/taginfo.js
@@ -50,7 +50,7 @@ let project = JSON.parse(
   fs.readFileSync(`${process.cwd()}/scripts/taginfo_template.json`)
 );
 let sprites = JSON.parse(
-  fs.readFileSync(`${process.cwd()}/sprites/sprite.json`)
+  fs.readFileSync(`${process.cwd()}/dist/sprites/sprite.json`)
 );
 addNetworkTags(project, sprites);
 fs.writeFileSync(

--- a/style/scripts/taginfo_template.json
+++ b/style/scripts/taginfo_template.json
@@ -1,0 +1,19 @@
+{
+  "data_format": 1,
+  "project": {
+    "name": "OpenStreetMap Americana",
+    "description": "A quintessentially American map style.",
+    "project_url": "https://github.com/ZeLonewolf/openstreetmap-americana/",
+    "doc_url": "https://wiki.openstreetmap.org/wiki/OpenStreetMap_Americana",
+    "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/doc-img/osm-americana-logo.png",
+    "contact_name": "",
+    "contact_email": ""
+  },
+  "tags": [
+    {
+      "key": "ref",
+      "object_types": ["relation"],
+      "description": "Populates shields that mark roads carrying the route relation."
+    }
+  ]
+}

--- a/style/scripts/taginfo_template.json
+++ b/style/scripts/taginfo_template.json
@@ -6,8 +6,8 @@
     "project_url": "https://github.com/ZeLonewolf/openstreetmap-americana/",
     "doc_url": "https://wiki.openstreetmap.org/wiki/OpenStreetMap_Americana",
     "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/doc-img/osm-americana-logo.png",
-    "contact_name": "",
-    "contact_email": ""
+    "contact_name": "Brian Sperlongano",
+    "contact_email": "zelonewolf@gmail.com"
   },
   "tags": [
     {


### PR DESCRIPTION
Added a script that generates a taginfo project file and saves it to the dist/ folder. The script is hooked up to `npm run build`, but you can also run it independently using `npm run taginfo`.

The file is based on a boilerplate JSON file. Contributors can feel free to manually add anything notable there. However, the proper place for most tags would be OpenMapTiles’ project file: openmaptiles/openmaptiles#1269. The final generated file primarily lists the `network` values Americana supports, because OpenMapTiles just forwards the raw `network` values to the style for style-specific processing. Here’s what the `network` entries look like:

```json
{
  {
    "key": "network",
    "value": "US:US",
    "object_types": [
      "relation"
    ],
    "description": "Roads carrying routes in this network are marked by shields.",
    "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/style/icons/shield40_us_us_2.svg"
  },
  {
    "key": "network",
    "value": "US:US:Truck",
    "object_types": [
      "relation"
    ],
    "description": "Roads carrying routes in this network are marked by shields modified by TRK banners.",
    "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/style/icons/shield40_us_us_2.svg"
  }
}
```

That will look something like this in taginfo:

Tag | Objects | How this key/tag is used in the project
----|:--:|----
[network](https://taginfo.openstreetmap.org/keys/network)=[US:US](https://taginfo.openstreetmap.org/tags/network=US:US) | <img src="https://taginfo.openstreetmap.org/img/types/relation.svg" width="16" alt="yes"> | <img src="https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/style/icons/shield40_us_us_2.svg" width="16" alt=""> Roads carrying routes in this network are marked by shields.
[network](https://taginfo.openstreetmap.org/keys/network)=[US:US:Truck](https://taginfo.openstreetmap.org/tags/network=US:US:Truck) | <img src="https://taginfo.openstreetmap.org/img/types/relation.svg" width="16" alt="yes"> | <img src="https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/style/icons/shield40_us_us_2.svg" width="16" alt=""> Roads carrying routes in this network are marked by shields modified by TRK banners.

Fixes #178. Once this PR is merged, the [taginfo project list](https://github.com/taginfo/taginfo-projects/blob/master/project_list.txt) needs to be updated.