### PR TITLE
add Nevada shields

### DIFF
--- a/doc-img/shield_map_us.svg
+++ b/doc-img/shield_map_us.svg
@@ -43,6 +43,7 @@ Place this code in the empty space below. */
 .nh,
 .nj,
 .nm,
+.nv,
 .ny,
 .oh,
 .or,

--- a/style/icons/shield40_us_nv.svg
+++ b/style/icons/shield40_us_nv.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="24" version="1.0" xmlns="http://www.w3.org/2000/svg">
+ <path style="fill:#fff;fill-opacity:1;stroke:#000;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M 17.499667,0.5 17.5,19 c -1.183602,-0.0052 -2,0.430994 -2,4 L 0.5,10.017241 V 0.5 Z"/>
+</svg>

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -554,6 +554,18 @@ export function loadShields(shieldImages) {
 
   shields["US:NM"] = roundedRectShield("white", "red", "black", 8, 1, null);
 
+  shields["US:NV"] = {
+    backgroundImage: shieldImages.shield40_us_nv,
+    textColor: "black",
+    padding: {
+      left: 2,
+      right: 2,
+      top: 2,
+      bottom: 12,
+    },
+  };
+  shields["US:NV:Clark"] = usMUTCDCountyShield;
+
   shields["US:NY"] = {
     backgroundImage: shieldImages.shield40_us_ny,
     textColor: "black",


### PR DESCRIPTION
One more state shape down!

Nevada curiously does not have any single-digit routes. Nearly all routes have 3 digits, except for routes 28 and 88. Due to the challenge of fitting 3 digits into a narrow state shape, I went with a height of 24px and a width of 18px.

The Clark County Road 215 shield is conflated with a standard MUTCD county shield here. This PR does not attempt to reproduce the special Clark County shield.

![Screenshot from 2022-03-31 17-58-39](https://user-images.githubusercontent.com/1732117/161156490-c90b376b-7d1f-4bf3-aefd-1e0143b98ec4.png)
![Screenshot from 2022-03-31 17-59-08](https://user-images.githubusercontent.com/1732117/161156491-8edabeaa-cb10-4cb9-b166-a2dbe66fe4b2.png)
![Screenshot from 2022-03-31 17-59-58](https://user-images.githubusercontent.com/1732117/161156494-99a2683d-db78-45b6-8345-9090fb58a7b7.png)
![Screenshot from 2022-03-31 18-00-19](https://user-images.githubusercontent.com/1732117/161156495-e4f39ee8-c57c-40f5-8a09-ad951e3d8b4c.png)

The shields as they are IRL:

![Nevada_28](https://user-images.githubusercontent.com/1732117/161156714-b85150b1-7bd7-4472-bed0-e3fa217f16de.svg)
![Nevada_318](https://user-images.githubusercontent.com/1732117/161156715-9f6f50b1-ad17-4d45-8aa6-23ce39bd9cf0.svg)
![Clark_County_Route_215_NV](https://user-images.githubusercontent.com/1732117/161157443-e3599a37-811b-4c29-a7b2-48401e35563b.svg)
