### PR TITLE
Update to new maplibre fork that inclues the CJK fix.

### DIFF
--- a/style/package-lock.json
+++ b/style/package-lock.json
@@ -11,7 +11,7 @@
         "@beyondtracks/spritezero-cli": "^2.3.0"
       },
       "devDependencies": {
-        "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5/maplibre-gl.tar.gz",
+        "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5-americana-1/maplibre-gl-2.0.5-americana-1.tar.gz",
         "openmapsamples-maplibre": "github:adamfranco/OpenMapSamples-MapLibre",
         "parcel": "^2.3.0",
         "prettier": "2.3.2"
@@ -2864,8 +2864,8 @@
     },
     "node_modules/maplibre-gl": {
       "version": "2.0.5",
-      "resolved": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5/maplibre-gl.tar.gz",
-      "integrity": "sha512-F2s75wRSwOTIvQk36WA+z1WtJi56VOYd0wFZPZFrTToQlx1Zi7JIk0Ua4C1/CVmdkr/pjyj3jHE7GIxanPi9bA==",
+      "resolved": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5-americana-1/maplibre-gl-2.0.5-americana-1.tar.gz",
+      "integrity": "sha512-hm4aG+aABB8i5RMtwsTmwZ+51Iz6+QEGmZeyWPWl9TKFfe2ujNy6E3kEPuFVCSvoFbA0moHiC9BrStn0Wgw+XQ==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -6401,8 +6401,8 @@
       }
     },
     "maplibre-gl": {
-      "version": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5/maplibre-gl.tar.gz",
-      "integrity": "sha512-F2s75wRSwOTIvQk36WA+z1WtJi56VOYd0wFZPZFrTToQlx1Zi7JIk0Ua4C1/CVmdkr/pjyj3jHE7GIxanPi9bA==",
+      "version": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5-americana-1/maplibre-gl-2.0.5-americana-1.tar.gz",
+      "integrity": "sha512-hm4aG+aABB8i5RMtwsTmwZ+51Iz6+QEGmZeyWPWl9TKFfe2ujNy6E3kEPuFVCSvoFbA0moHiC9BrStn0Wgw+XQ==",
       "dev": true
     },
     "mapnik": {
@@ -6639,7 +6639,7 @@
       "dev": true,
       "from": "openmapsamples-maplibre@github:adamfranco/OpenMapSamples-MapLibre",
       "requires": {
-        "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5/maplibre-gl.tar.gz",
+        "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5-americana-1/maplibre-gl-2.0.5-americana-1.tar.gz",
         "openmapsamples": "github:adamfranco/OpenMapSamples"
       }
     },

--- a/style/package.json
+++ b/style/package.json
@@ -21,7 +21,7 @@
     "@beyondtracks/spritezero-cli": "^2.3.0"
   },
   "devDependencies": {
-    "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5/maplibre-gl.tar.gz",
+    "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5-americana-1/maplibre-gl-2.0.5-americana-1.tar.gz",
     "openmapsamples-maplibre": "github:adamfranco/OpenMapSamples-MapLibre",
     "parcel": "^2.3.0",
     "prettier": "2.3.2"
@@ -30,6 +30,6 @@
     "npm": ">=8.3.0"
   },
   "overrides": {
-    "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5/maplibre-gl.tar.gz"
+    "maplibre-gl": "https://github.com/ZeLonewolf/maplibre-gl-js/releases/download/v2.0.5-americana-1/maplibre-gl-2.0.5-americana-1.tar.gz"
   }
 }


### PR DESCRIPTION
New Maplibre fork release: https://github.com/ZeLonewolf/maplibre-gl-js/releases/tag/v2.0.5-americana-1

CJK characters are no longer breaking rendering: ([location](http://localhost:1776/#15.49/39.897786/116.384559))
![Screen Shot 2022-02-23 at 9 15 58 PM](https://user-images.githubusercontent.com/25242/155444740-f7f8371f-76f6-41ab-bdc5-add95099e0ce.png)
