### PR TITLE
Add shields for New Zealand urban roads

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3149,6 +3149,7 @@ export function loadShields(shieldImages) {
       bottom: 5,
     },
   };
+  shields["NZ:UR"] = homeDownWhiteShield;
 
   // Ref-specific cases. Each entry should be documented in CONTRIBUTE.md
 


### PR DESCRIPTION
Adds shields for New Zealand's other numerical network, urban roads.

![Screenshot from 2022-07-04 08-57-40](https://user-images.githubusercontent.com/1732117/177159908-15de955d-4fdf-4e75-9065-fcc29a329a32.png)
