### PR TITLE
Refactor shield drawing code to be more sane and default plain shields to 2px rounded corners

### DIFF
--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -101,12 +101,6 @@ function drawShield(shieldDef, routeDef) {
   var bannerCount = ShieldDef.getBannerCount(shieldDef);
   var shieldBounds = null;
 
-  var drawnRef = routeDef.ref;
-
-  if (drawnRef === "" && shieldDef.refsByWayName) {
-    drawnRef = shieldDef.refsByWayName[wayName];
-  }
-
   var shieldArtwork = getRasterShieldBlank(shieldDef, routeDef);
   var compoundBounds = null;
 
@@ -116,7 +110,7 @@ function drawShield(shieldDef, routeDef) {
       shieldDef.backgroundDraw = ShieldDraw.rectangle;
     }
 
-    let drawnShieldCtx = shieldDef.backgroundDraw(drawnRef);
+    let drawnShieldCtx = shieldDef.backgroundDraw(routeDef.ref);
     compoundBounds = compoundShieldSize(drawnShieldCtx.canvas, bannerCount);
     ctx = Gfx.getGfxContext(compoundBounds);
 
@@ -208,7 +202,8 @@ function getShieldDef(routeDef) {
   if (
     !isValidRef(routeDef.ref) &&
     !shieldDef.notext &&
-    !("norefImage" in shieldDef)
+    !("norefImage" in shieldDef) &&
+    !(shieldDef.refsByWayName && routeDef.wayName)
   ) {
     return null;
   }
@@ -242,9 +237,14 @@ function generateShieldCtx(id) {
     return ShieldDraw.blank();
   }
 
+  // Handle special case for Kentucky
+  if (routeDef.ref === "" && shieldDef.refsByWayName) {
+    routeDef.ref = shieldDef.refsByWayName[routeDef.wayName];
+  }
+
   var ctx = drawShield(shieldDef, routeDef);
 
-  //Add modifier plaques above shields
+  // Add modifier plaques above shields
   drawBanners(ctx, routeDef.network);
 
   // Swap black with a different color for certain shields.

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -110,21 +110,14 @@ function drawShield(network, ref, wayName) {
       return null;
     }
 
+    shieldDef = ShieldDef.shields["default"];
+
     //Draw generic rectangular shield
     ctx = ShieldDraw.rectangle(ref);
 
     shieldBounds = {
       width: ctx.canvas.width,
       height: ctx.canvas.height,
-    };
-    shieldDef = {
-      padding: {
-        left: 2,
-        right: 2,
-        top: 1,
-        bottom: 2,
-      },
-      maxFontSize: 16,
     };
   } else {
     bannerCount = ShieldDef.getBannerCount(shieldDef);

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -52,27 +52,20 @@ function isValidRef(ref) {
  * Retrieve the shield blank that goes with a particular route.  If there are
  * multiple shields for a route (different widths), it picks the best shield.
  *
- * @param {*} network - route network
- * @param {*} ref - route number
+ * @param {*} shieldDef - shield definition for this route
+ * @param {*} routeDef - route tagging from OSM
  * @returns shield blank or null if no shield exists
  */
-function getRasterShieldBlank(network, ref) {
-  var shieldDef = ShieldDef.shields[network];
+function getRasterShieldBlank(shieldDef, routeDef) {
   var shieldArtwork = null;
   var textLayout;
   var bannerCount = 0;
   var bounds;
 
-  if (typeof shieldDef == "undefined") {
-    return null;
-  }
-
-  //Special cases
-  if (!isValidRef(ref)) {
-    if (typeof shieldDef.norefImage != "undefined") {
-      return shieldDef.norefImage;
-    }
-    return null;
+  //Special case where there's a defined fallback shield when no ref is tagged
+  //Example: PA Turnpike
+  if (!isValidRef(routeDef.ref)) {
+    return shieldDef.norefImage;
   }
 
   if (Array.isArray(shieldDef.backgroundImage)) {
@@ -80,7 +73,11 @@ function getRasterShieldBlank(network, ref) {
       shieldArtwork = shieldDef.backgroundImage[i];
 
       bounds = compoundShieldSize(shieldArtwork.data, bannerCount);
-      textLayout = ShieldText.layoutShieldTextFromDef(ref, shieldDef, bounds);
+      textLayout = ShieldText.layoutShieldTextFromDef(
+        routeDef.ref,
+        shieldDef,
+        bounds
+      );
       if (textLayout.fontPx > Gfx.fontSizeThreshold * Gfx.getPixelRatio()) {
         break;
       }
@@ -99,86 +96,66 @@ function textColor(shieldDef) {
   return "black";
 }
 
-function drawShield(network, ref, wayName) {
-  var shieldDef = ShieldDef.shields[network];
+function drawShield(shieldDef, routeDef) {
   var ctx = null;
-  var bannerCount = 0;
+  var bannerCount = ShieldDef.getBannerCount(shieldDef);
   var shieldBounds = null;
 
-  if (shieldDef == null) {
-    if (ref == "") {
-      return null;
+  var drawnRef = routeDef.ref;
+
+  if (drawnRef === "" && shieldDef.refsByWayName) {
+    drawnRef = shieldDef.refsByWayName[wayName];
+  }
+
+  var shieldArtwork = getRasterShieldBlank(shieldDef, routeDef);
+  var compoundBounds = null;
+
+  if (shieldArtwork == null) {
+    if (typeof shieldDef.backgroundDraw == "undefined") {
+      //Default to drawing a rectangle if shape draw function is not specified
+      shieldDef.backgroundDraw = ShieldDraw.rectangle;
     }
 
-    shieldDef = ShieldDef.shields["default"];
+    let drawnShieldCtx = shieldDef.backgroundDraw(drawnRef);
+    compoundBounds = compoundShieldSize(drawnShieldCtx.canvas, bannerCount);
+    ctx = Gfx.getGfxContext(compoundBounds);
 
-    //Draw generic rectangular shield
-    ctx = ShieldDraw.rectangle(ref);
+    ctx.drawImage(
+      drawnShieldCtx.canvas,
+      0,
+      bannerCount * ShieldDef.bannerSizeH
+    );
 
     shieldBounds = {
-      width: ctx.canvas.width,
-      height: ctx.canvas.height,
+      width: drawnShieldCtx.canvas.width,
+      height: drawnShieldCtx.canvas.height,
     };
   } else {
-    bannerCount = ShieldDef.getBannerCount(shieldDef);
-
-    if (ref === "" && shieldDef.refsByWayName) {
-      ref = shieldDef.refsByWayName[wayName];
-    }
-
-    var shieldArtwork = getRasterShieldBlank(network, ref);
-    var compoundBounds = null;
-
-    if (shieldArtwork == null) {
-      if (typeof shieldDef.backgroundDraw != "undefined") {
-        let drawnShieldCtx = shieldDef.backgroundDraw(ref);
-        compoundBounds = compoundShieldSize(drawnShieldCtx.canvas, bannerCount);
-        ctx = Gfx.getGfxContext(compoundBounds);
-
-        ctx.drawImage(
-          drawnShieldCtx.canvas,
-          0,
-          bannerCount * ShieldDef.bannerSizeH
-        );
-
-        shieldBounds = {
-          width: drawnShieldCtx.canvas.width,
-          height: drawnShieldCtx.canvas.height,
-        };
-      } else {
-        return null;
-      }
-    } else {
-      compoundBounds = compoundShieldSize(shieldArtwork.data, bannerCount);
-      ctx = Gfx.getGfxContext(compoundBounds);
-      loadShield(ctx, shieldArtwork, bannerCount);
-      shieldBounds = {
-        width: shieldArtwork.data.width,
-        height: shieldArtwork.data.height,
-      };
-    }
+    compoundBounds = compoundShieldSize(shieldArtwork.data, bannerCount);
+    ctx = Gfx.getGfxContext(compoundBounds);
+    loadShield(ctx, shieldArtwork, bannerCount);
+    shieldBounds = {
+      width: shieldArtwork.data.width,
+      height: shieldArtwork.data.height,
+    };
   }
 
-  if (!isValidRef(ref)) {
-    if (
-      "norefImage" in shieldDef ||
-      ("backgroundDraw" in shieldDef && shieldDef.notext)
-    ) {
-      //Valid shield with no ref to draw
-      return ctx;
-    }
-    //No ref to draw, therefore draw nothing
-    return null;
+  if (
+    (!isValidRef(routeDef.ref) && "norefImage" in shieldDef) ||
+    (shieldDef.notext && "backgroundDraw" in shieldDef)
+  ) {
+    //Pictoral shield with no ref to draw
+    return ctx;
   }
 
-  if (shieldDef.notext == true) {
+  if (shieldDef.notext) {
     //If the shield definition says not to draw a ref, ignore ref
     return ctx;
   }
 
   //The ref is valid and we're supposed to draw it
   var textLayout = ShieldText.layoutShieldTextFromDef(
-    ref,
+    routeDef.ref,
     shieldDef,
     shieldBounds
   );
@@ -186,7 +163,7 @@ function drawShield(network, ref, wayName) {
   textLayout.yBaseline += bannerCount * ShieldDef.bannerSizeH;
 
   ctx.fillStyle = textColor(shieldDef);
-  ShieldText.drawShieldText(ctx, ref, textLayout);
+  ShieldText.drawShieldText(ctx, routeDef.ref, textLayout);
 
   return ctx;
 }
@@ -215,9 +192,33 @@ export function missingIconLoader(map, e) {
   );
 }
 
-function generateShieldCtx(id) {
+function getShieldDef(routeDef) {
+  if (routeDef == null) {
+    return null;
+  }
+
+  var shieldDef = ShieldDef.shields[routeDef.network];
+
+  if (shieldDef == null) {
+    //Default to a plain white rectangle with black outline and text
+    return isValidRef(routeDef.ref) ? ShieldDef.shields["default"] : null;
+  }
+
+  //Determine whether a route without a ref gets drawn
+  if (
+    !isValidRef(routeDef.ref) &&
+    !shieldDef.notext &&
+    !("norefImage" in shieldDef)
+  ) {
+    return null;
+  }
+
+  return shieldDef;
+}
+
+function getRouteDef(id) {
   if (id == "shield_") {
-    return ShieldDraw.blank();
+    return null;
   }
 
   var network_ref = id.split("\n")[1];
@@ -226,20 +227,30 @@ function generateShieldCtx(id) {
   var ref = network_ref_parts[1];
   var wayName = id.split("\n")[2];
 
-  var ctx = drawShield(network, ref, wayName);
+  return {
+    network: network,
+    ref: ref,
+    wayName: wayName,
+  };
+}
 
-  if (ctx == null) {
-    //Does not meet the criteria to draw a shield
+function generateShieldCtx(id) {
+  var routeDef = getRouteDef(id);
+  var shieldDef = getShieldDef(routeDef);
+
+  if (shieldDef == null) {
     return ShieldDraw.blank();
   }
 
+  var ctx = drawShield(shieldDef, routeDef);
+
   //Add modifier plaques above shields
-  drawBanners(ctx, network);
+  drawBanners(ctx, routeDef.network);
 
   // Swap black with a different color for certain shields.
   // The secondary canvas is necessary here for some reason. Without it,
   // the recolored shield gets an opaque instead of transparent background.
-  var colorLighten = ShieldDef.shieldLighten(network, ref);
+  var colorLighten = ShieldDef.shieldLighten(routeDef);
 
   if (colorLighten) {
     let colorCtx = Gfx.getGfxContext(ctx.canvas);

--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -250,7 +250,7 @@ function generateShieldCtx(id) {
   // Swap black with a different color for certain shields.
   // The secondary canvas is necessary here for some reason. Without it,
   // the recolored shield gets an opaque instead of transparent background.
-  var colorLighten = ShieldDef.shieldLighten(routeDef);
+  var colorLighten = ShieldDef.shieldLighten(shieldDef, routeDef);
 
   if (colorLighten) {
     let colorCtx = Gfx.getGfxContext(ctx.canvas);

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -216,6 +216,10 @@ export function loadShields(shieldImages) {
     padding: padding_trapezoid_down,
   };
 
+  // Default
+
+  shields["default"] = roundedRectShield("white", "black", "black", 2, 1);
+
   // North America
 
   shields["CA:transcanada"] = {
@@ -331,13 +335,7 @@ export function loadShields(shieldImages) {
     ["ETR"]
   );
   shields["CA:ON:secondary"] = trapezoidDownShield;
-  shields["CA:ON:tertiary"] = roundedRectShield(
-    "white",
-    "black",
-    "black",
-    1,
-    1
-  );
+  shields["CA:ON:tertiary"] = shields["default"];
   shields["CA:ON:Halton"] = trapezoidUpShieldGreenYellow;
   shields["CA:ON:Peel"] = trapezoidUpShieldBlackYellow;
   shields["CA:ON:Simcoe"] = trapezoidUpShieldWhiteBlue;
@@ -391,10 +389,9 @@ export function loadShields(shieldImages) {
     (countyTownshipOrCity) =>
       (shields[`CA:ON:${countyTownshipOrCity}`] = trapezoidUpShield)
   );
-  shields["CA:ON:Hastings:Wollaston"] = banneredShield(
-    roundedRectShield("white", "black", "black", 1, 1),
-    ["TWP"]
-  );
+  shields["CA:ON:Hastings:Wollaston"] = banneredShield(shields["default"], [
+    "TWP",
+  ]);
   shields["CA:ON:Waterloo:Wellesley"] = circleShield("white", "black");
   shields["CA:ON:Waterloo:Woolwich"] = circleShield("white", "black");
   ["North Dumfries", "Wilmot"].forEach(
@@ -463,7 +460,7 @@ export function loadShields(shieldImages) {
   };
   shields["CA:SK:tertiary"] = homeDownWhiteBlueShield;
 
-  shields["CA:YT"] = roundedRectShield("white", "black", "black", 1, 1);
+  shields["CA:YT"] = shields["default"];
 
   shields["US:I"] = {
     backgroundImage: [
@@ -626,7 +623,7 @@ export function loadShields(shieldImages) {
     },
   };
 
-  shields["US:CT"] = roundedRectShield("white", "black", "black", 1, 1);
+  shields["US:CT"] = shields["default"];
   shields["US:DC"] = {
     backgroundImage: shieldImages.shield40_us_dc,
     textColor: "black",
@@ -804,8 +801,8 @@ export function loadShields(shieldImages) {
     },
   };
 
-  shields["US:IL"] = roundedRectShield("white", "black", "black", 1, 1);
-  shields["US:IN"] = roundedRectShield("white", "black", "black", 1, 1);
+  shields["US:IL"] = shields["default"];
+  shields["US:IN"] = shields["default"];
 
   shields["US:IN:Toll"] = {
     norefImage: shieldImages.shield40_us_in_toll,
@@ -882,7 +879,7 @@ export function loadShields(shieldImages) {
   shields["US:LA:Spur"] = banneredShield(shields["US:LA"], ["SPUR"]);
   shields["US:LA:Truck"] = banneredShield(shields["US:LA"], ["TRK"]);
 
-  shields["US:MA"] = roundedRectShield("white", "black", "black", 1, 1);
+  shields["US:MA"] = shields["default"];
 
   let padding_us_md = {
     left: 4,
@@ -911,7 +908,7 @@ export function loadShields(shieldImages) {
     ["BUS"]
   );
 
-  shields["US:ME"] = roundedRectShield("white", "black", "black", 1, 1);
+  shields["US:ME"] = shields["default"];
   shields["US:MI"] = diamondShield;
   shields["US:MI:CR"] = usMUTCDCountyShield;
 
@@ -945,13 +942,7 @@ export function loadShields(shieldImages) {
   shields["US:MO:Alternate"] = banneredShield(shields["US:MO"], ["ALT"]);
   shields["US:MO:Business"] = banneredShield(shields["US:MO"], ["BUS"]);
   shields["US:MO:Spur"] = banneredShield(shields["US:MO"], ["SPUR"]);
-  shields["US:MO:Supplemental"] = roundedRectShield(
-    "white",
-    "black",
-    "black",
-    1,
-    1
-  );
+  shields["US:MO:Supplemental"] = shields["default"];
   shields["US:MO:Supplemental:Spur"] = banneredShield(
     shields["US:MO:Supplemental"],
     ["SPUR"]
@@ -974,7 +965,7 @@ export function loadShields(shieldImages) {
 
   shields["US:MS"] = circleShield("white", "black");
 
-  shields["US:MT"] = roundedRectShield("white", "black", "black", 1, 1);
+  shields["US:MT"] = shields["default"];
   shields["US:MT:secondary"] = {
     backgroundImage: shieldImages.shield40_us_mt_secondary,
     textColor: "black",
@@ -1078,7 +1069,7 @@ export function loadShields(shieldImages) {
     "Union",
     "Warren",
   ].forEach((county) => (shields[`US:NJ:${county}`] = usMUTCDCountyShield));
-  shields["US:NJ:Bergen"] = roundedRectShield("white", "black", "black", 1, 1);
+  shields["US:NJ:Bergen"] = shields["default"];
 
   shields["US:NM"] = roundedRectShield("white", "red", "black", 8, 1, null);
 
@@ -1167,16 +1158,8 @@ export function loadShields(shieldImages) {
     "TRU:Kinsman",
     "WYA:township",
   ].forEach(
-    // Black on white rectangle
     (countyTownshipOrCity) =>
-      (shields[`US:OH:${countyTownshipOrCity}`] = roundedRectShield(
-        "white",
-        "black",
-        "black",
-        2,
-        1,
-        null
-      ))
+      (shields[`US:OH:${countyTownshipOrCity}`] = shields["default"])
   );
   [
     "ATH",
@@ -1400,7 +1383,7 @@ export function loadShields(shieldImages) {
     backgroundDraw: ShieldDraw.paBelt,
   };
 
-  shields["US:RI"] = roundedRectShield("white", "black", "black", 1, 1);
+  shields["US:RI"] = shields["default"];
 
   shields["US:SC"] = {
     backgroundImage: shieldImages.shield40_us_sc,
@@ -1431,7 +1414,7 @@ export function loadShields(shieldImages) {
     },
   };
 
-  shields["US:TX"] = roundedRectShield("white", "black", "black", 1, 1, null);
+  shields["US:TX"] = shields["default"];
   shields["US:TX:Andrews:Andrews:Loop"] = banneredShield(
     roundedRectShield("white", "#003f87", "#003f87", 1, 1, null),
     ["LOOP"]
@@ -1628,16 +1611,7 @@ export function loadShields(shieldImages) {
     "Waushara",
     "Winnebago",
     "Wood",
-  ].forEach(
-    (county) =>
-      (shields[`US:WI:${county}`] = roundedRectShield(
-        "white",
-        "black",
-        "black",
-        1,
-        1
-      ))
-  );
+  ].forEach((county) => (shields[`US:WI:${county}`] = shields["default"]));
   shields["US:WI:Marquette:Truck"] = banneredShield(
     shields["US:WI:Marquette"],
     ["TRK"]
@@ -1653,7 +1627,7 @@ export function loadShields(shieldImages) {
     },
   };
 
-  shields["US:WV"] = roundedRectShield("white", "black", "black", 1, 1);
+  shields["US:WV"] = shields["default"];
   shields["US:WY"] = roundedRectShield("#ffcd00", "black", "black", 1, 1);
 
   // Asia
@@ -1751,16 +1725,7 @@ export function loadShields(shieldImages) {
     "JS:Liyang",
     "JS:Xuzhou",
     "JS:Wuzhong",
-  ].forEach(
-    (county) =>
-      (shields[`CN:${county}`] = roundedRectShield(
-        "white",
-        "black",
-        "black",
-        2,
-        1
-      ))
-  );
+  ].forEach((county) => (shields[`CN:${county}`] = shields["default"]));
 
   shields["HK"] = {
     backgroundImage: shieldImages.shield40_hk,
@@ -1864,7 +1829,7 @@ export function loadShields(shieldImages) {
   };
 
   shields["np:national"] = roundedRectShield("#006747", "white", "white", 2, 1);
-  shields["np:regional"] = roundedRectShield("white", "black", "black", 2, 1);
+  shields["np:regional"] = shields["default"];
 
   shields["PH:N"] = homeDownWhiteShield;
   shields["PH:E"] = {
@@ -1936,14 +1901,7 @@ export function loadShields(shieldImages) {
     },
   };
   ["city", "county", "district", "township"].forEach(
-    (type) =>
-      (shields[`TW:${type}`] = roundedRectShield(
-        "white",
-        "black",
-        "black",
-        2,
-        1
-      ))
+    (type) => (shields[`TW:${type}`] = shields["default"])
   );
 
   shields["vn:expressway"] = roundedRectShield(
@@ -1954,7 +1912,7 @@ export function loadShields(shieldImages) {
     1,
     null
   );
-  shields["vn:national"] = roundedRectShield("white", "black", "black", 2, 1);
+  shields["vn:national"] = shields["default"];
 
   // Europe
   shields["e-road"] = {

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -2058,18 +2058,13 @@ export function hasShieldArtwork(network) {
  * should be converted from the standard black US route shield to the historic
  * brown color.  This function is a comprehensive list of special cases.
  *
- * @param {*} network - Route network
- * @param {*} ref - Route ref value
+ * @param {*} shieldDef - Shield definition
  */
-export function shieldLighten(network, ref) {
-  var shieldDef = shields[network];
-  if (shieldDef == null) {
-    return null;
-  }
+export function shieldLighten(shieldDef, routeDef) {
   //Ref-specific cases.  Additional entries should be documented in CONTRIBUTE.md
-  switch (network) {
+  switch (routeDef.network) {
     case "US:GA":
-      switch (ref) {
+      switch (routeDef.ref) {
         case "515":
           return "#003478";
         case "520":
@@ -2078,7 +2073,7 @@ export function shieldLighten(network, ref) {
           return null;
       }
     case "CA:YT":
-      switch (ref) {
+      switch (routeDef.ref) {
         case "2":
         case "3":
           return "#ce9d00";

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -301,7 +301,7 @@ export function loadShields(shieldImages) {
     },
   };
   shields["CA:NS:T"] = badgeShield;
-  shields["CA:NS:R"] = roundedRectShield("#693f23", "white", "white", 1, 1);
+  shields["CA:NS:R"] = roundedRectShield("#693f23", "white", "white", 2, 1);
 
   shields["CA:NT"] = {
     backgroundImage: shieldImages.shield40_ca_nt,
@@ -1416,7 +1416,7 @@ export function loadShields(shieldImages) {
 
   shields["US:TX"] = shields["default"];
   shields["US:TX:Andrews:Andrews:Loop"] = banneredShield(
-    roundedRectShield("white", "#003f87", "#003f87", 1, 1, null),
+    roundedRectShield("white", "#003f87", "#003f87", 2, 1, null),
     ["LOOP"]
   );
   shields["US:TX:Loop"] = banneredShield(shields["US:TX"], ["LOOP"]);
@@ -1431,13 +1431,13 @@ export function loadShields(shieldImages) {
   shields["US:TX:PA"] = banneredShield(shields["US:TX"], ["P.A."]);
   shields["US:TX:RM"] = banneredShield(shields["US:TX"], ["R.M."]);
   shields["US:TX:Recreational"] = banneredShield(
-    roundedRectShield("white", "#693f23", "#693f23", 1, 1, null),
+    roundedRectShield("white", "#693f23", "#693f23", 2, 1, null),
     ["R"]
   );
   shields["US:TX:NASA"] = banneredShield(shields["US:TX"], ["NASA"]);
 
   shields["US:TX:Toll"] = banneredShield(
-    roundedRectShield("#003f87", "white", "white", 1, 1, null),
+    roundedRectShield("#003f87", "white", "white", 2, 1, null),
     ["TOLL"]
   );
   shields["US:TX:BCTRA"] = shields["US:TX:Toll"];
@@ -1628,7 +1628,7 @@ export function loadShields(shieldImages) {
   };
 
   shields["US:WV"] = shields["default"];
-  shields["US:WY"] = roundedRectShield("#ffcd00", "black", "black", 1, 1);
+  shields["US:WY"] = roundedRectShield("#ffcd00", "black", "black", 2, 1);
 
   // Asia
   shields["BD:national"] = roundedRectShield("#006747", "white", "white", 2, 1);


### PR DESCRIPTION
This is an initial refactor pass to enable fixes for the current shield banner shadow overlap, which is impossible to fix currently due to code complexity.  I'm hoping this edit reduces the amount of complexity in the shield drawing code and makes it easier for contributors to work with.

In addition, I refactored out commonality in the shield definition for "default" white rectangles.  They had a mix of 1px and 2px rounded corners, so I defaulted this to 2px shields, which I think looks a little nicer.