### PR TITLE
Markdown typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Contributors welcome!_
 
 The repository is organized as follows:
 
-- **src/** - The map style. See [CONTRIBUTING.md][].
+- **src/** - The map style. See [CONTRIBUTING.md](CONTRIBUTING.md).
 - **dev/** - Development tools used for style development. See [Style Developer Tools](dev/README.md)
 - _Coming soon! Other customized parts of the tech stack._
 


### PR DESCRIPTION
Implicit link names only work with link definitions, not with URLs.