### PR TITLE
add Nebraska shields

### DIFF
--- a/doc-img/shield_map_us.svg
+++ b/doc-img/shield_map_us.svg
@@ -40,6 +40,7 @@ Place this code in the empty space below. */
 .mt,
 .nc,
 .nd,
+.ne,
 .nh,
 .nj,
 .nm,

--- a/style/icons/shield40_us_ne_2.svg
+++ b/style/icons/shield40_us_ne_2.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 0.5,0.5 3,19 h 13 l 3,-19 z" fill="#fff" stroke="#000"/>
+</svg>

--- a/style/icons/shield40_us_ne_3.svg
+++ b/style/icons/shield40_us_ne_3.svg
@@ -1,0 +1,3 @@
+<svg width="26" height="20" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 0.5,0.5 4,19 h 17 l 4,-19 z" fill="#fff" stroke="#000"/>
+</svg>

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -500,6 +500,25 @@ export function loadShields(shieldImages) {
   shields["US:ND:Business"] = banneredShield(shields["US:ND"], ["BUS"]);
   shields["US:ND:Truck"] = banneredShield(shields["US:ND"], ["TRK"]);
 
+  shields["US:NE"] = {
+    backgroundImage: [
+      shieldImages.shield40_us_ne_2,
+      shieldImages.shield40_us_ne_3,
+    ],
+    textColor: "black",
+    padding: {
+      left: 4,
+      right: 4,
+      top: 4,
+      bottom: 4,
+    },
+  };
+
+  shields["US:NE:Business"] = banneredShield(shields["US:NE"], ["BUS"]);
+  shields["US:NE:Link"] = banneredShield(shields["US:NE"], ["LINK"]);
+  shields["US:NE:Rec"] = banneredShield(shields["US:NE"], ["REC"]);
+  shields["US:NE:Spur"] = banneredShield(shields["US:NE"], ["SPUR"]);
+
   shields["US:NH"] = {
     backgroundImage: shieldImages.shield40_us_nh,
     textColor: "black",


### PR DESCRIPTION
_"I tried to ford the river and one of my oxen died"_

Remember the good ol' days of the Oregon Trail? Now all you have to do is zoom in on a map of Nebraska! These covered-wagon-inspired shields are sure to make you ooh, and awe, and catch dysentery.

![Screenshot from 2022-04-01 08-25-30](https://user-images.githubusercontent.com/1732117/161263121-4011cfb2-9587-43a1-b00f-2bb3f52fe7b9.png)
![Screenshot from 2022-04-01 08-26-02](https://user-images.githubusercontent.com/1732117/161263124-f80d8815-8d38-40d0-af76-aa27cbee51be.png)
![Screenshot from 2022-04-01 08-26-33](https://user-images.githubusercontent.com/1732117/161263126-ba1d43ec-71ae-4ac5-a411-11ef68f1e5a7.png)

The shields in real life are as follows. Artwork and the state name are removed, and the words "LINK", "SPUR", "RECREATION ROAD" and "BUSINESS" are moved above the shield as banners. The latter two are abbreviated to "REC" and "BUS", respectively.

![N-2](https://user-images.githubusercontent.com/1732117/161263176-fae62149-8308-4f5d-8859-ae2250a2f9bc.svg)
![N-370](https://user-images.githubusercontent.com/1732117/161263175-ff80ba34-40bf-433e-a1f8-ccd135eec47b.svg)
![N_LINK_55X](https://user-images.githubusercontent.com/1732117/161263180-e176612d-6fb6-404d-9e20-24966202fde9.svg)
![N_REC_88B](https://user-images.githubusercontent.com/1732117/161263177-ca669138-83ea-4bef-a644-1f1d57d40414.svg)
![N_SPUR_55G](https://user-images.githubusercontent.com/1732117/161263179-cb978293-099d-4c7c-beb7-f8b853132a76.svg)
