### PR TITLE
Adjust pill shield padding

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -68,14 +68,27 @@ function pillShield(
   outlineWidth,
   rectWidth
 ) {
-  return roundedRectShield(
-    fillColor,
-    strokeColor,
-    textColor,
-    10,
-    outlineWidth,
-    rectWidth
-  );
+  textColor = textColor ?? strokeColor;
+  outlineWidth = outlineWidth ?? 1;
+  return {
+    backgroundDraw: (ref) =>
+      ShieldDraw.roundedRectangle(
+        fillColor,
+        strokeColor,
+        ref,
+        10,
+        outlineWidth,
+        rectWidth
+      ),
+    textLayoutConstraint: ShieldText.ellipseTextConstraint,
+    padding: {
+      left: 2,
+      right: 2,
+      top: 2,
+      bottom: 2,
+    },
+    textColor: textColor,
+  };
 }
 
 function banneredShield(baseDef, modifiers) {

--- a/style/js/shield_text.js
+++ b/style/js/shield_text.js
@@ -51,18 +51,14 @@ export function rectTextConstraint(spaceBounds, textBounds) {
 }
 
 export function roundedRectTextConstraint(spaceBounds, textBounds, radius) {
-  if (radius < 8) {
-    //Shrink space bounds so that corners hit the arcs
-    return rectTextConstraint(
-      {
-        width: spaceBounds.width - radius * (2 - Math.sqrt(2)),
-        height: spaceBounds.height - radius * (2 - Math.sqrt(2)),
-      },
-      textBounds
-    );
-  } else {
-    return ellipseTextConstraint(spaceBounds, textBounds);
-  }
+  //Shrink space bounds so that corners hit the arcs
+  return rectTextConstraint(
+    {
+      width: spaceBounds.width - radius * (2 - Math.sqrt(2)),
+      height: spaceBounds.height - radius * (2 - Math.sqrt(2)),
+    },
+    textBounds
+  );
 }
 
 /**


### PR DESCRIPTION
Removes special casing and defines `pillShield()` as a rounded rectangle with radius 10, with identical text constraints to `ovalShield()`.

before/after:
![Screenshot from 2022-06-11 20-40-17](https://user-images.githubusercontent.com/1732117/173209523-5abada9d-edf6-4056-b335-0792dc2aa957.png) ![Screenshot from 2022-06-11 20-39-54](https://user-images.githubusercontent.com/1732117/173209522-2fde7a6f-4e7f-483f-9b82-e893dce23967.png)
