### PR TITLE
Remove extra padding from attribution logo

### DIFF
--- a/style/configs/config.maptiler.js
+++ b/style/configs/config.maptiler.js
@@ -13,7 +13,7 @@ const MAPTILER_KEY = "<your MapTiler key>";
 
 const OPENMAPTILES_URL = `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${MAPTILER_KEY}`;
 const ATTRIBUTION_LOGO = `
-<a id="attribution-logo" href="https://www.maptiler.com/">
+<a href="https://www.maptiler.com/">
   <img src="https://api.maptiler.com/resources/logo.svg" alt="MapTiler logo"/>
 </a>`;
 const ATTRIBUTION_TEXT =


### PR DESCRIPTION
This PR removes the extra vertical padding that currently appears under the attribution logo, due to a repeated CSS id.