### PR TITLE
Add intertate downtown, identical to business

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -687,6 +687,8 @@ export function loadShields(shieldImages) {
   };
 
   shields["US:I:Business:Spur"] = shields["US:I:Business:Loop"];
+  shields["US:I:Downtown:Loop"] = shields["US:I:Business:Loop"];
+  shields["US:I:Downtown:Spur"] = shields["US:I:Business:Spur"];
 
   // US Highways
   shields["US:US"] = badgeShield;


### PR DESCRIPTION
In Sioux Falls, there are Business Interstate Spur/Loop (29, 90, 229) except they're "Downtown" instead of "Business". While we don't include those words and just use green shields, the distinction exists.

![Screenshot_20220722-083448](https://user-images.githubusercontent.com/23022/180440265-236e2203-488a-4552-9581-eec955026851.png)
