### PR TITLE
Add US:I:Future

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -673,6 +673,7 @@ export function loadShields(shieldImages) {
   };
 
   shields["US:I:Alternate"] = banneredShield(shields["US:I"], ["ALT"]);
+  shields["US:I:Future"] = banneredShield(shields["US:I"], ["FUT"]);
   shields["US:I:Truck"] = banneredShield(shields["US:I"], ["TRK"]);
   shields["US:I:Express"] = banneredShield(shields["US:I"], ["EXPR"]);
   shields["US:I:Express:Toll"] = shields["US:I:Express"];


### PR DESCRIPTION
Relations with `network=US:I:Future` and `ref=*` appear to represent "Future" interstate routes that are signed in the field with real Interstate shields that say "Future" in the red part of the shield, or as a plaque. This is distinct from e.g. "Future I-nn Corridor" that are not signed as such, and are tagged with `fut_ref=*`.

Add a FUT banner to render these.

Future I-86 and Future I-99 _might_ be mistagged — will render here but might be signed in the field as "Future Corridor" — but I'm not sure. The other ones are all in NC and look correct if Wikipedia can be trusted.