### PR TITLE
add Wyoming shields

### DIFF
--- a/doc-img/shield_map_us.svg
+++ b/doc-img/shield_map_us.svg
@@ -49,7 +49,8 @@ Place this code in the empty space below. */
 .vi,
 .vt,
 .wa,
-.wv { fill: #8250df; }
+.wv,
+.wy { fill: #8250df; }
 
 
 </style>

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -860,7 +860,9 @@ export function loadShields(shieldImages) {
   shields["US:WA:Spur"] = banneredShield(shields["US:WA"], ["SPUR"]);
   shields["US:WA:Business"] = banneredShield(shields["US:WA"], ["BUS"]);
   shields["US:WA:Alternate"] = banneredShield(shields["US:WA"], ["ALT"]);
+
   shields["US:WV"] = roundedRectShield("white", "black", "black", 1, 1);
+  shields["US:WY"] = roundedRectShield("#ffcd00", "black", "black", 1, 1);
 
   // Asia
   shields["BD:national"] = roundedRectShield("#006747", "white", "white", 2, 1);


### PR DESCRIPTION
Adds Wyoming shields, represented as black text on a yellow rectangular shield. The word "WYOMING" and the cowboy illustration are removed.

![Screenshot from 2022-03-24 08-08-23](https://user-images.githubusercontent.com/1732117/159913382-9aa2b827-430d-4dc9-8f0b-78f2d22c7222.png)