### PR TITLE
Add Prince Edward Island shields

### DIFF
--- a/style/icons/shield40_ca_pe.svg
+++ b/style/icons/shield40_ca_pe.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
+ <path style="fill:#fff;stroke:#006747;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter" d="M 0.5,3.5 V 13 c 0,3.836955 5.6630452,6.5 9.5,6.5 3.836955,0 9.5,-2.663045 9.5,-6.5 V 3.5 Z"/>
+ <path style="fill:#006747;stroke:#006747;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4" d="m 0.5,1.5 c 0,-0.4714045 0.5285955,-1 1,-1 h 17 c 0.471405,0 1,0.5285955 1,1 v 2 h -19 z"/>
+</svg>

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -179,6 +179,17 @@ export function loadShields(shieldImages) {
     },
   };
 
+  shields["CA:PE"] = {
+    backgroundImage: shieldImages.shield40_ca_pe,
+    textColor: "black",
+    padding: {
+      left: 2,
+      right: 2,
+      top: 5,
+      bottom: 5,
+    },
+  };
+
   shields["CA:SK:primary"] = homeDownBlueShield;
   shields["CA:SK:secondary"] = {
     backgroundImage: shieldImages.shield40_ca_sk_secondary,


### PR DESCRIPTION
Adds shields for Canada's littlest province, Prince Edward Island. 

![Screenshot from 2022-04-09 17-49-34](https://user-images.githubusercontent.com/1732117/162592701-459c42e5-eeea-4bca-9e56-1963cf4a226f.png)
![Screenshot from 2022-04-09 17-49-59](https://user-images.githubusercontent.com/1732117/162592703-daea57d2-f620-48c3-831a-91c744be00db.png)

PEI only has one fixed-width shield design (other than the Trans-Canada Highway). The design introduced in this PR removes the tree silhouette artwork, changes the green to match the existing colour palette and shrinks the top border. The top border remains thicker than the rest of the border to allude to the removed artwork.

![PEI_Highway_2](https://user-images.githubusercontent.com/1732117/162592698-b7767f3d-e57a-4b5b-bccf-7fe852b7a014.svg)
![PEI_Highway_25A](https://user-images.githubusercontent.com/1732117/162592697-21b0ea01-0055-460b-85bd-f0f8cbde0fac.svg)