### PR TITLE
Update world shield coverage map

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -157,7 +157,8 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .sk,
 .ua,
 .xk,
-.nz { fill: #8250df; }
+.nz,
+.cw { fill: #8250df; }
 
 /* Color individual borders
 For example, to color the border between Angola and Namibia in green, add this line in the space below:

--- a/scripts/status_map.js
+++ b/scripts/status_map.js
@@ -5,6 +5,10 @@ import * as ShieldDef from "../src/js/shield_defs.js";
 
 function fillPaths(svg, codes) {
   let selectors = new Set(codes.map((code) => `.${code.toLowerCase()}`));
+  if (selectors.has(".nl")) {
+    // Curaçao routes use NL prefix with the Netherlands.
+    selectors.add(".cw");
+  }
   return svg.replace(".supported", new Array(...selectors).join(",\n"));
 }
 


### PR DESCRIPTION
Added Åland (#417). Added Curaçao more durably than in #418. Running `npm run build` will no longer unhighlight Curaçao.