### PR TITLE
Add Ghana shields

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -116,6 +116,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 
 .ca,
 .us,
+.gh,
 .bd,
 .cn,
 .hk,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2397,6 +2397,14 @@ export function loadShields(shieldImages) {
     (county) => (shields[`US:WY:${county}`] = pentagonShieldBlueYellow)
   );
 
+  // AFRICA
+
+  // Ghana
+  shields["GH:national"] =
+    shields["GH:inter-regional"] =
+    shields["GH:regional"] =
+      roundedRectShield(Color.shields.yellow, Color.shields.black);
+
   // ASIA
 
   // Bangladesh


### PR DESCRIPTION
Adds shields for Ghana, all of which are black-on-yellow rectangles.

Techiman, Ghana:
![Screenshot from 2022-06-26 22-23-35](https://user-images.githubusercontent.com/1732117/175848402-3eb7ddeb-072d-4e48-bd0e-3713af924a7b.png)