### PR TITLE
Add Uruguay shields

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -116,6 +116,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 
 .ca,
 .us,
+.uy,
 .gh,
 .bd,
 .cn,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2397,6 +2397,11 @@ export function loadShields(shieldImages) {
     (county) => (shields[`US:WY:${county}`] = pentagonShieldBlueYellow)
   );
 
+  // SOUTH AMERICA
+
+  // Uruguay
+  shields["UY"] = homeDownBlueWhiteShield;
+
   // AFRICA
 
   // Ghana


### PR DESCRIPTION
Adds shields for Uruguay.

National routes of Uruguay are tagged `network=UY`, and have a blue home-plate shield.

![Screenshot from 2022-07-01 18-05-48](https://user-images.githubusercontent.com/1732117/176973547-43c105ed-072c-44b4-a1d2-b468f2d90e1d.png)