### PR TITLE
Change deployment tiles from MapTiler Cloud to AWS-hosted Planetiler instance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           cd style
           npm install --include=dev
-          sed 's/<your MapTiler key>/hJFMGrd2JszhwfJx5M2k/g' configs/config.maptiler.js > config.js
+          cp configs/config.aws.js > config.js
           npm run build
         # MapTiler key hJFMGrd2JszhwfJx5M2k only allows requests from zelonewolf.github.io
 


### PR DESCRIPTION
Fixes #214

This PR changes the github pages hosted demo to an AWS planetiler-generated OpenMapTiles server under my personal control.  It was last updated about a month ago, but I have the ability to regenerate planet on demand when it's needed to support continued style development.  Please ask in Slack if an update is needed.

I have no way to test this other than merging and seeing if anything breaks.  You'll know it's working because NJ Turnpike signs will show up.