### PR TITLE
PRC and Hong Kong shields

### DIFF
--- a/style/icons/shield40_cn_national_expressway_2.svg
+++ b/style/icons/shield40_cn_national_expressway_2.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20" height="20" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <use transform="matrix(.92938 0 0 -.92938 19977 4810.8)" width="300" height="240" fill="#ffffff" stroke="#000000" stroke-linejoin="round" stroke-width="309" xlink:href="#state_outline"/>
+ <rect width="20" height="20" rx="1.25" ry="1.25" fill="#bf2033" stroke-width=".625"/>
+ <rect transform="scale(1,-1)" x="1" y="-19" width="18" height="14" fill="#006747" stroke-width="0"/>
+</svg>

--- a/style/icons/shield40_cn_national_expressway_3.svg
+++ b/style/icons/shield40_cn_national_expressway_3.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="25" height="20" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <use transform="matrix(.92938 0 0 -.92938 19977 4810.8)" width="300" height="240" fill="#ffffff" stroke="#000000" stroke-linejoin="round" stroke-width="309" xlink:href="#state_outline"/>
+ <rect width="25" height="20" rx="1.25" ry="1.25" fill="#bf2033" stroke-width=".625"/>
+ <rect transform="scale(1,-1)" x="1" y="-19" width="23" height="14" fill="#006747" stroke-width="0"/>
+</svg>

--- a/style/icons/shield40_cn_national_expressway_4.svg
+++ b/style/icons/shield40_cn_national_expressway_4.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30" height="20" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <use transform="matrix(.92938 0 0 -.92938 19977 4810.8)" width="300" height="240" fill="#ffffff" stroke="#000000" stroke-linejoin="round" stroke-width="309" xlink:href="#state_outline"/>
+ <rect width="30" height="20" rx="1.25" ry="1.25" fill="#bf2033" stroke-width=".625"/>
+ <rect transform="scale(1,-1)" x="1" y="-19" width="28" height="14" fill="#006747" stroke-width="0"/>
+</svg>

--- a/style/icons/shield40_cn_regional_expressway_2.svg
+++ b/style/icons/shield40_cn_regional_expressway_2.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20" height="20" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <use transform="matrix(.92938 0 0 -.92938 19977 4810.8)" width="300" height="240" fill="#ffffff" stroke="#000000" stroke-linejoin="round" stroke-width="309" xlink:href="#state_outline"/>
+ <rect width="20" height="20" rx="1.25" ry="1.25" fill="#ffcd00" stroke-width=".625"/>
+ <rect transform="scale(1,-1)" x="1" y="-19" width="18" height="14" fill="#006747" stroke-width="0"/>
+</svg>

--- a/style/icons/shield40_cn_regional_expressway_3.svg
+++ b/style/icons/shield40_cn_regional_expressway_3.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="25" height="20" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <use transform="matrix(.92938 0 0 -.92938 19977 4810.8)" width="300" height="240" fill="#ffffff" stroke="#000000" stroke-linejoin="round" stroke-width="309" xlink:href="#state_outline"/>
+ <rect width="25" height="20" rx="1.25" ry="1.25" fill="#ffcd00" stroke-width=".625"/>
+ <rect transform="scale(1,-1)" x="1" y="-19" width="23" height="14" fill="#006747" stroke-width="0"/>
+</svg>

--- a/style/icons/shield40_cn_regional_expressway_4.svg
+++ b/style/icons/shield40_cn_regional_expressway_4.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30" height="20" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <use transform="matrix(.92938 0 0 -.92938 19977 4810.8)" width="300" height="240" fill="#ffffff" stroke="#000000" stroke-linejoin="round" stroke-width="309" xlink:href="#state_outline"/>
+ <rect width="30" height="20" rx="1.25" ry="1.25" fill="#ffcd00" stroke-width=".625"/>
+ <rect transform="scale(1,-1)" x="1" y="-19" width="28" height="14" fill="#006747" stroke-width="0"/>
+</svg>

--- a/style/icons/shield40_hk.svg
+++ b/style/icons/shield40_hk.svg
@@ -1,43 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="20"
-   height="20"
-   version="1.0"
-   id="svg830"
-   sodipodi:docname="shield40_hk.svg"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs834" />
-  <sodipodi:namedview
-     id="namedview832"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     showgrid="true"
-     inkscape:zoom="31.35"
-     inkscape:cx="9.3779904"
-     inkscape:cy="10"
-     inkscape:window-width="1393"
-     inkscape:window-height="855"
-     inkscape:window-x="0"
-     inkscape:window-y="23"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg830">
-    <inkscape:grid
-       type="xygrid"
-       id="grid1182" />
-  </sodipodi:namedview>
-  <path
-     fill="#f7b146"
-     d="M 0.5,0.5002934 V 8.0617066 C 1.2865429,17.52555 9.9996353,19.5 9.9996353,19.5 c 0,0 8.7031957,-1.974743 9.4893297,-11.4385868 L 19.5,0.5 Z"
-     id="path916"
-     style="stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill:#ffcd00"
-     sodipodi:nodetypes="cccccc" />
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20" height="20" version="1.0" xmlns="http://www.w3.org/2000/svg">
+ <path d="m0.5 0.50029v7.5614c0.78654 9.4638 9.4996 11.438 9.4996 11.438s8.7032-1.9747 9.4893-11.439l0.011035-7.5614z" fill="#ffcd00" stroke="#000"/>
 </svg>

