### PR TITLE
Improve visibility of lake labels

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -50,6 +50,7 @@ americanaLayers.push(
 
   lyrWater.waterwayLabel,
   lyrWater.waterLabel,
+  lyrWater.waterPointLabel,
 
   lyrRoad.motorwayTunnel.casing(),
   lyrRoad.trunkExpresswayTunnel.casing(),

--- a/style/layer/water.js
+++ b/style/layer/water.js
@@ -113,6 +113,7 @@ export const waterwayLabel = {
   paint: labelPaintProperties,
 };
 
+//Lake labels rendered as a linear feature
 export const waterLabel = {
   id: "water_label",
   type: "symbol",
@@ -125,9 +126,36 @@ export const waterLabel = {
       ["exponential", 2],
       ["zoom"],
       3,
+      11,
+      12,
+      18,
+      20,
+      40,
+    ],
+    "text-letter-spacing": 0.25,
+  },
+  paint: labelPaintProperties,
+};
+
+//Lake labels rendered as a point feature
+export const waterPointLabel = {
+  id: "water_point_label",
+  type: "symbol",
+  source: "openmaptiles",
+  "source-layer": "water_name",
+  layout: {
+    //  "symbol-placement": "line",
+    "text-field": ["get", "name"],
+    "text-font": ["Metropolis Bold Italic"],
+    // "text-max-angle": 55,
+    "text-size": [
+      "interpolate",
+      ["exponential", 2],
+      ["zoom"],
+      3,
       8,
       12,
-      10,
+      14,
       20,
       40,
     ],

--- a/style/layer/water.js
+++ b/style/layer/water.js
@@ -144,10 +144,8 @@ export const waterPointLabel = {
   source: "openmaptiles",
   "source-layer": "water_name",
   layout: {
-    //  "symbol-placement": "line",
     "text-field": ["get", "name"],
     "text-font": ["Metropolis Bold Italic"],
-    // "text-max-angle": 55,
     "text-size": [
       "interpolate",
       ["exponential", 2],

--- a/style/layer/water.js
+++ b/style/layer/water.js
@@ -117,6 +117,7 @@ export const waterwayLabel = {
 export const waterLabel = {
   id: "water_label",
   type: "symbol",
+  filter: ["all", ["==", "$type", "LineString"]],
   source: "openmaptiles",
   "source-layer": "water_name",
   layout: {
@@ -143,6 +144,7 @@ export const waterPointLabel = {
   type: "symbol",
   source: "openmaptiles",
   "source-layer": "water_name",
+  filter: ["all", ["==", "$type", "Point"]],
   layout: {
     "text-field": ["get", "name"],
     "text-font": ["Metropolis Bold Italic"],


### PR DESCRIPTION
This PR slightly increases the size of lake labels, and adds rendering of lake labels represented as points in the tiles.  The quality of label placement is driven by the data provided by the tiles, but this should at least be an improvement over the current labelling.

Lake Ontario, before and after:
![image](https://user-images.githubusercontent.com/3254090/155857238-bbd52a4e-bf78-471b-9ed4-9766393dd64a.png)
![image](https://user-images.githubusercontent.com/3254090/155857209-353a83f3-d12e-4a4e-876f-e0f1cc17a65e.png)

Finger Lakes, before and after:
![image](https://user-images.githubusercontent.com/3254090/155857284-1c89da03-c08e-46b6-8d90-197773547727.png)
![image](https://user-images.githubusercontent.com/3254090/155857305-228477a8-48be-4c51-b881-d83634638d03.png)

New Hampshire, before and after:
![image](https://user-images.githubusercontent.com/3254090/155857332-d9425dd1-c149-491d-b7f9-53063af805c4.png)
![image](https://user-images.githubusercontent.com/3254090/155857358-cefbdaf2-f438-4256-b6a6-711fea2c508a.png)
