### PR TITLE
Change Onondaga County NY to signed

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1648,6 +1648,7 @@ export function loadShields(shieldImages) {
     "Madison",
     "Montgomery",
     "Oneida",
+    "Onondaga", // ref=57, unsigned_ref=91 (only)
     "Orange",
     "Oswego",
     "Otsego",


### PR DESCRIPTION
Onondaga County, NY county routes are all actually unsigned. But one of them is signed. This change simply changes the one signed route from the default rendering to the blue pentagon, which it is signed as. (Specifically, NY 57 was replaced in 1982 with Oswego CR 57 and Onondaga CR (unsigned=91, signed=57).

But for reference, I did verify that no other route in this network has a value of `ref=*`, only `unsigned_ref=*`, and so were not rendering and will not render.

```
 ~ ¶ curl -fs https://overpass-api.de/api/interpreter -d 'data=[out:csv(::id,type,route,name,network,ref,unsigned_ref,wikipedia,wikidata;true;"|")];rel[network="US:NY:Onondaga"];out tags;' >onondaga.csv 
 ~ ¶ <onondaga.csv xsv input '-d|' | xsv frequency -s ref 
field,value,count
ref,(NULL),276
ref,57,1
```