### PR TITLE
Waterways and labels

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -38,6 +38,8 @@ americanaLayers.push(
   lyrBoundary.countryCasing,
 
   lyrWater.water,
+  lyrWater.waterway,
+  lyrWater.waterwayIntermittent,
 
   lyrPark.outline,
 
@@ -45,6 +47,9 @@ americanaLayers.push(
   lyrBoundary.county,
   lyrBoundary.state,
   lyrBoundary.country,
+
+  lyrWater.waterwayLabel,
+  lyrWater.waterLabel,
 
   lyrRoad.motorwayTunnel.casing(),
   lyrRoad.trunkExpresswayTunnel.casing(),

--- a/style/constants/color.js
+++ b/style/constants/color.js
@@ -1,6 +1,7 @@
 export const waterFill = "hsl(211, 42%, 70%)";
 export const waterLine = "hsl(211, 73%, 78%)";
 export const waterIntermittent = "hsl(205, 89%, 83%)";
+export const waterLabel = "hsl(211, 43%, 28%)";
 
 export const hueBorder = 0;
 export const hueBorderCasing = 281;

--- a/style/layer/water.js
+++ b/style/layer/water.js
@@ -2,155 +2,50 @@
 
 import * as Color from "../constants/color.js";
 
-export const waterwayTunnel = {
-  id: "waterway_tunnel",
+const bigRivers = ["river", "canal"];
+const mediumRivers = ["stream"];
+// drain, ditch
+
+export const waterway = {
+  id: "waterway",
   type: "line",
-  paint: {
-    "line-color": Color.waterLine,
-    "line-width": {
-      base: 1.3,
-      stops: [
-        [13, 0.5],
-        [20, 6],
-      ],
-    },
-    "line-dasharray": [2, 4],
-  },
-  filter: ["all", ["==", "brunnel", "tunnel"]],
-  layout: {
-    "line-cap": "round",
-    visibility: "visible",
-  },
   source: "openmaptiles",
-  minzoom: 14,
   "source-layer": "waterway",
+  layout: {
+    "line-join": "round",
+    "line-cap": "round",
+  },
+  filter: ["!=", ["get", "intermittent"], 1],
+  paint: {
+    "line-color": Color.waterFill,
+    "line-width": [
+      "interpolate",
+      ["exponential", 2],
+      ["zoom"],
+      3,
+      0.5,
+      16,
+      [
+        "case",
+        ["in", ["get", "class"], ["literal", bigRivers]],
+        10,
+        ["in", ["get", "class"], ["literal", mediumRivers]],
+        6,
+        2,
+      ],
+    ],
+    "line-opacity": ["case", ["==", ["get", "brunnel"], "tunnel"], 0.3, 1],
+  },
 };
 
-export const waterwayRiver = {
-  id: "waterway_river",
-  type: "line",
+export const waterwayIntermittent = {
+  ...waterway,
+  id: "waterway_intermittent",
+  filter: ["==", ["get", "intermittent"], 1],
   paint: {
-    "line-color": Color.waterLine,
-    "line-width": {
-      base: 1.2,
-      stops: [
-        [11, 0.5],
-        [20, 6],
-      ],
-    },
+    ...waterway.paint,
+    "line-dasharray": [2, 3],
   },
-  filter: [
-    "all",
-    ["==", "class", "river"],
-    ["!=", "brunnel", "tunnel"],
-    ["!=", "intermittent", 1],
-  ],
-  layout: {
-    "line-cap": "round",
-    visibility: "visible",
-  },
-  source: "openmaptiles",
-  metadata: {},
-  "source-layer": "waterway",
-};
-export const waterwayRiverIntermittent = {
-  id: "waterway_river_intermittent",
-  type: "line",
-  paint: {
-    "line-color": Color.waterLine,
-    "line-width": {
-      base: 1.2,
-      stops: [
-        [11, 0.5],
-        [20, 6],
-      ],
-    },
-    "line-dasharray": [3, 2],
-  },
-  filter: [
-    "all",
-    ["==", "class", "river"],
-    ["!=", "brunnel", "tunnel"],
-    ["==", "intermittent", 1],
-  ],
-  layout: {
-    "line-cap": "round",
-  },
-  source: "openmaptiles",
-  metadata: {},
-  "source-layer": "waterway",
-};
-export const waterwayOther = {
-  id: "waterway_other",
-  type: "line",
-  paint: {
-    "line-color": Color.waterLine,
-    "line-width": {
-      base: 1.3,
-      stops: [
-        [13, 0.5],
-        [20, 6],
-      ],
-    },
-  },
-  filter: [
-    "all",
-    ["!=", "class", "river"],
-    ["!=", "brunnel", "tunnel"],
-    ["!=", "intermittent", 1],
-  ],
-  layout: {
-    "line-cap": "round",
-    visibility: "visible",
-  },
-  source: "openmaptiles",
-  metadata: {},
-  "source-layer": "waterway",
-};
-
-export const waterwayOtherIntermittent = {
-  id: "waterway_other_intermittent",
-  type: "line",
-  paint: {
-    "line-color": Color.waterLine,
-    "line-width": {
-      base: 1.3,
-      stops: [
-        [13, 0.5],
-        [20, 6],
-      ],
-    },
-    "line-dasharray": [4, 3],
-  },
-  filter: [
-    "all",
-    ["!=", "class", "river"],
-    ["!=", "brunnel", "tunnel"],
-    ["==", "intermittent", 1],
-  ],
-  layout: {
-    "line-cap": "round",
-    visibility: "visible",
-  },
-  source: "openmaptiles",
-  metadata: {},
-  "source-layer": "waterway",
-};
-
-export const waterIntermittent = {
-  id: "water_intermittent",
-  type: "fill",
-  paint: {
-    "fill-color": Color.waterIntermittent,
-    "fill-opacity": 0.85,
-  },
-  filter: ["all", ["==", "intermittent", 1]],
-  layout: {
-    visibility: "visible",
-  },
-  source: "openmaptiles",
-  metadata: {},
-  "source-layer": "water",
 };
 
 export const water = {
@@ -158,12 +53,85 @@ export const water = {
   type: "fill",
   paint: {
     "fill-color": Color.waterFill,
-  },
-  filter: ["all", ["!=", "intermittent", 1], ["!=", "brunnel", "tunnel"]],
-  layout: {
-    visibility: "visible",
+    "fill-opacity": [
+      "case",
+      [
+        "any",
+        ["==", ["get", "intermittent"], 1],
+        ["==", ["get", "brunnel"], "tunnel"],
+      ],
+      0.3,
+      1,
+    ],
   },
   source: "openmaptiles",
-  metadata: {},
   "source-layer": "water",
+};
+
+const labelPaintProperties = {
+  "text-halo-color": "#fff",
+  "text-color": Color.waterLabel,
+  "text-halo-width": 0.75,
+  "text-halo-blur": 0.25,
+};
+
+const labelLayoutProperties = {
+  "symbol-placement": "line",
+  "text-field": ["get", "name"],
+  "text-font": ["Metropolis Bold Italic"],
+  "text-max-angle": 55,
+};
+
+export const waterwayLabel = {
+  id: "waterway_label",
+  type: "symbol",
+  source: "openmaptiles",
+  "source-layer": "waterway",
+  filter: ["!=", "brunnel", "tunnel"],
+  layout: {
+    ...labelLayoutProperties,
+    "text-size": [
+      "interpolate",
+      ["exponential", 2],
+      ["zoom"],
+      3,
+      8,
+      12,
+      ["case", ["in", ["get", "class"], ["literal", bigRivers]], 14, 10],
+      20,
+      [
+        "case",
+        ["in", ["get", "class"], ["literal", bigRivers]],
+        40,
+        ["in", ["get", "class"], ["literal", mediumRivers]],
+        20,
+        15,
+      ],
+    ],
+    "text-letter-spacing": 0.15,
+  },
+  paint: labelPaintProperties,
+};
+
+export const waterLabel = {
+  id: "water_label",
+  type: "symbol",
+  source: "openmaptiles",
+  "source-layer": "water_name",
+  layout: {
+    ...labelLayoutProperties,
+    "text-size": [
+      "interpolate",
+      ["exponential", 2],
+      ["zoom"],
+      3,
+      8,
+      12,
+      10,
+      20,
+      40,
+    ],
+    "text-letter-spacing": 0.25,
+  },
+  paint: labelPaintProperties,
 };


### PR DESCRIPTION
Fixes #58

Summary of changes:

Waterway color should be same as water fill, not sure why it was not.

Add labels for waterways (as well as water_name, but that data layer needs some love).

I would love a serif font in the openmaptiles fonts, but Bold Italic works well enough.

Labels go above borders and outlines, but below nearly everything else. I think this is more "interesting effect" than "somewhat unreadable", but would love others' opinions.

Font size is fairly restrained. Looks comfortable in rivers accompanied by a wide area and without.

Waterways don't scale up proportionally as you zoom in to z22 but stop at 10px. Fine tuning a physical model can happen in a different change, but I think this nicely transitions from river area to linear river in the cases I've spot checked.

Did not specify a zoom level, relying on the zoom level inherent in the tiles. The inherent curviness of rivers to cause labels to show up for big straight rivers earlier than small curvy streams. Text angle at 55 is about as high as remains readable, aided by the letter spacing. Could add explicit zoom levels if this is too stochastic.

Screenshots:
![Screenshot 2022-02-25 21 21 00](https://user-images.githubusercontent.com/23022/155825279-3132db04-2c0e-4e7e-a80d-28aa5efd3216.png)
![Screenshot 2022-02-25 21 19 23](https://user-images.githubusercontent.com/23022/155825280-f5ef8ffb-8a67-4183-a295-012c96717ba5.png)
![Screenshot 2022-02-25 21 18 51](https://user-images.githubusercontent.com/23022/155825281-ac6e5bcb-e97e-4b59-b12c-cef091a901d4.png)

