### PR TITLE
Change CTRMA shield border to yellow

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -302,6 +302,11 @@ export function loadShields(shieldImages) {
     textColor: Color.shields.white,
   };
 
+  let homeDownShieldBlueRed = {
+    ...homeDownShieldBlue,
+    backgroundImage: shieldImages.shield_home_blue_red_3,
+  };
+
   // Hexagon shields
   let hexagonVerticalShieldYellow = {
     backgroundImage: shieldImages.shield_hex_vert_yellow,
@@ -2103,12 +2108,17 @@ export function loadShields(shieldImages) {
     ["R"]
   );
   shields["US:TX:NASA"] = banneredShield(shields["US:TX"], ["NASA"]);
-  shields["US:TX:Toll"] = roundedRectShield(
+
+  // Texas toll roads
+  shields["US:TX:Toll"] = shields["US:TX:NTTA"] = roundedRectShield(
     Color.shields.blue,
     Color.shields.white
   );
-  shields["US:TX:CTRMA"] = shields["US:TX:Toll"];
-  shields["US:TX:NTTA"] = shields["US:TX:Toll"];
+  shields["US:TX:CTRMA"] = roundedRectShield(
+    Color.shields.blue,
+    Color.shields.yellow,
+    Color.shields.white
+  );
   shields["US:TX:Express:Toll"] = banneredShield(shields["US:TX:Toll"], [
     "EXPR",
   ]);
@@ -2117,10 +2127,10 @@ export function loadShields(shieldImages) {
     "EXPR",
     "LOOP",
   ]);
-  shields["US:TX:Montgomery:MCTRA"] = {
-    ...homeDownShieldBlue,
-    backgroundImage: shieldImages.shield_home_blue_red_3,
-  };
+  shields["US:TX:Montgomery:MCTRA"] = homeDownShieldBlueRed;
+  // HCTRA and FBCTRA: see ref-specific cases below
+
+  // Texas county roads
   [
     "Anderson",
     "Blanco",


### PR DESCRIPTION
The Central Texas Regional Mobility Authority actually has a yellow-bordered shield for toll roads, unlike TxDOT and NTTA.

![Screenshot from 2022-07-10 14-02-52](https://user-images.githubusercontent.com/1732117/178156704-2992d455-9eca-443c-90b9-2701b8f59f50.png)
![183A_Toll_Road](https://user-images.githubusercontent.com/1732117/178156710-da3a3a06-021a-4bc3-a201-ac89646a09bc.svg)
