### PR TITLE
Disable network=motorway rendering

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -619,17 +619,24 @@ export function loadShields(shieldImages) {
     },
   };
 
+  /**
+   * The top-level Swiss highway network is currently tagged with the oddly generic network=motorway.
+   * Given the general lack of data consumer support for road route relations in Europe, this code is
+   * temporarily disabled until we can be assured that supporting such a generic value for a national
+   * network is appropriate mapper feedback.
+   */
+
   // Switzerland
-  shields["motorway"] = {
-    backgroundImage: shieldImages.shield40_ch_2,
-    textColor: "white",
-    padding: {
-      left: 2,
-      right: 2,
-      top: 5,
-      bottom: 5,
-    },
-  };
+  // shields["motorway"] = {
+  //   backgroundImage: shieldImages.shield40_ch_2,
+  //   textColor: "white",
+  //   padding: {
+  //     left: 2,
+  //     right: 2,
+  //     top: 5,
+  //     bottom: 5,
+  //   },
+  // };
 
   shields["HU:national"] = {
     backgroundImage: shieldImages.shield40_hu_2,


### PR DESCRIPTION
This PR temporarily disables the rendering of network-specific highway shields for `network=motorway`, which is currently tagged on Swiss highway networks following discussion on #149.  This is intended to allow for the project to take a "wait and see" approach to determine whether this generic value is adopted by other route relation data consumers as the tagging specific to Switzerland.  In the meantime, Swiss highway networks will continue to be rendered with generic white rectangles.