### PR TITLE
Prevent waterway label underlap

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -234,6 +234,7 @@ bridgeLayers.forEach((layer) =>
 
 americanaLayers.push(
   //The labels at the end of the list draw on top of the layers at the beginning.
+  lyrRoadLabel.bridgeSpacer,
   lyrRoadLabel.motorway,
   lyrRoadLabel.trunk,
   lyrRoadLabel.primary,

--- a/style/americana.js
+++ b/style/americana.js
@@ -207,6 +207,8 @@ var bridgeLayers = [
   lyrRoad.motorwayBridge.surface(),
   lyrRoad.motorwayLinkBridge.surface(),
 
+  lyrRoadLabel.bridgeSpacer,
+
   lyrOneway.bridge,
   lyrOneway.bridgeLink,
 ];
@@ -234,7 +236,6 @@ bridgeLayers.forEach((layer) =>
 
 americanaLayers.push(
   //The labels at the end of the list draw on top of the layers at the beginning.
-  lyrRoadLabel.bridgeSpacer,
   lyrRoadLabel.motorway,
   lyrRoadLabel.trunk,
   lyrRoadLabel.primary,

--- a/style/layer/road_label.js
+++ b/style/layer/road_label.js
@@ -130,6 +130,8 @@ export const smallService = {
   "source-layer": "transportation_name",
 };
 
+// A spacer label on each bridge to push any waterway label away from the bridge.
+// https://github.com/ZeLonewolf/openstreetmap-americana/issues/198
 export const bridgeSpacer = {
   id: "bridge_spacer",
   type: "symbol",

--- a/style/layer/road_label.js
+++ b/style/layer/road_label.js
@@ -129,3 +129,24 @@ export const smallService = {
   source: "openmaptiles",
   "source-layer": "transportation_name",
 };
+
+export const bridgeSpacer = {
+  id: "bridge_spacer",
+  type: "symbol",
+  source: "openmaptiles",
+  "source-layer": "transportation",
+  filter: [
+    "all",
+    ["==", "brunnel", "bridge"],
+    ["in", "class", "motorway", "trunk", "primary"],
+  ],
+  paint: {
+    "icon-opacity": 0,
+  },
+  layout: {
+    "symbol-placement": "line-center",
+    "icon-image": "dot_city",
+    "icon-allow-overlap": true,
+    "icon-size": 0.1,
+  },
+};

--- a/style/layer/road_label.js
+++ b/style/layer/road_label.js
@@ -137,16 +137,13 @@ export const bridgeSpacer = {
   type: "symbol",
   source: "openmaptiles",
   "source-layer": "transportation",
-  filter: [
-    "all",
-    ["==", "brunnel", "bridge"],
-    ["in", "class", "motorway", "trunk", "primary"],
-  ],
+  filter: ["all", ["==", "brunnel", "bridge"], ["in", "$type", "LineString"]],
   paint: {
     "icon-opacity": 0,
   },
   layout: {
-    "symbol-placement": "line-center",
+    "symbol-placement": "line",
+    "symbol-spacing": 2,
     "icon-image": "dot_city",
     "icon-allow-overlap": true,
     "icon-size": 0.1,


### PR DESCRIPTION
Added an invisible spacer icon to bridges along a motorway, trunk road, or primary road to push waterway labels away from the bridge.

<img src="https://user-images.githubusercontent.com/1231218/155827297-b1fc55f1-800a-43fc-bb62-e5a7de26728b.png" width="400" alt="Before z12"> <img src="https://user-images.githubusercontent.com/1231218/155827236-84017379-90c3-49d3-a098-14c5008d0574.png" width="400" alt="After z12">

The spacer layer is placed just before the highway label layers, so it shouldn’t affect highway labels. However, it does prevent some labeling of waterways where there are many crossings. Perhaps we could decrease the waterway label layer’s [`symbol-spacing`](https://maplibre.org/maplibre-gl-js-docs/style-spec/layers/#layout-symbol-symbol-spacing) if that becomes a problem.

The spacer icon technique could also help push shields away from road–road separations where they would be ambiguous.

Fixes #198.