### PR TITLE
Add black and white oval shields for town maintained sections of Vermont routes

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -1514,7 +1514,7 @@ export function loadShields(shieldImages) {
 
   shields["US:VI"] = circleShield("white", "black");
 
-  // Vermont routes - green and white 
+  // Vermont routes - green and white
   shields["US:VT"] = {
     backgroundImage: shieldImages.shield40_us_vt,
     textColor: "#006b54",

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -1514,6 +1514,7 @@ export function loadShields(shieldImages) {
 
   shields["US:VI"] = circleShield("white", "black");
 
+  // Vermont routes - green and white 
   shields["US:VT"] = {
     backgroundImage: shieldImages.shield40_us_vt,
     textColor: "#006b54",
@@ -1524,6 +1525,8 @@ export function loadShields(shieldImages) {
       bottom: 5,
     },
   };
+  // Vermont routes town maintained sections - black and white ovals
+  shields["US:VT:Town"] = circleShield("white", "black");
 
   shields["US:WA"] = {
     backgroundImage: shieldImages.shield40_us_wa,


### PR DESCRIPTION
This PR should close #268 by adding standard black and white oval shields for `network=US:VT:Town`.  It looks like this network value is not in the tiles yet (at least for [the example I checked](https://www.openstreetmap.org/relation/13646610)), so an updated tileset will be required before they are visible on the map.
![Screen Shot 2022-05-09 at 5 14 49 PM](https://user-images.githubusercontent.com/281482/167500420-a6fcfe17-c924-4678-8262-e3347c7c3d9c.png)
<img width="450" src="https://user-images.githubusercontent.com/281482/167500425-6ba49c5f-f653-4258-883c-24543a0f1ed8.png">



