### PR TITLE
Add U.S. insular areas to shield coverage world map

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -167,7 +167,12 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .ua,
 .xk,
 .nz,
-.cw { fill: #8250df; }
+.cw,
+.as,
+.gu,
+.mp,
+.nm,
+.vi { fill: #8250df; }
 
 /* Color individual borders
 For example, to color the border between Angola and Namibia in green, add this line in the space below:

--- a/scripts/status_map.js
+++ b/scripts/status_map.js
@@ -9,6 +9,15 @@ function fillPaths(svg, codes) {
     // Curaçao routes use NL prefix with the Netherlands.
     selectors.add(".cw");
   }
+  if (selectors.has(".us")) {
+    // Routes in United States insular areas use US prefix with the U.S.
+    selectors.add(".as");
+    selectors.add(".gu");
+    selectors.add(".mp");
+    selectors.add(".nm");
+    //selectors.add(".pr");
+    selectors.add(".vi");
+  }
   return svg.replace(".supported", new Array(...selectors).join(",\n"));
 }
 


### PR DESCRIPTION
Added United States insular areas other than Puerto Rico (#240) to the shield coverage world map for consistency with the shield coverage U.S. map.