### PR TITLE
Change line caps on aeroways from square to butt

### DIFF
--- a/style/layer/aeroway.js
+++ b/style/layer/aeroway.js
@@ -82,7 +82,7 @@ export const runway = {
     },
   },
   layout: {
-    "line-cap": "square",
+    "line-cap": "butt",
     visibility: "visible",
   },
   source: "openmaptiles",
@@ -120,7 +120,7 @@ export const taxiway = {
     },
   },
   layout: {
-    "line-cap": "square",
+    "line-cap": "butt",
     visibility: "visible",
   },
   minzoom: 12,


### PR DESCRIPTION
When suggesting changes on #318, I didn't realize butt line caps were different from square line caps, let alone an option available. With butt caps, runways no longer extend past airport boundaries, and don't leave protrusions when they end at a T-intersection with a taxiway.

before
![Screenshot from 2022-05-19 21-35-40](https://user-images.githubusercontent.com/1732117/169431146-7454e875-7d0b-4c56-a172-f52776eebad9.png)

after
![Screenshot from 2022-05-19 21-35-11](https://user-images.githubusercontent.com/1732117/169431144-306c7bcf-ff71-414a-9ba2-9d49b0da634b.png)