### PR TITLE
Consolidate road label layers

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -232,16 +232,11 @@ americanaLayers.push(
   lyrRoadLabel.motorway,
   lyrRoadLabel.trunk,
   lyrRoadLabel.primary,
-  lyrRoadLabel.primaryHZ,
   lyrRoadLabel.secondary,
-  lyrRoadLabel.secondaryHZ,
   lyrRoadLabel.tertiary,
-  lyrRoadLabel.tertiaryHZ,
   lyrRoadLabel.minor,
-  lyrRoadLabel.minorHZ,
   lyrRoadLabel.service,
   lyrRoadLabel.smallService,
-  lyrRoadLabel.serviceHZ,
 
   lyrPark.label,
 

--- a/style/layer/road_label.js
+++ b/style/layer/road_label.js
@@ -1,24 +1,34 @@
 "use strict";
 
-var offsetLabelStyle = {
+const textLayout = {
   "text-font": ["Metropolis Light"],
-  "text-size": 12,
   "text-field": "{name:latin} {name:nonlatin}",
-  "text-anchor": "bottom",
   "text-max-angle": 20,
   "symbol-placement": "line",
 };
 
-var centerLabelStyle = {
-  "text-font": ["Metropolis Light"],
-  "text-size": 10,
-  "text-field": "{name:latin} {name:nonlatin}",
-  "text-anchor": "center",
-  "text-max-angle": 20,
-  "symbol-placement": "line",
-};
+/**
+ * Returns layout properties that differ between an offset treatment at lower
+ * zoom levels versus an in-road treatment at higher zoom levels.
+ *
+ * @param {*} minHighZoom Lowest zoom level at which to apply the in-road
+ *  treatment. Omit this parameter to always apply the offset treatment and
+ *  never the in-road treatment.
+ */
+function zoomDependentLayout(minHighZoom) {
+  return {
+    "text-size":
+      typeof minHighZoom === "undefined"
+        ? 12
+        : ["step", ["zoom"], 12, minHighZoom, 10],
+    "text-anchor":
+      typeof minHighZoom === "undefined"
+        ? "bottom"
+        : ["step", ["zoom"], "bottom", minHighZoom, "center"],
+  };
+}
 
-var textPaint = {
+const textPaint = {
   "text-color": "#333",
   "text-halo-color": "#fff",
   "text-halo-blur": 0.5,
@@ -30,7 +40,7 @@ export const motorway = {
   type: "symbol",
   paint: textPaint,
   filter: ["all", ["==", "class", "motorway"]],
-  layout: offsetLabelStyle,
+  layout: Object.assign(zoomDependentLayout(), textLayout),
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
@@ -41,7 +51,7 @@ export const trunk = {
   paint: textPaint,
   filter: ["all", ["==", "class", "trunk"]],
   minzoom: 10,
-  layout: offsetLabelStyle,
+  layout: Object.assign(zoomDependentLayout(), textLayout),
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
@@ -52,19 +62,7 @@ export const primary = {
   paint: textPaint,
   filter: ["all", ["==", "class", "primary"]],
   minzoom: 11,
-  maxzoom: 16,
-  layout: offsetLabelStyle,
-  source: "openmaptiles",
-  "source-layer": "transportation_name",
-};
-
-export const primaryHZ = {
-  id: "primary_label_hz",
-  type: "symbol",
-  paint: textPaint,
-  filter: ["all", ["==", "class", "primary"]],
-  minzoom: 16,
-  layout: centerLabelStyle,
+  layout: Object.assign(zoomDependentLayout(16), textLayout),
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
@@ -75,19 +73,7 @@ export const secondary = {
   paint: textPaint,
   filter: ["all", ["==", "class", "secondary"]],
   minzoom: 12,
-  maxzoom: 16,
-  layout: offsetLabelStyle,
-  source: "openmaptiles",
-  "source-layer": "transportation_name",
-};
-
-export const secondaryHZ = {
-  id: "secondary_label_hz",
-  type: "symbol",
-  paint: textPaint,
-  filter: ["all", ["==", "class", "secondary"]],
-  minzoom: 16,
-  layout: centerLabelStyle,
+  layout: Object.assign(zoomDependentLayout(16), textLayout),
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
@@ -98,19 +84,7 @@ export const tertiary = {
   paint: textPaint,
   filter: ["all", ["==", "class", "tertiary"]],
   minzoom: 13,
-  maxzoom: 17,
-  layout: offsetLabelStyle,
-  source: "openmaptiles",
-  "source-layer": "transportation_name",
-};
-
-export const tertiaryHZ = {
-  id: "tertiary_label_hz",
-  type: "symbol",
-  paint: textPaint,
-  filter: ["all", ["==", "class", "tertiary"]],
-  minzoom: 17,
-  layout: centerLabelStyle,
+  layout: Object.assign(zoomDependentLayout(17), textLayout),
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
@@ -121,19 +95,7 @@ export const minor = {
   paint: textPaint,
   filter: ["all", ["==", "class", "minor"]],
   minzoom: 13,
-  maxzoom: 17,
-  layout: offsetLabelStyle,
-  source: "openmaptiles",
-  "source-layer": "transportation_name",
-};
-
-export const minorHZ = {
-  id: "minor_label_hz",
-  type: "symbol",
-  paint: textPaint,
-  filter: ["all", ["==", "class", "minor"]],
-  minzoom: 17,
-  layout: centerLabelStyle,
+  layout: Object.assign(zoomDependentLayout(17), textLayout),
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
@@ -148,19 +110,7 @@ export const service = {
     ["!in", "service", "parking_aisle", "driveway"],
   ],
   minzoom: 14,
-  maxzoom: 17,
-  layout: offsetLabelStyle,
-  source: "openmaptiles",
-  "source-layer": "transportation_name",
-};
-
-export const serviceHZ = {
-  id: "service_label_hz",
-  type: "symbol",
-  paint: textPaint,
-  filter: ["all", ["==", "class", "service"]],
-  minzoom: 17,
-  layout: centerLabelStyle,
+  layout: Object.assign(zoomDependentLayout(17), textLayout),
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
@@ -175,8 +125,7 @@ export const smallService = {
     ["in", "service", "parking_aisle", "driveway"],
   ],
   minzoom: 15,
-  maxzoom: 17,
-  layout: offsetLabelStyle,
+  layout: Object.assign(zoomDependentLayout(), textLayout),
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };


### PR DESCRIPTION
Consolidated the road label layers for low and high zoom levels using `step` expressions. Consolidating layers that only vary by paint or layout properties will make it easier to grok the codebase once we add more layers that differ more significantly.

Theoretically, minimizing the number of layers results in better performance, though I suspect the performance hotspots lie elsewhere at this point. A more tangible effect is that labels transform directly from one treatment to another when crossing the threshold between low and high zoom levels. Before, if a label would be placed in the same location on either side of the threshold, it would still appear to fade out and back in with some delay. The new behavior feels a little snappier.

https://user-images.githubusercontent.com/1231218/155242795-3aed653a-3e4c-4d7c-a6e4-54c462c06114.mov

https://user-images.githubusercontent.com/1231218/155242809-7d1dc545-5a68-4bba-9855-6d05aa53b5c4.mov

The samples show a minor difference in label placement depending on whether a layer has a constant or variable `text-size` and `text-anchor`, but I don’t see a corresponding difference on the actual map. The difference was already there, but it’s a little more pronounced in the samples now:

![before](https://user-images.githubusercontent.com/1231218/155240489-aebeec41-e827-431e-b0f6-dedba0a19c58.png)
![after](https://user-images.githubusercontent.com/1231218/155240680-81292ee0-cbda-4a6f-a8ff-b4636f0b2163.png)