### PR TITLE
Remove unused trapezoid shield

### DIFF
--- a/icons/shield_trapezoid_green_yellow_3.svg
+++ b/icons/shield_trapezoid_green_yellow_3.svg
@@ -1,3 +1,0 @@
-<svg width="26" height="20" xmlns="http://www.w3.org/2000/svg">
- <path d="m 0.5,0.5 4,19 h 17 l 4,-19 z" fill="#fff" stroke="#000" style="fill:#006747;stroke:#ffcd00"/>
-</svg>

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -223,10 +223,7 @@ export function loadShields(shieldImages) {
 
   let trapezoidUpShieldGreenYellow = {
     ...trapezoidUpShieldBlackYellow,
-    backgroundImage: [
-      shieldImages.shield_trapezoid_green_yellow_2,
-      shieldImages.shield_trapezoid_green_yellow_3,
-    ],
+    backgroundImage: shieldImages.shield_trapezoid_green_yellow_2,
   };
 
   let trapezoidDownShield = {


### PR DESCRIPTION
Removes the wide variant of the yellow-bordered green trapezoid shield. This shield design is assigned only to Halton Region, Ontario, Canada, which does not signpost any routes with 3 or more digits.