### PR TITLE
Shields of Nepal

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -873,6 +873,9 @@ export function loadShields(shieldImages) {
     },
   };
 
+  shields["np:national"] = roundedRectShield("#006747", "white", "white", 2, 1);
+  shields["np:regional"] = roundedRectShield("white", "black", "black", 2, 1);
+
   shields["PH:N"] = {
     backgroundImage: [
       shieldImages.shield40_ph_national_2,


### PR DESCRIPTION
Added route shields for national highways and feeder roads (regional roads) in Nepal.

[<img src="https://user-images.githubusercontent.com/1231218/158012925-c5debefd-2338-4ef9-b4bf-24379366bd2d.png" width="400" alt="Kathmandu">](https://zelonewolf.github.io/openstreetmap-americana/#13/27.69229/85.2804)<br>_National highways and feeder roads in Kathmandu._