### PR TITLE
Add shields for Venezuela

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -116,6 +116,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 
 .ca,
 .us,
+.ve,
 .gh,
 .bd,
 .cn,

--- a/icons/shield40_ve_t.svg
+++ b/icons/shield40_ve_t.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="20" overflow="visible" xmlns="http://www.w3.org/2000/svg">
+ <path style="fill:#fff;stroke:#000;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M 0.5,0.5 C 2,1 2.5,2 2.5,3 v 12 c 0,1.385 1.115,2.5 2.5,2.5 h 4 c 1,0 1.5,0.5 2,2 0.5,-1.5 1,-2 2,-2 h 4 c 1.385,0 2.5,-1.115 2.5,-2.5 V 3 c 0,-1 0.5,-2 2,-2.5 z"/>
+</svg>

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2397,6 +2397,56 @@ export function loadShields(shieldImages) {
     (county) => (shields[`US:WY:${county}`] = pentagonShieldBlueYellow)
   );
 
+  // SOUTH AMERICA
+
+  // Venezuela
+  [
+    "AM",
+    "AN",
+    "AP",
+    "AR",
+    "BA",
+    "BO",
+    "CA",
+    "CO",
+    "DA",
+    "DC",
+    "FA",
+    "GU",
+    "LA",
+    "ME",
+    "MI",
+    "MO",
+    "NE",
+    "PO",
+    "SU",
+    "TA",
+    "TR",
+    "VA",
+    "YA",
+    "ZU",
+  ].forEach(
+    (state) =>
+      ([
+        shields[`VE:T:${state}`],
+        shields[`VE:L:${state}`],
+        shields[`VE:R:${state}`],
+      ] = [
+        {
+          backgroundImage: shieldImages.shield40_ve_t,
+          textColor: Color.shields.black,
+          padding: {
+            left: 4,
+            right: 4,
+            top: 3,
+            bottom: 5,
+          },
+        },
+        ovalShield(Color.shields.white, Color.shields.black),
+        diamondShield,
+      ])
+  );
+
   // AFRICA
 
   // Ghana


### PR DESCRIPTION
Fixes #424.

After prefixes are removed from `ref=*` values on Venezuelan route relations, @ZeLonewolf can run a data update. I'll then post new screenshots with the new `ref=*` values.

_Después de eliminar los prefijos de los valores `ref=*` en las relaciones de ruta venezolanas, @ZeLonewolf puede ejecutar una actualización de datos. Luego publicaré nuevas capturas de pantalla con los nuevos valores `ref=*`._

![Screenshot from 2022-06-28 21-07-46](https://user-images.githubusercontent.com/1732117/176329669-18c012b4-84ac-4010-9989-374c2b18d23f.png)
