### PR TITLE
Change default shield to plain text with halo

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -259,10 +259,16 @@ export function loadShields(shieldImages) {
 
   // Default
 
-  shields["default"] = roundedRectShield(
-    Color.shields.white,
-    Color.shields.black
-  );
+  shields["default"] = {
+    textColor: Color.shields.black,
+    textHaloColor: Color.backgroundFill,
+    padding: {
+      left: 3,
+      right: 3,
+      top: 3,
+      bottom: 3,
+    },
+  };
 
   // North America
 


### PR DESCRIPTION
Fixes #363.

Changes the default shield to plain text with a halo and no background shield. This design makes no assumptions about shield design in cases where routes have numbers but not shields, and where shields may be present but are not yet supported by this project.

![Screenshot from 2022-06-12 15-34-37](https://user-images.githubusercontent.com/1732117/173250264-d07a5ebf-8ad9-4c18-80a1-108e446275d7.png)