### PR TITLE
Add shields for West Virginia 'county' roads

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -1708,6 +1708,11 @@ export function loadShields(shieldImages) {
   };
 
   shields["US:WV"] = shields["default"];
+  shields["US:WV:County"] = pillShield(
+    Color.shields.white,
+    Color.shields.black
+  );
+
   shields["US:WY"] = roundedRectShield(
     Color.shields.yellow,
     Color.shields.black,


### PR DESCRIPTION
Fixes #13, opting for the horizontal layout.

A stacked layout for these shields (and others with similar layouts, like Italian diramazioni) would be an improvement, but that can be left for later.

![Screenshot from 2022-06-03 11-58-55](https://user-images.githubusercontent.com/1732117/171902430-33ddb741-b22d-4614-ba67-0c1e2f65f369.png) ![Screenshot from 2022-06-03 11-59-16](https://user-images.githubusercontent.com/1732117/171902432-6f919e74-d84a-4ca0-ad67-c6b3410e88b7.png)
