### PR TITLE
Add styling for (non-protected-area) parks

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -34,6 +34,7 @@ var americanaLayers = [];
 americanaLayers.push(
   lyrBackground.base,
   lyrPark.fill,
+  lyrPark.parkFill,
 
   lyrBoundary.countyCasing,
   lyrBoundary.stateCasing,
@@ -44,6 +45,7 @@ americanaLayers.push(
   lyrWater.waterwayIntermittent,
 
   lyrPark.outline,
+  lyrPark.parkOutline,
 
   lyrBoundary.city,
   lyrBoundary.county,
@@ -252,6 +254,7 @@ americanaLayers.push(
   lyrRoadLabel.smallService,
 
   lyrPark.label,
+  lyrPark.parkLabel,
 
   lyrHighwayShield.motorway,
   lyrHighwayShield.trunk,

--- a/style/layer/park.js
+++ b/style/layer/park.js
@@ -59,3 +59,55 @@ export const label = {
   metadata: {},
   "source-layer": "park",
 };
+
+export const parkFill = {
+  id: "park-fill",
+  type: "fill",
+  filter: ["==", "subclass", "park"],
+  paint: {
+    "fill-color": Color.parkFill,
+  },
+  layout: {
+    visibility: "visible",
+  },
+  source: "openmaptiles",
+  metadata: {},
+  "source-layer": "landcover",
+};
+
+export const parkOutline = {
+  id: "park-outline",
+  type: "line",
+  filter: ["==", "subclass", "park"],
+  paint: {
+    "line-color": Color.parkOutline,
+  },
+  layout: {
+    visibility: "visible",
+  },
+  source: "openmaptiles",
+  metadata: {},
+  "source-layer": "landcover",
+};
+
+export const parkLabel = {
+  id: "park-label",
+  type: "symbol",
+  filter: ["==", "class", "park"],
+  paint: {
+    "text-color": Color.parkLabel,
+    "text-halo-blur": 1,
+    "text-halo-color": "rgba(255, 255, 255, 1)",
+    "text-halo-width": 1,
+  },
+  layout: {
+    visibility: "visible",
+    "text-field": name_en,
+    "text-font": ["Metropolis Bold"],
+    "text-size": 10,
+    "symbol-sort-key": ["get", "rank"],
+  },
+  source: "openmaptiles",
+  metadata: {},
+  "source-layer": "poi",
+};


### PR DESCRIPTION
These [are tagged](https://openmaptiles.org/schema/#fields) in OpenMapTiles in the landcover layer with subclass=park, not in the park layer (which is just for protected areas).

![Screenshot from 2022-05-05 22-48-36](https://user-images.githubusercontent.com/101657206/167063984-26059034-9aec-4eca-98c9-e499d1c9a618.png)

![Screenshot from 2022-05-05 22-48-55](https://user-images.githubusercontent.com/101657206/167063990-feb2fc4d-925f-454e-aaba-3618f5513512.png)

