### PR TITLE
Add highways under construction

### DIFF
--- a/src/americana.js
+++ b/src/americana.js
@@ -9,6 +9,7 @@ import * as ShieldDef from "./js/shield_defs.js";
 import * as lyrAeroway from "./layer/aeroway.js";
 import * as lyrBackground from "./layer/background.js";
 import * as lyrBoundary from "./layer/boundary.js";
+import * as lyrConstruction from "./layer/construction.js";
 import * as lyrHighwayShield from "./layer/highway_shield.js";
 import * as lyrOneway from "./layer/oneway.js";
 import * as lyrPark from "./layer/park.js";
@@ -64,6 +65,8 @@ americanaLayers.push(
 
   lyrBackground.pierArea,
   lyrBackground.pierLine,
+
+  lyrConstruction.road,
 
   lyrRoad.motorwayLinkTunnel.casing(),
   lyrRoad.trunkLinkTunnel.casing(),
@@ -407,6 +410,8 @@ americanaLayers.push(
   lyrRoadLabel.minor,
   lyrRoadLabel.service,
   lyrRoadLabel.smallService,
+
+  lyrConstruction.label,
 
   lyrPark.label,
   lyrPark.parkLabel,

--- a/src/layer/construction.js
+++ b/src/layer/construction.js
@@ -60,7 +60,7 @@ export const road = {
       "interpolate",
       ["exponential", 2],
       ["zoom"],
-      12,
+      11,
       0,
       20,
       2,

--- a/src/layer/construction.js
+++ b/src/layer/construction.js
@@ -1,7 +1,7 @@
 const majorConstruction = [
-  "any",
-  ["in", "motorway", ["get", "class"]],
-  ["in", "trunk", ["get", "class"]],
+  "match",
+  ["get", "class"],
+  ["motorway_construction", "trunk_construction"],
 ];
 
 const constructionColor = [
@@ -9,11 +9,11 @@ const constructionColor = [
   ["exponential", 2],
   ["zoom"],
   10,
-  ["case", majorConstruction, "lightcoral", "lightslategray"],
+  [...majorConstruction, "lightcoral", "lightslategray"],
   13,
-  ["case", majorConstruction, "maroon", "lightslategray"],
+  [...majorConstruction, "maroon", "lightslategray"],
   15,
-  ["case", majorConstruction, "maroon", "slategray"],
+  [...majorConstruction, "maroon", "slategray"],
 ];
 
 const constructionFilter = [

--- a/src/layer/construction.js
+++ b/src/layer/construction.js
@@ -43,12 +43,13 @@ export const road = {
   paint: {
     "line-color": constructionColor,
     "line-opacity": ["interpolate", ["exponential", 2], ["zoom"], 10, 0, 11, 1],
+    "line-blur": 0.75,
     "line-width": 1,
-    "line-dasharray": [2, 1],
+    "line-dasharray": [2.5, 1.25],
     "line-offset": 0,
     "line-gap-width": [
       "interpolate",
-      ["exponential", 2],
+      ["exponential", 1.2],
       ["zoom"],
       11,
       0,

--- a/src/layer/construction.js
+++ b/src/layer/construction.js
@@ -1,0 +1,91 @@
+const majorConstruction = [
+  "any",
+  ["in", "motorway", ["get", "class"]],
+  ["in", "trunk", ["get", "class"]],
+];
+
+const constructionColor = [
+  "interpolate-lab",
+  ["exponential", 2],
+  ["zoom"],
+  10,
+  ["case", majorConstruction, "lightcoral", "lightslategray"],
+  13,
+  ["case", majorConstruction, "maroon", "lightslategray"],
+  15,
+  ["case", majorConstruction, "maroon", "slategray"],
+];
+
+const constructionFilter = [
+  "in",
+  ["get", "class"],
+  [
+    "literal",
+    [
+      "motorway_construction",
+      "trunk_construction",
+      "primary_construction",
+      "secondary_construction",
+      "tertiary_construction",
+      "minor_construction",
+      "service_construction",
+    ],
+  ],
+];
+
+export const road = {
+  id: "highway-construction",
+  type: "line",
+  source: "openmaptiles",
+  "source-layer": "transportation",
+  filter: constructionFilter,
+  minzoom: 9,
+  paint: {
+    "line-color": constructionColor,
+    "line-opacity": ["interpolate", ["exponential", 2], ["zoom"], 10, 0, 11, 1],
+    "line-width": [
+      "interpolate",
+      ["exponential", 2],
+      ["zoom"],
+      9,
+      0,
+      12,
+      ["case", majorConstruction, 1, 0.5],
+      15,
+      1,
+    ],
+    "line-dasharray": [2, 1],
+    "line-offset": 0,
+    "line-gap-width": [
+      "interpolate",
+      ["exponential", 2],
+      ["zoom"],
+      12,
+      0,
+      20,
+      2,
+    ],
+  },
+};
+
+export const label = {
+  id: "highway-construction-name",
+  type: "symbol",
+  source: "openmaptiles",
+  "source-layer": "transportation_name",
+  filter: constructionFilter,
+  minzoom: 15,
+  layout: {
+    "symbol-placement": "line",
+    "text-font": ["Metropolis Light"],
+    "text-size": 12,
+    "text-field": "{name}",
+    "text-anchor": "bottom",
+  },
+  paint: {
+    "text-color": constructionColor,
+    "text-halo-color": "white",
+    "text-halo-width": 2,
+    "text-halo-blur": 0.5,
+  },
+};

--- a/src/layer/construction.js
+++ b/src/layer/construction.js
@@ -43,17 +43,7 @@ export const road = {
   paint: {
     "line-color": constructionColor,
     "line-opacity": ["interpolate", ["exponential", 2], ["zoom"], 10, 0, 11, 1],
-    "line-width": [
-      "interpolate",
-      ["exponential", 2],
-      ["zoom"],
-      9,
-      0,
-      12,
-      ["case", majorConstruction, 1, 0.5],
-      15,
-      1,
-    ],
+    "line-width": 1,
     "line-dasharray": [2, 1],
     "line-offset": 0,
     "line-gap-width": [


### PR DESCRIPTION
Fixes #212

Treatment is minimalist. Main purpose served is to identify what a gap in the road network might represent, particularly for a long-term road closure. Only attributes included are whether it is trunk/motorway (red) or other roads (blue). Includes the name, in that same color, which additionally contrasts with regular roads.

Omits path, track, and raceway.

<img width="568" alt="image" src="https://user-images.githubusercontent.com/23022/179835208-d583ffd5-d12a-4d4d-b7d1-b7b8da28f356.png">

Doesn't use the words "under construction"; the dotted line should imply the noncorporeal nature of the feature, and the color (and the geometry these features tend to have) should clue the viewer that this is related to the highways.

Includes the name property only. While some roads under construction might only have a ref and some route relations, it generally looks weird to have shields floating above roads that aren't there yet, and it looks perfectly fine for a highway under construction to not have any label.

Layer count: 2.
Avoids attempting to render "the entire road style, but dashed", as that proved to be impracticable in #215, in taming the style, the number of layers, and visually. Ignoring bridge/tunnel is probably the right choice.

This should be sufficiently distinct from railways, unpaved roads, and admin_8 borders, but maybe not.

<img width="480" alt="image" src="https://user-images.githubusercontent.com/23022/179839104-c2ae0e99-9c3b-48de-8be9-5a3ead70e4bb.png">
<img width="1491" alt="image" src="https://user-images.githubusercontent.com/23022/179839120-a1289abf-29dd-4b5c-b780-7f02cd31af85.png">