--- a/style/icons/shield40_hk.svg
+++ b/style/icons/shield40_hk.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="20"
+   height="20"
+   version="1.0"
+   id="svg830"
+   sodipodi:docname="shield40_hk.svg"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs834" />
+  <sodipodi:namedview
+     id="namedview832"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="true"
+     inkscape:zoom="31.35"
+     inkscape:cx="9.3779904"
+     inkscape:cy="10"
+     inkscape:window-width="1393"
+     inkscape:window-height="855"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg830">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1182" />
+  </sodipodi:namedview>
+  <path
+     fill="#f7b146"
+     d="M 0.5,0.5002934 V 8.0617066 C 1.2865429,17.52555 9.9996353,19.5 9.9996353,19.5 c 0,0 8.7031957,-1.974743 9.4893297,-11.4385868 L 19.5,0.5 Z"
+     id="path916"
+     style="stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill:#ffcd00"
+     sodipodi:nodetypes="cccccc" />
+</svg>

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -610,6 +610,85 @@ export function loadShields(shieldImages) {
   shields["US:WA:Alternate"] = banneredShield(shields["US:WA"], ["ALT"]);
 
   // Asia
+  shields["CN:national"] = roundedRectShield(
+    "#bf2033",
+    "white",
+    "white",
+    2,
+    1,
+    null
+  );
+  shields["CN:expressway"] = {
+    backgroundImage: [
+      shieldImages.shield40_cn_national_expressway_2,
+      shieldImages.shield40_cn_national_expressway_3,
+      shieldImages.shield40_cn_national_expressway_4,
+    ],
+    textColor: "white",
+    padding: {
+      left: 2,
+      right: 2,
+      top: 6,
+      bottom: 2,
+    },
+  };
+  [
+    "AH",
+    "BJ",
+    "CQ",
+    "FJ",
+    "GD",
+    "GS",
+    "GX",
+    "GZ",
+    "HA",
+    "HB",
+    "HE",
+    "HI",
+    "HL",
+    "HN",
+    "JL",
+    "JS",
+    "JX",
+    "LN",
+    "NM",
+    "NX",
+    "QH",
+    "SC",
+    "SD",
+    "SH",
+    "SN",
+    "SX",
+    "TJ",
+    "XJ",
+    "XZ",
+    "YN",
+    "ZJ",
+  ].forEach((province) => {
+    shields[`CN:${province}`] = roundedRectShield(
+      "#ffcd00",
+      "black",
+      "black",
+      2,
+      1,
+      null
+    );
+    shields[`CN:${province}:expressway`] = {
+      backgroundImage: [
+        shieldImages.shield40_cn_regional_expressway_2,
+        shieldImages.shield40_cn_regional_expressway_3,
+        shieldImages.shield40_cn_regional_expressway_4,
+      ],
+      textColor: "white",
+      padding: {
+        left: 2,
+        right: 2,
+        top: 6,
+        bottom: 2,
+      },
+    };
+  });
+
   shields["TW:freeway"] = {
     backgroundImage: shieldImages.shield40_tw_freeway,
     textLayoutConstraint: ShieldText.ellipseTextConstraint,

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -689,6 +689,18 @@ export function loadShields(shieldImages) {
     };
   });
 
+  shields["HK"] = {
+    backgroundImage: shieldImages.shield40_hk,
+    textLayoutConstraint: ShieldText.southHalfellipseTextConstraint,
+    textColor: "black",
+    padding: {
+      left: 1,
+      right: 1,
+      top: 1,
+      bottom: 12,
+    },
+  };
+
   shields["TW:freeway"] = {
     backgroundImage: shieldImages.shield40_tw_freeway,
     textLayoutConstraint: ShieldText.ellipseTextConstraint,


### PR DESCRIPTION
Added route shields for the PRC and Hong Kong.

The last two digits of the auxiliary national expressway shield should be smaller than the first two digits, but that would require custom drawing code, so for now all the digits are the same size.

China’s portion of the Asian Highway network is not yet supported because there’s currently no tagging distinction between the Chinese AH shields and the ones used in other countries: #122.

To generate the previews below, I had to comment out this style’s spritesheet. Otherwise, #191 prevented me from seeing anything in China.

[<img src="https://user-images.githubusercontent.com/1231218/155295396-d3155abb-2c37-4322-a18d-fe94e81bd4ee.png" width="400" alt="Beijing">](https://zelonewolf.github.io/openstreetmap-americana/#10.12/30.4219/114.073)<br>_Beijing_

[<img src="https://user-images.githubusercontent.com/1231218/155296523-150eb44c-a7f0-4e14-a2f3-6b0125738f6a.png" width="400" alt="Chongqing">](https://zelonewolf.github.io/openstreetmap-americana/#9.37/29.8262/106.0986)<br>_Chongqing_

[<img src="https://user-images.githubusercontent.com/1231218/155294465-cb688c73-f011-4aed-adc3-44df5ab75b3e.png" width="400" alt="Hong Kong">](https://zelonewolf.github.io/openstreetmap-americana/#8/22.491/113.91)<br>_Hong Kong, Macau, and Shenzhen_
