### PR TITLE
Add highway shield for Colorado state routes

### DIFF
--- a/doc-img/shield_map_us.svg
+++ b/doc-img/shield_map_us.svg
@@ -17,6 +17,7 @@ Place this code in the empty space below. */
 .us,
 .az,
 .ca,
+.co,
 .ct,
 .de,
 .ga,

--- a/style/icons/shield40_us_co.svg
+++ b/style/icons/shield40_us_co.svg
@@ -5,6 +5,7 @@
  <path fill="#003f87" d="M1 1H19V3.5H1z"/>
  <path d="m0.5 18.5v-17a1 1 135 0 1 1-1h17a1 1 45 0 1 1 1v17a1 1 135 0 1-1 1h-17a1 1 45 0 1-1-1z" fill="none" stroke="#000"/>
  <path d="m1 9.5h18" stroke="#000"/>
+ <path fill="#ffcd00" d="M3 3H6.5V7H3z"/>
  <circle cx="5.25" cy="5" r="1.25" fill="#ffcd00" stroke="#ffcd00"/>
  <path d="m7.4675 6.1544a2.5 2.5 0 0 1-2.811 1.2742 2.5 2.5 0 0 1-1.9065-2.427 2.5 2.5 0 0 1 1.9036-2.4293 2.5 2.5 0 0 1 2.8125 1.2708" fill="none" stroke="#bf2033" stroke-width="1.5"/>
 </svg>

--- a/style/icons/shield40_us_co.svg
+++ b/style/icons/shield40_us_co.svg
@@ -1,11 +1,8 @@
-<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
- <path fill="#fff" d="M1 10H19V19H1z"/>
- <path fill="#003f87" d="M1 6.5H19V9H1z"/>
- <path fill="#fff" d="M1 3.5H19V6.5H1z"/>
- <path fill="#003f87" d="M1 1H19V3.5H1z"/>
- <path d="m0.5 18.5v-17a1 1 135 0 1 1-1h17a1 1 45 0 1 1 1v17a1 1 135 0 1-1 1h-17a1 1 45 0 1-1-1z" fill="none" stroke="#000"/>
- <path d="m1 9.5h18" stroke="#000"/>
- <path fill="#ffcd00" d="M3 3H6.5V7H3z"/>
- <circle cx="5.25" cy="5" r="1.25" fill="#ffcd00" stroke="#ffcd00"/>
- <path d="m7.4675 6.1544a2.5 2.5 0 0 1-2.811 1.2742 2.5 2.5 0 0 1-1.9065-2.427 2.5 2.5 0 0 1 1.9036-2.4293 2.5 2.5 0 0 1 2.8125 1.2708" fill="none" stroke="#bf2033" stroke-width="1.5"/>
+<svg width="23" height="20" xmlns="http://www.w3.org/2000/svg">
+ <path fill="#fff" d="M1 1H22V19H1z"/>
+ <path fill="#003f87" d="M1 1H22V3.5H1zM1 6.5H22V9H1z"/>
+ <path d="m0.5 18.5v-17a1 1 135 0 1 1-1h20a1 1 45 0 1 1 1v17a1 1 135 0 1-1 1h-20a1 1 45 0 1-1-1z" fill="none" stroke="#000"/>
+ <path fill="#ffcd00" d="M4.032 3H7.532V7H4.032z"/>
+ <circle cx="6.282" cy="5" r="1.25" fill="#ffcd00" stroke="#ffcd00"/>
+ <path d="m8.5 6.1544a2.5 2.5 0 0 1-2.811 1.2742 2.5 2.5 0 0 1-1.9065-2.427 2.5 2.5 0 0 1 1.9036-2.4293 2.5 2.5 0 0 1 2.8125 1.2708" fill="none" stroke="#bf2033" stroke-width="1.5"/>
 </svg>

--- a/style/icons/shield40_us_co.svg
+++ b/style/icons/shield40_us_co.svg
@@ -1,0 +1,10 @@
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+ <path fill="#fff" d="M1 10H19V19H1z"/>
+ <path fill="#003f87" d="M1 6.5H19V9H1z"/>
+ <path fill="#fff" d="M1 3.5H19V6.5H1z"/>
+ <path fill="#003f87" d="M1 1H19V3.5H1z"/>
+ <path d="m0.5 18.5v-17a1 1 135 0 1 1-1h17a1 1 45 0 1 1 1v17a1 1 135 0 1-1 1h-17a1 1 45 0 1-1-1z" fill="none" stroke="#000"/>
+ <path d="m1 9.5h18" stroke="#000"/>
+ <circle cx="5.25" cy="5" r="1.25" fill="#ffcd00" stroke="#ffcd00"/>
+ <path d="m7.4675 6.1544a2.5 2.5 0 0 1-2.811 1.2742 2.5 2.5 0 0 1-1.9065-2.427 2.5 2.5 0 0 1 1.9036-2.4293 2.5 2.5 0 0 1 2.8125 1.2708" fill="none" stroke="#bf2033" stroke-width="1.5"/>
+</svg>

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -247,7 +247,7 @@ export function loadShields(shieldImages) {
     padding: {
       left: 2,
       right: 2,
-      top: 10,
+      top: 9.5,
       bottom: 2,
     },
   };

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -240,6 +240,18 @@ export function loadShields(shieldImages) {
 
   shields["US:CA:Business"] = banneredShield(shields["US:CA"], ["BUS"]);
   shields["US:CA:CR"] = usMUTCDCountyShield;
+
+  shields["US:CO"] = {
+    backgroundImage: shieldImages.shield40_us_co,
+    textColor: "black",
+    padding: {
+      left: 2,
+      right: 2,
+      top: 10,
+      bottom: 2,
+    },
+  };
+
   shields["US:CT"] = roundedRectShield("white", "black", "black", 1, 1);
   shields["US:DE"] = circleShield("white", "black");
   shields["US:DE:Alternate"] = banneredShield(shields["US:DE"], ["ALT"]);


### PR DESCRIPTION
Adds a highway shield graphic and definition for Colorado state routes. 

Note that with current tagging Colorado's E-470 shows up with this shield, but it is not part of the same highway network. See #248 (this PR does not close that issue).

1x display:
![image](https://user-images.githubusercontent.com/1845290/159357401-72f88c84-95aa-468b-8161-a9a8ca8a04b0.png)

2x display:
![image](https://user-images.githubusercontent.com/1845290/159357532-04869f58-d618-4e0c-9203-a402936264be.png)

