### PR TITLE
Add Vietnam expressway shields

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -644,6 +644,15 @@ export function loadShields(shieldImages) {
     },
   };
 
+  shields["vn:expressway"] = roundedRectShield(
+    "#ffcd00",
+    "black",
+    "black",
+    2,
+    1,
+    null
+  );
+
   // Europe
   shields["e-road"] = {
     backgroundImage: [


### PR DESCRIPTION
Added a shield for expressways in Vietnam. The tagging scheme for Vietnamese route relations coalesced around the `network=vn:*` prefix too recently to be picked up by the tile server, but here’s how it’ll look:

[<img src="https://user-images.githubusercontent.com/1231218/155260777-007f3401-053b-40d8-b75f-48af88f72f31.png" width="400" alt="CT.01">](https://zelonewolf.github.io/openstreetmap-americana/#8.77/10.3671/106.1288)

As in https://github.com/ZeLonewolf/openstreetmap-americana/issues/141#issuecomment-1046409219, I’m not sure putting `CT.` in the `ref` is quite correct, since no one would ever say or write “expressway CT.01”. But it does match what’s on the shield, so this is expedient for now. Even if there’s consensus to drop the `CT.` from `ref`, it might be desirable to drop the “CT.” from the map as a simplification anyways.