### PR TITLE
Update OpenMapSamples to include toll renderings from #334.

### DIFF
--- a/style/package-lock.json
+++ b/style/package-lock.json
@@ -3327,7 +3327,7 @@
     },
     "node_modules/openmapsamples": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/adamfranco/OpenMapSamples.git#782d9c4ea0399c4355368cd63ef184987c92c679",
+      "resolved": "git+ssh://git@github.com/adamfranco/OpenMapSamples.git#5014e9f74d7fd49b4e57bc2e8045d3e0b913f221",
       "dev": true,
       "license": "LGPL-3.0-or-later",
       "dependencies": {
@@ -6829,7 +6829,7 @@
       }
     },
     "openmapsamples": {
-      "version": "git+ssh://git@github.com/adamfranco/OpenMapSamples.git#782d9c4ea0399c4355368cd63ef184987c92c679",
+      "version": "git+ssh://git@github.com/adamfranco/OpenMapSamples.git#5014e9f74d7fd49b4e57bc2e8045d3e0b913f221",
       "dev": true,
       "from": "openmapsamples@github:adamfranco/OpenMapSamples",
       "requires": {


### PR DESCRIPTION
Include the addition of toll/non-toll samples
![Screen Shot 2022-05-23 at 1 54 28 PM](https://user-images.githubusercontent.com/25242/169878766-02f7c76d-d322-42c3-ac0b-f6c44d7b7512.png)
.