### PR TITLE
Add a debug statement to output the layer count

### DIFF
--- a/src/americana.js
+++ b/src/americana.js
@@ -384,6 +384,8 @@ americanaLayers.push(
   lyrPlace.continent
 );
 
+console.debug(`Loaded ${americanaLayers.length} layers`);
+
 var getUrl = window.location;
 var baseUrl = getUrl.protocol + "//" + getUrl.host + getUrl.pathname;
 


### PR DESCRIPTION
This PR adds a console debug statement to output the total number of layers.  This is useful in assessing changes in layer count for a PR.  In Google Chrome, the debug log can be access by clicking the "All levels" drop down and changing the log to verbose.