### PR TITLE
Filter out disputed boundary lines

### DIFF
--- a/style/layer/boundary.js
+++ b/style/layer/boundary.js
@@ -178,6 +178,7 @@ export const countryCasing = {
   filter: ["all", ["in", "admin_level", 2], ["==", "maritime", 0]],
   minzoom: 2,
   layout: {
+    "line-cap": "round",
     "line-join": "round",
     visibility: "visible",
   },

--- a/style/layer/boundary.js
+++ b/style/layer/boundary.js
@@ -14,7 +14,7 @@ export const city = {
   filter: [
     "all",
     ["==", "admin_level", 8],
-    ["!has", "claimed_by"],
+    ["==", "disputed", 0],
     ["==", "maritime", 0],
   ],
   minzoom: 11,
@@ -42,7 +42,7 @@ export const countyCasing = {
   filter: [
     "all",
     ["==", "admin_level", 6],
-    ["!has", "claimed_by"],
+    ["==", "disputed", 0],
     ["==", "maritime", 0],
   ],
   minzoom: 11,
@@ -66,7 +66,7 @@ export const county = {
   filter: [
     "all",
     ["==", "admin_level", 6],
-    ["!has", "claimed_by"],
+    ["==", "disputed", 0],
     ["==", "maritime", 0],
   ],
   minzoom: 9,
@@ -175,12 +175,7 @@ export const countryCasing = {
       ],
     },
   },
-  filter: [
-    "all",
-    ["in", "admin_level", 2],
-    ["!has", "claimed_by"],
-    ["==", "maritime", 0],
-  ],
+  filter: ["all", ["in", "admin_level", 2], ["==", "maritime", 0]],
   minzoom: 2,
   layout: {
     "line-join": "round",
@@ -224,7 +219,7 @@ export const country = {
   filter: [
     "all",
     ["in", "admin_level", 2],
-    ["!has", "claimed_by"],
+    ["==", "disputed", 0],
     ["==", "maritime", 0],
   ],
   maxzoom: 24,

--- a/style/scripts/taginfo_template.json
+++ b/style/scripts/taginfo_template.json
@@ -27,10 +27,17 @@
       "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/style/icons/star_state_capital.svg"
     },
     {
-      "key": "claimed_by",
-      "object_types": ["way", "relation"],
-      "description": "Hides the boundary.",
-      "doc_url": "https://openmaptiles.org/schema/#claimed_by"
+      "key": "disputed",
+      "value": "yes",
+      "object_types": ["way"],
+      "description": "Deemphasizes the second-level administrative boundary, showing the line casing but hiding the usual line.",
+      "doc_url": "https://openmaptiles.org/schema/#disputed"
+    },
+    {
+      "key": "disputed_by",
+      "object_types": ["way"],
+      "description": "Deemphasizes the second-level administrative boundary, showing the line casing but hiding the usual line.",
+      "doc_url": "https://openmaptiles.org/schema/#disputed"
     },
     {
       "key": "expressway",


### PR DESCRIPTION
Filter out disputed boundary lines based on `disputed` instead of `claimed_by`, but keep showing casings for the boundary lines that OSM includes in boundary relations.

<img src="https://user-images.githubusercontent.com/1231218/156630192-21ab81b1-027e-433a-b624-53c9171d3a5e.png" width="400" alt="before"> <img src="https://user-images.githubusercontent.com/1231218/156636583-b94626af-3427-486e-90bf-d6c4e4ac3f59.png" width="400" alt="after"><br>_Boundaries disputed [between India and China](https://zelonewolf.github.io/openstreetmap-americana/#6/33.191/78.668)._

Fixes #210.