### PR TITLE
Remove Interstate layer from high zoom

### DIFF
--- a/src/layer/road.js
+++ b/src/layer/road.js
@@ -122,13 +122,24 @@ function uniqueLayerID(hwyClass, link, part, brunnel, constraints) {
   return layerID;
 }
 
-function baseRoadLayer(highwayClass, id, brunnel, minzoom, link, constraints) {
+function baseRoadLayer(
+  highwayClass,
+  id,
+  brunnel,
+  minzoom,
+  maxzoom,
+  link,
+  constraints
+) {
   var layer = Util.layerClone(
     defRoad,
     uniqueLayerID(highwayClass, link, id, brunnel, constraints)
   );
   layer.filter = filterRoad(highwayClass, link, brunnel);
   layer.minzoom = minzoom;
+  if (maxzoom) {
+    layer.maxzoom = maxzoom;
+  }
   return layer;
 }
 
@@ -140,6 +151,7 @@ class Road {
       "fill",
       this.brunnel,
       this.minZoomFill,
+      this.maxZoomFill,
       this.link,
       this.constraints
     );
@@ -156,6 +168,7 @@ class Road {
       "casing",
       this.brunnel,
       this.minZoomCasing,
+      this.maxZoomCasing,
       this.link,
       this.constraints
     );
@@ -179,6 +192,7 @@ class Road {
       "surface",
       this.brunnel,
       Math.min(this.minZoomCasing, this.minZoomFill),
+      Math.max(this.maxZoomCasing, this.maxZoomFill),
       this.link,
       this.constraints
     );


### PR DESCRIPTION
The `InterstateMotorway` class has instance variables `maxZoomCasing` and `maxZoomFill` that were unused. This PR uses them to block the layer from showing up at higher zoom and covering motorway brunnels.

before:
![Screenshot from 2022-07-23 12-03-46](https://user-images.githubusercontent.com/1732117/180613047-a1793eb0-48c7-4bac-ac1f-61032042b3ce.png)

after
![Screenshot from 2022-07-23 12-02-58](https://user-images.githubusercontent.com/1732117/180613032-5660f245-c158-4b7e-abc6-6bd04fb260f0.png)
