### PR TITLE
Add Truck-bannered North Carolina state routes

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -989,6 +989,7 @@ export function loadShields(shieldImages) {
   shields["US:NC"] = diamondShield;
   shields["US:NC:Bypass"] = banneredShield(shields["US:NC"], ["BYP"]);
   shields["US:NC:Business"] = banneredShield(shields["US:NC"], ["BUS"]);
+  shields["US:NC:Truck"] = banneredShield(shields["US:NC"], ["TRK"]);
   shields["US:NC:Charlotte"] = {
     backgroundImage: shieldImages.shield40_us_nc_charlotte,
     textColor: "white",


### PR DESCRIPTION
One-liner; adds support for Truck-bannered state routes in North Carolina.
![Screenshot from 2022-05-08 09-40-40](https://user-images.githubusercontent.com/1732117/167298931-68d2d529-82af-42e6-829a-042701c65f9c.png)