### PR TITLE
Adjust padding of US Interstate shield

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -495,6 +495,12 @@ export function loadShields(shieldImages) {
 
   shields["CA:YT"] = shields["default"];
 
+  let padding_us_interstate = {
+    left: 4,
+    right: 4,
+    top: 5,
+    bottom: 5,
+  };
   shields["US:I"] = {
     backgroundImage: [
       shieldImages.shield40_us_interstate_2,
@@ -502,12 +508,7 @@ export function loadShields(shieldImages) {
     ],
     textLayoutConstraint: ShieldText.southHalfellipseTextConstraint,
     textColor: Color.shields.white,
-    padding: {
-      left: 3.5,
-      right: 3.5,
-      top: 5,
-      bottom: 4,
-    },
+    padding: padding_us_interstate,
   };
 
   shields["US:I:Alternate"] = banneredShield(shields["US:I"], ["ALT"]);
@@ -522,12 +523,7 @@ export function loadShields(shieldImages) {
     ],
     textLayoutConstraint: ShieldText.southHalfellipseTextConstraint,
     textColor: Color.shields.white,
-    padding: {
-      left: 3,
-      right: 3,
-      top: 5,
-      bottom: 5,
-    },
+    padding: padding_us_interstate,
   };
 
   shields["US:I:Business:Spur"] = shields["US:I:Business:Loop"];

--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -498,7 +498,7 @@ export function loadShields(shieldImages) {
   let padding_us_interstate = {
     left: 4,
     right: 4,
-    top: 5,
+    top: 6,
     bottom: 5,
   };
   shields["US:I"] = {


### PR DESCRIPTION
Adjusts the padding of US Interstate shields to prevent 3-digit routes from being shown on the 2-digit shield variant.
![Screenshot from 2022-06-05 21-06-00](https://user-images.githubusercontent.com/1732117/172078766-d16d5ac2-4b30-4c4d-b0be-3ab598190e01.png) ![Screenshot from 2022-06-05 21-06-16](https://user-images.githubusercontent.com/1732117/172078767-553e15c7-6be7-4f0f-ab35-e6803ccabfe0.png)
![Screenshot from 2022-06-05 21-06-34](https://user-images.githubusercontent.com/1732117/172078769-f7d6f692-92ed-470f-a355-488b6bc2ba8f.png) ![Screenshot from 2022-06-05 21-06-53](https://user-images.githubusercontent.com/1732117/172078770-b3a782d2-2435-4d1d-9e4c-86f6176386d9.png)
