### PR TITLE
Add Chile to shield coverage world map

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -116,6 +116,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 
 .ca,
 .us,
+.cl,
 .co,
 .uy,
 .ve,


### PR DESCRIPTION
This is a quick followup to #474 that adds Chile to the shield coverage world map in the readme, now that there’s basic coverage of that country’s shields.