### PR TITLE
Fix banner drop shadow overlapping shield

### DIFF
--- a/style/js/shield.js
+++ b/style/js/shield.js
@@ -18,17 +18,15 @@ function loadShield(ctx, shield, bannerCount) {
   ctx.drawImage(drawCtx.canvas, 0, bannerCount * ShieldDef.bannerSizeH);
 }
 
-function drawBanners(ctx, network) {
+function drawBannerPart(ctx, network, drawFunc) {
   var shieldDef = ShieldDef.shields[network];
 
   if (shieldDef == null || typeof shieldDef.modifiers == "undefined") {
     return ctx; //Unadorned shield
   }
 
-  ctx.fillStyle = "black";
-
   for (var i = 0; i < shieldDef.modifiers.length; i++) {
-    ShieldText.drawBannerText(ctx, shieldDef.modifiers[i], i);
+    drawFunc(ctx, shieldDef.modifiers[i], i);
   }
 
   return ctx;
@@ -265,10 +263,14 @@ function generateShieldCtx(id) {
 
   var ctx = generateBlankGraphicsContext(shieldDef, routeDef);
 
+  // Add the halo around modifier plaque text
+  drawBannerPart(ctx, routeDef.network, ShieldText.drawBannerHaloText);
+
+  // Draw the shield and shield text
   drawShield(ctx, shieldDef, routeDef);
 
-  // Add modifier plaques above shields
-  drawBanners(ctx, routeDef.network);
+  // Add modifier plaque text
+  drawBannerPart(ctx, routeDef.network, ShieldText.drawBannerText);
 
   // Swap black with a different color for certain shields.
   // The secondary canvas is necessary here for some reason. Without it,

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -5,7 +5,8 @@ import * as ShieldText from "./shield_text.js";
 import * as Gfx from "./screen_gfx.js";
 
 //Height of modifier banners
-export const bannerSizeH = 8 * Gfx.getPixelRatio();
+export const bannerSizeH = 9 * Gfx.getPixelRatio();
+export const bannerPadding = 0.5 * Gfx.getPixelRatio();
 
 export const shields = {};
 

--- a/style/js/shield_text.js
+++ b/style/js/shield_text.js
@@ -208,21 +208,47 @@ export function drawBannerText(ctx, text, bannerIndex) {
     height: ShieldDef.bannerSizeH,
   });
 
-  ctx.textBaseline = "top";
-  ctx.font = Gfx.shieldFont(textLayout.fontPx);
-  ctx.shadowColor = "rgba(250, 246, 242, 1)";
-  [-2, 2].forEach((offsetX) => {
-    [-2, 2].forEach((offsetY) => {
-      ctx.shadowOffsetX = offsetX;
-      ctx.shadowOffsetY = offsetY;
+  ctx.fillStyle = "black";
 
-      ctx.fillText(
-        text,
-        textLayout.xBaseline,
-        textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
-      );
-    });
+  ctx.font = Gfx.shieldFont(textLayout.fontPx);
+  ctx.textBaseline = "top";
+  ctx.textAlign = "center";
+
+  ctx.fillText(
+    text,
+    textLayout.xBaseline,
+    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
+  );
+}
+
+/**
+ * Draw drop shadow for text on a modifier plate above a shield
+ *
+ * @param {*} ctx - graphics context to draw to
+ * @param {*} text - text to draw
+ * @param {*} bannerIndex - plate position to draw, 0=top, incrementing
+ */
+export function drawBannerHaloText(ctx, text, bannerIndex) {
+  var textLayout = layoutShieldTextFromDef(text, null, {
+    width: ctx.canvas.width,
+    height: ShieldDef.bannerSizeH,
   });
+
+  ctx.shadowColor = "rgba(250, 246, 242, 1)";
+  ctx.strokeStyle = ctx.shadowColor;
+  ctx.font = Gfx.shieldFont(textLayout.fontPx);
+  ctx.textBaseline = "top";
+  ctx.textAlign = "center";
+  ctx.shadowBlur = 5;
+  ctx.lineWidth = 1.2;
+
+  ctx.strokeText(
+    text,
+    textLayout.xBaseline,
+    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
+  );
+  ctx.shadowColor = null;
+  ctx.shadowBlur = null;
 }
 
 export function calculateTextWidth(text, fontSize) {

--- a/style/js/shield_text.js
+++ b/style/js/shield_text.js
@@ -205,7 +205,7 @@ export function drawShieldText(ctx, text, textLayout) {
 export function drawBannerText(ctx, text, bannerIndex) {
   var textLayout = layoutShieldTextFromDef(text, null, {
     width: ctx.canvas.width,
-    height: ShieldDef.bannerSizeH,
+    height: ShieldDef.bannerSizeH - ShieldDef.bannerPadding,
   });
 
   ctx.fillStyle = "black";
@@ -217,7 +217,9 @@ export function drawBannerText(ctx, text, bannerIndex) {
   ctx.fillText(
     text,
     textLayout.xBaseline,
-    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
+    textLayout.yBaseline +
+      bannerIndex * ShieldDef.bannerSizeH -
+      ShieldDef.bannerPadding
   );
 }
 
@@ -231,7 +233,7 @@ export function drawBannerText(ctx, text, bannerIndex) {
 export function drawBannerHaloText(ctx, text, bannerIndex) {
   var textLayout = layoutShieldTextFromDef(text, null, {
     width: ctx.canvas.width,
-    height: ShieldDef.bannerSizeH,
+    height: ShieldDef.bannerSizeH - ShieldDef.bannerPadding,
   });
 
   ctx.shadowColor = "rgba(250, 246, 242, 1)";
@@ -245,7 +247,9 @@ export function drawBannerHaloText(ctx, text, bannerIndex) {
   ctx.strokeText(
     text,
     textLayout.xBaseline,
-    textLayout.yBaseline + bannerIndex * ShieldDef.bannerSizeH
+    textLayout.yBaseline +
+      bannerIndex * ShieldDef.bannerSizeH -
+      ShieldDef.bannerPadding
   );
   ctx.shadowColor = null;
   ctx.shadowBlur = null;


### PR DESCRIPTION
This PR fixes the issue we have with banner text drop shadows obscuring the top of a shield.  In addition, this removes the kludge we were using to draw a glow effect and replaces it with an actual glow effect using a text stroke with blur.

**Before**
![image](https://user-images.githubusercontent.com/3254090/169631355-1a3761dd-b108-4545-9d3e-a1cecd440b74.png)

**After**
![image](https://user-images.githubusercontent.com/3254090/169631274-3a054420-1f92-4614-82ba-f26ea5926b93.png)
