### PR TITLE
Re-order water layer

### DIFF
--- a/src/americana.js
+++ b/src/americana.js
@@ -59,10 +59,6 @@ americanaLayers.push(
   lyrFerry.ferry,
   lyrFerry.ferryLabel,
 
-  lyrWater.waterwayLabel,
-  lyrWater.waterLabel,
-  lyrWater.waterPointLabel,
-
   lyrBackground.pierArea,
   lyrBackground.pierLine,
 
@@ -354,6 +350,10 @@ americanaLayers.push(
   lyrRoadLabel.smallService,
 
   lyrConstruction.label,
+
+  lyrWater.waterwayLabel,
+  lyrWater.waterLabel,
+  lyrWater.waterPointLabel,
 
   lyrPark.label,
   lyrPark.parkLabel,


### PR DESCRIPTION
Fixes #507

This PR re-orders the water layer labels to be on top of other feature types.  The original thought of putting the water labels lower was to have it go "under" things like bridges, but I think that approach is no longer in vogue and a bit to avant garde for what we're trying to do here.

The screen shot below still feels a little clash-y but it solves the specific issue described in the bug report.

![image](https://user-images.githubusercontent.com/3254090/180585729-97c84f61-2ca9-4b37-a4f9-de81226ddf45.png)

