### PR TITLE
Thicken road label halo

### DIFF
--- a/style/js/shield_text.js
+++ b/style/js/shield_text.js
@@ -206,8 +206,36 @@ export function drawBannerText(ctx, text, bannerIndex) {
 
   ctx.textBaseline = "top";
   ctx.font = Gfx.shieldFont(textLayout.fontPx);
-  ctx.shadowColor = "white";
-  ctx.shadowBlur = 10;
+  ctx.shadowColor = "rgba(250, 246, 242, 1)";
+  ctx.shadowOffsetX = -2;
+  ctx.shadowOffsetY = -2;
+
+  ctx.fillText(
+    text,
+    textLayout.xBaseline,
+    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
+  );
+
+  ctx.shadowOffsetX = -2;
+  ctx.shadowOffsetY = 2;
+
+  ctx.fillText(
+    text,
+    textLayout.xBaseline,
+    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
+  );
+
+  ctx.shadowOffsetX = 2;
+  ctx.shadowOffsetY = -2;
+
+  ctx.fillText(
+    text,
+    textLayout.xBaseline,
+    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
+  );
+
+  ctx.shadowOffsetX = 2;
+  ctx.shadowOffsetY = 2;
 
   ctx.fillText(
     text,

--- a/style/js/shield_text.js
+++ b/style/js/shield_text.js
@@ -207,41 +207,18 @@ export function drawBannerText(ctx, text, bannerIndex) {
   ctx.textBaseline = "top";
   ctx.font = Gfx.shieldFont(textLayout.fontPx);
   ctx.shadowColor = "rgba(250, 246, 242, 1)";
-  ctx.shadowOffsetX = -2;
-  ctx.shadowOffsetY = -2;
+  [-2, 2].forEach((offsetX) => {
+    [-2, 2].forEach((offsetY) => {
+      ctx.shadowOffsetX = offsetX;
+      ctx.shadowOffsetY = offsetY;
 
-  ctx.fillText(
-    text,
-    textLayout.xBaseline,
-    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
-  );
-
-  ctx.shadowOffsetX = -2;
-  ctx.shadowOffsetY = 2;
-
-  ctx.fillText(
-    text,
-    textLayout.xBaseline,
-    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
-  );
-
-  ctx.shadowOffsetX = 2;
-  ctx.shadowOffsetY = -2;
-
-  ctx.fillText(
-    text,
-    textLayout.xBaseline,
-    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
-  );
-
-  ctx.shadowOffsetX = 2;
-  ctx.shadowOffsetY = 2;
-
-  ctx.fillText(
-    text,
-    textLayout.xBaseline,
-    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
-  );
+      ctx.fillText(
+        text,
+        textLayout.xBaseline,
+        textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
+      );
+    });
+  });
 }
 
 export function calculateTextWidth(text, fontSize) {

--- a/style/layer/road_label.js
+++ b/style/layer/road_label.js
@@ -30,9 +30,9 @@ function zoomDependentLayout(minHighZoom) {
 
 const textPaint = {
   "text-color": "#333",
-  "text-halo-color": "#fff",
+  "text-halo-color": "rgba(250, 246, 242, 1)",
   "text-halo-blur": 0.5,
-  "text-halo-width": 1,
+  "text-halo-width": 2,
 };
 
 export const motorway = {


### PR DESCRIPTION
Doubled the thickness of the halo around road labels and changed them to an off-white color matching the background. These changes make the halo look more like a knockout effect than an outline around the text.

The previous treatment doesn’t provide enough contrast when the label overlaps a dark element. Since the black text on its own didn’t have enough contrast with the dark element beneath, it almost seemed like the text itself was a translucent white casing with no fill.

The halo blur isn’t strictly necessary anymore, but I left it in because it gives the halo a bit of sophistication versus a solid halo, which can look outdated.

<img src="https://user-images.githubusercontent.com/1231218/155860763-65264710-f17d-4745-af52-c9066b9cd0b4.png" width="400" alt="6th before"> <img src="https://user-images.githubusercontent.com/1231218/155860832-d2ad3c03-cdc2-4c40-8e2e-c3dfe4a5d00b.png" width="400" alt="6th after"><br>_The road labels along [this freeway](https://zelonewolf.github.io/openstreetmap-americana/#15/39.1005/-84.54523) are legible against the constant red color of the freeway beneath._

<img src="https://user-images.githubusercontent.com/1231218/155860596-c739eb88-3797-41dc-b7a4-85c990c7aa76.png" width="400" alt="Queensgate before"> <img src="https://user-images.githubusercontent.com/1231218/155860598-27775e24-36d9-4f3e-a77b-1139691c7cac.png" width="400" alt="Queensgate after"><br>_The road labels at [this freeway junction](https://zelonewolf.github.io/openstreetmap-americana/#15/39.10045/-84.52528) are legible against the alternating red color of freeways crossing perpendicularly beneath the labels._

<img src="https://user-images.githubusercontent.com/1231218/155860513-483b31f3-7e00-491d-b109-e8bab1b246e1.png" width="400" alt="Mt. Airy before"> <img src="https://user-images.githubusercontent.com/1231218/155860517-7abfc738-efae-44f1-be65-e0f9c5e9c021.png" width="400" alt="Mt. Airy after"><br>_The off-white halo keeps the labels from drawing too much attention in and around [this park](https://zelonewolf.github.io/openstreetmap-americana/#14/39.1674/-84.58289)._

<img src="https://user-images.githubusercontent.com/1231218/155860915-dbf25713-f0e4-4007-9874-d80edc4e8661.png" width="400" alt="Lake Pontchartrain Causeway before"> <img src="https://user-images.githubusercontent.com/1231218/155860925-f9eabddd-4e3e-4b28-aff9-eb877263f464.png" width="400" alt="Lake Pontchartrain Causeway after"><br>_Labels for [road bridges over water](https://zelonewolf.github.io/openstreetmap-americana/#11/30.078/-90.1115) are more easily readable at a glance._