### PR TITLE
Add shields for Iran freeways

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -120,6 +120,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .bd,
 .cn,
 .hk,
+.ir,
 .jp,
 .my,
 .np,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2527,10 +2527,6 @@ export function loadShields(shieldImages) {
     Color.shields.blue,
     Color.shields.white
   );
-  shields["ir:national"] = roundedRectShield(
-    Color.shields.green,
-    Color.shields.white
-  );
 
   // Japan
   shields["JP:E"] = roundedRectShield(Color.shields.green, Color.shields.white);

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2522,6 +2522,16 @@ export function loadShields(shieldImages) {
     },
   };
 
+  // Iran
+  shields["ir:freeways"] = roundedRectShield(
+    Color.shields.blue,
+    Color.shields.white
+  );
+  shields["ir:national"] = roundedRectShield(
+    Color.shields.green,
+    Color.shields.white
+  );
+
   // Japan
   shields["JP:E"] = roundedRectShield(Color.shields.green, Color.shields.white);
   shields["JP:national"] = {


### PR DESCRIPTION
Adds shields for national freeways ~and roads~ of Iran.

In real life, highways are posted with both Western Arabic numerals and Persian numerals. Since we're emulating an American road atlas style and using English labels wherever possible, I think it's appropriate to stick with the Western Arabic numerals found in `ref=*`, though the Persian numerals are specified in `ref:fa=*` which may be helpful when implementing language switching in the future (#21).

![Screenshot from 2022-06-27 20-04-03](https://user-images.githubusercontent.com/1732117/176059515-55428159-2a69-4fa1-bdad-749c0dd0d8ac.png)