### PR TITLE
Explicitly declare Montana as a plain shield

### DIFF
--- a/doc-img/shield_map_us.svg
+++ b/doc-img/shield_map_us.svg
@@ -14,7 +14,7 @@
 .ca,.gu {fill:#FF0000}
 In this example, Kansas, Montana and Pennsylvania are colored blue, and California and Guam are colored red.
 Place this code in the empty space below. */
-.us, .az, .ca, .ct, .de, .ga, .hi, .ia, .id, .il, .in, .ks, .ky, .ma, .mi, .me, .mn, .ms, .nc, .nh, .nj, .nm, .ny, .oh, .or, .pa, .ri, .sc, .va, .vt, .wa, .wv { fill: #8250df; }
+.us, .az, .ca, .ct, .de, .ga, .hi, .ia, .id, .il, .in, .ks, .ky, .ma, .mi, .me, .mn, .ms, .mt, .nc, .nh, .nj, .nm, .ny, .oh, .or, .pa, .ri, .sc, .va, .vt, .wa, .wv { fill: #8250df; }
 
 
 </style>

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -379,6 +379,7 @@ export function loadShields(shieldImages) {
   };
 
   shields["US:MS"] = circleShield("white", "black");
+  shields["US:MT"] = roundedRectShield("white", "black", "black", 1, 1);
   shields["US:NC"] = diamondShield;
   shields["US:NC:Bypass"] = banneredShield(shields["US:NC"], ["BYP"]);
   shields["US:NC:Business"] = banneredShield(shields["US:NC"], ["BUS"]);


### PR DESCRIPTION
Explicitly adds the plain white rounded rectangle shield for Montana state routes.

From the Montana DOT's Sign Catalog:
![image](https://user-images.githubusercontent.com/1845290/158408455-df75449d-c772-4b67-9805-356094e3e0de.png)

I don't think there's a way to legibly convey the `MONTANA` wording on the shield at the scale used in _Americana_, so I'm proposing we use the plain white rounded rectangle shield for Montana state routes.