### PR TITLE
Add localhost configuration option

### DIFF
--- a/style/configs/config.localhost.js
+++ b/style/configs/config.localhost.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/*
+  Locally-run openmaptiles build
+*/
+const OPENMAPTILES_URL =
+  "http://localhost:8080/data/v3.json";
+
+export default {
+  OPENMAPTILES_URL,
+};

--- a/style/configs/config.localhost.js
+++ b/style/configs/config.localhost.js
@@ -3,8 +3,7 @@
 /*
   Locally-run openmaptiles build
 */
-const OPENMAPTILES_URL =
-  "http://localhost:8080/data/v3.json";
+const OPENMAPTILES_URL = "http://localhost:8080/data/v3.json";
 
 export default {
   OPENMAPTILES_URL,


### PR DESCRIPTION
This PR adds a convenience config file for a locally-generated openmaptiles build.  This is useful in cases where you need to test a style change that needs a more up-to-date version of the map that is present on remote tile servers.