### PR TITLE
Change label halo color for roads under construction

### DIFF
--- a/src/layer/construction.js
+++ b/src/layer/construction.js
@@ -1,3 +1,5 @@
+import * as Color from "../constants/color.js";
+
 const majorConstruction = [
   "match",
   ["get", "class"],
@@ -75,7 +77,7 @@ export const label = {
   },
   paint: {
     "text-color": constructionColor,
-    "text-halo-color": "white",
+    "text-halo-color": Color.backgroundFill,
     "text-halo-width": 2,
     "text-halo-blur": 0.5,
   },


### PR DESCRIPTION
Changes the label halo added in #502 from white to the background fill color to match other road labels.

![Screenshot from 2022-07-23 15-41-27](https://user-images.githubusercontent.com/1732117/180620595-659e274c-6905-4d57-88db-f6093cb30d8f.png)