### PR TITLE
Move aeroway layer above road tunnels

### DIFF
--- a/style/americana.js
+++ b/style/americana.js
@@ -62,10 +62,6 @@ americanaLayers.push(
   lyrWater.waterLabel,
   lyrWater.waterPointLabel,
 
-  lyrAeroway.runway,
-  lyrAeroway.runwayArea,
-  lyrAeroway.taxiway,
-
   lyrRoad.motorwayTunnel.casing(),
   lyrRoad.trunkExpresswayTunnel.casing(),
   lyrRoad.trunkTunnel.casing(),
@@ -103,6 +99,10 @@ americanaLayers.push(
 
   lyrOneway.tunnel,
   lyrOneway.tunnelLink,
+
+  lyrAeroway.runway,
+  lyrAeroway.runwayArea,
+  lyrAeroway.taxiway,
 
   lyrRoad.motorway.casing(),
   lyrRoad.trunkExpressway.casing(),


### PR DESCRIPTION
Reorders layers so that runways and taxiways are above tunnels.

before:
![Screenshot from 2022-05-15 21-00-50](https://user-images.githubusercontent.com/1732117/168503137-c665142c-e28d-4f9a-abdf-51dffdad3bbe.png)

after:
![Screenshot from 2022-05-15 20-58-22](https://user-images.githubusercontent.com/1732117/168503092-fadb42f4-b6ad-4410-960b-c3762d2948f4.png)
