### PR TITLE
Shields of Bangladesh

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -707,6 +707,9 @@ export function loadShields(shieldImages) {
   shields["US:WA:Alternate"] = banneredShield(shields["US:WA"], ["ALT"]);
 
   // Asia
+  shields["BD:national"] = roundedRectShield("#006747", "white", "white", 2, 1);
+  shields["BD:regional"] = roundedRectShield("#ffcd00", "black", "black", 2, 1);
+
   shields["CN:national"] = roundedRectShield(
     "#bf2033",
     "white",


### PR DESCRIPTION
Added route shields for national and regional highways in Bangladesh. District roads are not yet mapped as relations.

[<img src="https://user-images.githubusercontent.com/1231218/158012593-00e88641-6eca-4355-bd20-46bbe5b4b770.png" width="400" alt="Barishal">](https://zelonewolf.github.io/openstreetmap-americana/#14/22.67995/90.35098)<br>_National and regional highways in Barishal._