### PR TITLE
Use english name on water features for consistency

### DIFF
--- a/style/layer/water.js
+++ b/style/layer/water.js
@@ -75,9 +75,16 @@ const labelPaintProperties = {
   "text-halo-blur": 0.25,
 };
 
+const nameField = [
+  "coalesce",
+  ["get", "name:en"],
+  ["get": "name_en"],
+  ["get", "name"],
+];
+
 const labelLayoutProperties = {
   "symbol-placement": "line",
-  "text-field": ["get", "name"],
+  "text-field": nameField,
   "text-font": ["Metropolis Bold Italic"],
   "text-max-angle": 55,
 };
@@ -146,7 +153,7 @@ export const waterPointLabel = {
   "source-layer": "water_name",
   filter: ["all", ["==", "$type", "Point"]],
   layout: {
-    "text-field": ["get", "name"],
+    "text-field": nameField,
     "text-font": ["Metropolis Bold Italic"],
     "text-size": [
       "interpolate",

--- a/style/layer/water.js
+++ b/style/layer/water.js
@@ -78,7 +78,7 @@ const labelPaintProperties = {
 const nameField = [
   "coalesce",
   ["get", "name:en"],
-  ["get": "name_en"],
+  ["get", "name_en"],
   ["get", "name"],
 ];
 


### PR DESCRIPTION
Before:
<img width="408" alt="Screen Shot 2022-05-17 at 11 13 58 AM" src="https://user-images.githubusercontent.com/23022/168846358-de6adddb-282e-4516-b85e-4ae49bd7be2b.png">
<img width="495" alt="Screen Shot 2022-05-17 at 11 13 42 AM" src="https://user-images.githubusercontent.com/23022/168846363-ca926aa9-33ee-4965-8600-62d7d3e31615.png">

After:

<img width="413" alt="Screen Shot 2022-05-17 at 11 13 03 AM" src="https://user-images.githubusercontent.com/23022/168846400-5f97d154-0a0a-4771-9390-4c96b945321c.png">
<img width="426" alt="Screen Shot 2022-05-17 at 11 12 44 AM" src="https://user-images.githubusercontent.com/23022/168846399-4c4788ae-e4bb-4477-853b-acc1b8fc7223.png">

(Font change unrelated, but I note that the existing font set lacks Hebrew.)
