### PR TITLE
Don't produce a 20x20 blank for a missing shield.

### DIFF
--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -291,7 +291,8 @@ function generateShieldCtx(id) {
   var shieldDef = getShieldDef(routeDef);
 
   if (shieldDef == null) {
-    return null;
+    // Want to return null here, but that gives a corrupted display. See #243
+    return Gfx.getGfxContext({ width: 1, height: 1 });
   }
 
   // Swap black with a different color for certain shields.

--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -219,6 +219,9 @@ export function missingIconHandler(map, e) {
 
 export function missingIconLoader(map, e) {
   var ctx = generateShieldCtx(e.id);
+  if (ctx == null) {
+    return null;
+  }
   var imgData = ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height);
   map.addImage(
     e.id,
@@ -288,7 +291,7 @@ function generateShieldCtx(id) {
   var shieldDef = getShieldDef(routeDef);
 
   if (shieldDef == null) {
-    return ShieldDraw.blank(routeDef.ref);
+    return null;
   }
 
   // Swap black with a different color for certain shields.

--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -218,11 +218,13 @@ export function missingIconHandler(map, e) {
 }
 
 export function missingIconLoader(map, e) {
-  var ctx = generateShieldCtx(e.id);
+  let ctx = generateShieldCtx(e.id);
   if (ctx == null) {
-    return null;
+    // Want to return null here, but that gives a corrupted display. See #243
+    console.warn("Didn't produce a shield for", JSON.stringify(e.id));
+    ctx = Gfx.getGfxContext({ width: 1, height: 1 });
   }
-  var imgData = ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height);
+  const imgData = ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height);
   map.addImage(
     e.id,
     {
@@ -291,8 +293,7 @@ function generateShieldCtx(id) {
   var shieldDef = getShieldDef(routeDef);
 
   if (shieldDef == null) {
-    // Want to return null here, but that gives a corrupted display. See #243
-    return Gfx.getGfxContext({ width: 1, height: 1 });
+    return null;
   }
 
   // Swap black with a different color for certain shields.


### PR DESCRIPTION
Change to a 1x1 blank, which wastes slightly less space; log a warning to say that we can't do that shield.

(Producing no image triggers the corrupt icon display again.)

Fixes #440