### PR TITLE
Put each region code on a separate line in status map CSS

### DIFF
--- a/doc-img/shield_map_us.svg
+++ b/doc-img/shield_map_us.svg
@@ -14,7 +14,39 @@
 .ca,.gu {fill:#FF0000}
 In this example, Kansas, Montana and Pennsylvania are colored blue, and California and Guam are colored red.
 Place this code in the empty space below. */
-.us, .az, .ca, .ct, .de, .ga, .hi, .ia, .id, .il, .in, .ks, .ky, .ma, .mi, .me, .mn, .ms, .mt, .nc, .nh, .nj, .nm, .ny, .oh, .or, .pa, .ri, .sc, .va, .vt, .wa, .wv { fill: #8250df; }
+.us,
+.az,
+.ca,
+.ct,
+.de,
+.ga,
+.hi,
+.ia,
+.id,
+.il,
+.in,
+.ks,
+.ky,
+.ma,
+.mi,
+.me,
+.mn,
+.ms,
+.mt,
+.nc,
+.nh,
+.nj,
+.nm,
+.ny,
+.oh,
+.or,
+.pa,
+.ri,
+.sc,
+.va,
+.vt,
+.wa,
+.wv { fill: #8250df; }
 
 
 </style>

--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -114,7 +114,24 @@ The lines may be combined if desired:
 .gh,.sg {fill:#0000FF; visibility:visible}
 See the end of this file for a list of available jurisdictions and their codes. */
 
-.ca, .us, .bd, .cn, .hk, .my, .np, .ph, .kr, .tw, .vn, .at, .cz, .it, .hu, .sk, .si, .nl { fill: #8250df; }
+.ca,
+.us,
+.bd,
+.cn,
+.hk,
+.my,
+.np,
+.ph,
+.kr,
+.tw,
+.vn,
+.at,
+.cz,
+.it,
+.hu,
+.sk,
+.si,
+.nl { fill: #8250df; }
 
 /* Color individual borders
 For example, to color the border between Angola and Namibia in green, add this line in the space below:

--- a/style/scripts/status_map.js
+++ b/style/scripts/status_map.js
@@ -5,7 +5,7 @@ import * as ShieldDef from "../js/shield_defs.js";
 
 function fillPaths(svg, codes) {
   let selectors = new Set(codes.map((code) => `.${code.toLowerCase()}`));
-  return svg.replace(".supported", new Array(...selectors).join(", "));
+  return svg.replace(".supported", new Array(...selectors).join(",\n"));
 }
 
 // Inject a map of each sprite ID to an absolute image URL instead of the usual sprite metadata.


### PR DESCRIPTION
Each class in the CSS code of the shield progress maps is now on a separate line. The separate lines will help to minimize the number of merge conflicts in PRs that add or remove shield definitions. Fortunately, `svgo` doesn’t optimize away this whitespace.