### PR TITLE
Add AT Schnellstraße shield

### DIFF
--- a/style/js/shield_defs.js
+++ b/style/js/shield_defs.js
@@ -2529,6 +2529,11 @@ export function loadShields(shieldImages) {
     Color.shields.white
   );
 
+  shields["AT:S-road"] = roundedRectShield(
+    Color.shields.blue,
+    Color.shields.white
+  );
+
   // Bosnia and Herzegovina
   shields["ba:Autoceste"] = roundedRectShield(
     Color.shields.green,


### PR DESCRIPTION
Adds shields for Austrian Schnellstraßen (S1, etc.); these look the same as the existing shields for the Autobahnen (A1, etc.).  Other road networks (B, L) do not have a `network=` tag.

![](https://user-images.githubusercontent.com/313929/173237880-794bbec5-3612-4a33-a98a-0848d0ee5361.png)

This is how the shields look like on a street sign:
![](https://upload.wikimedia.org/wikipedia/commons/8/86/TERN_Schriftart%2C_Autobahnschild%2C_S1.jpg?uselang=de)