### PR TITLE
Add Colorado E470 shield and adjust Colorado state shield size

### DIFF
--- a/style/icons/shield40_us_co.svg
+++ b/style/icons/shield40_us_co.svg
@@ -1,8 +1,8 @@
-<svg width="23" height="20" xmlns="http://www.w3.org/2000/svg">
- <path fill="#fff" d="M1 1H22V19H1z"/>
- <path fill="#003f87" d="M1 1H22V3.5H1zM1 6.5H22V9H1z"/>
- <path fill="#ffcd00" d="M4.032 3H7.532V7H4.032z"/>
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+ <path fill="#fff" d="M 1,1 H 19 V 19 H 1 Z"/>
+ <path fill="#003f87" d="M 1,1 H 19 V 3.5 H 1 Z M 1,6.5 H 19 V 9 H 1 Z"/>
+ <path fill="#ffcd00" d="m 4.032,3 h 3.5 v 4 h -3.5 z"/>
  <circle cx="6.282" cy="5" r="1.25" fill="#ffcd00" stroke="#ffcd00"/>
- <path d="m8.5 6.1544a2.5 2.5 0 0 1-2.811 1.2742 2.5 2.5 0 0 1-1.9065-2.427 2.5 2.5 0 0 1 1.9036-2.4293 2.5 2.5 0 0 1 2.8125 1.2708" fill="none" stroke="#bf2033" stroke-width="1.5"/>
- <rect style="fill:none;fill-rule:evenodd;stroke:#000" width="22" height="19" x=".5" y=".5" rx="1.5" ry="1.5"/>
+ <path d="M 8.5,6.1544 C 7.968288,7.1758442 6.8076337,7.7019579 5.689,7.4286 4.5703887,7.1552267 3.7832048,6.153131 3.7825,5.0016 3.7818181,3.8500597 4.567807,2.8470113 5.6861,2.5723 6.80439,2.2976094 7.9656571,2.8223164 8.4986,3.8431" fill="none" stroke="#bf2033" stroke-width="1.5"/>
+ <rect style="fill:none;fill-rule:evenodd;stroke:#000" width="19" height="19" x=".5" y=".5" rx="1.5" ry="1.5"/>
 </svg>

--- a/style/icons/shield40_us_co_e470.svg
+++ b/style/icons/shield40_us_co_e470.svg
@@ -1,0 +1,5 @@
+<svg height="20" width="20" xmlns="http://www.w3.org/2000/svg">
+ <rect style="fill:#fff;fill-rule:evenodd;stroke:#000;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" width="19" height="19" x=".5" y=".5" rx="1.5" ry="1.5"/>
+ <path style="fill:#6d2077;stroke-width:.349084" d="M 8.4819054,6.3039328 9.9909122,4.8013917 14.194408,8.9996495 H 17 L 9.9898697,2 7.0766614,4.9014896 Z M 10.019218,9 6.5148448,5.501737 3,9 Z"/>
+ <path style="fill:none;stroke:#df4661;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 3,9.5 H 17"/>
+</svg>

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -656,6 +656,16 @@ export function loadShields(shieldImages) {
       bottom: 2,
     },
   };
+  shields["US:CO:E470"] = {
+    backgroundImage: shieldImages.shield40_us_co_e470,
+    textColor: Color.shields.black,
+    padding: {
+      left: 2,
+      right: 2,
+      top: 9.5,
+      bottom: 2,
+    },
+  };
 
   shields["US:CT"] = shields["default"];
   shields["US:DC"] = {


### PR DESCRIPTION
Fixes #248.

Also shrinks the Colorado state route shield to a square, as shields typically look in real life. Text size is unaffected.

![Screenshot from 2022-05-26 17-39-04](https://user-images.githubusercontent.com/1732117/170584681-3a9e8a38-16d6-40df-9b87-1fad0b27c9d3.png) ![Screenshot from 2022-05-26 17-38-33](https://user-images.githubusercontent.com/1732117/170584679-092619dc-2ca8-4fab-97f8-dd6356d11033.png)