### PR TITLE
Documentation: fix Curacao support

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -145,7 +145,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .md,
 .me,
 .mk,
-.nl,
+.nl, .cw,
 .pl,
 .pt,
 .ro,


### PR DESCRIPTION
For some reason the CW country code disappeared from the map in #406,
but #394 provides full support for Curacao.