### PR TITLE
Add Chicago Skyway shield

### DIFF
--- a/icons/shield40_us_il_skyway.svg
+++ b/icons/shield40_us_il_skyway.svg
@@ -1,0 +1,4 @@
+<svg xml:space="preserve" overflow="visible" height="20" width="20" xmlns="http://www.w3.org/2000/svg">
+ <rect style="fill:#003f87;fill-rule:evenodd;stroke:#fff;stroke-linecap:round;stroke-linejoin:bevel" width="19" height="19" x=".5" y=".5" rx="1.5" ry="1.5"/>
+ <path style="fill:#fff;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:bevel" d="M 8,14 C 5.790861,14 4,12.209139 4,10 4,7.790861 5.790861,6 8,6 h 4 c 2.209139,0 4,1.790861 4,4 0,2.209139 -1.790861,4 -4,4 z"/>
+</svg>

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1040,6 +1040,10 @@ export function loadShields(shieldImages) {
   ].forEach(
     (county) => (shields[`US:IL:${county}`] = pentagonShieldBlueYellow)
   );
+  shields["US:IL:Cook:Chicago:Skyway"] = {
+    norefImage: shieldImages.shield40_us_il_skyway,
+    notext: true,
+  };
 
   shields["US:IN"] = roundedRectShield(
     Color.shields.white,


### PR DESCRIPTION
Fixes #291, completing an unbroken string of toll road shields from Chicago to New Jersey.

![Screenshot from 2022-06-25 16-23-42](https://user-images.githubusercontent.com/1732117/175789526-9a8940d8-dec4-479a-aa2a-b3eff70cb7d0.png)