### PR TITLE
Fixed reference to wrong filename for Montana secondary shield

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -382,7 +382,7 @@ export function loadShields(shieldImages) {
 
   shields["US:MT"] = roundedRectShield("white", "black", "black", 1, 1);
   shields["US:MT:secondary"] = {
-    backgroundImage: shieldImages.shield40_us_mt_taller,
+    backgroundImage: shieldImages.shield40_us_mt_secondary,
     textColor: "black",
     padding: {
       left: 2,


### PR DESCRIPTION
I was working with too many files and left an intermediate filename in the copy of shield_defs.js that I pushed. This PR puts the proper filename back.