### PR TITLE
Add a console debug when plain shield will be used

### DIFF
--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -261,6 +261,7 @@ function getShieldDef(routeDef) {
 
   if (shieldDef == null) {
     // Default to plain black text with halo and no background shield
+    console.debug("Generic shield for", JSON.stringify(routeDef));
     return isValidRef(routeDef.ref) ? ShieldDef.shields["default"] : null;
   }
 


### PR DESCRIPTION
When no shield is produced we log a warning, already.

When the generic floating number without a shield is produced, add a debug log. Rationale: These are at least visible on the map and so aren't necessarily something that must be fixed here (for instance, they might require changes to the tile build to understand different `route=*` values…), and they're also visible in their own right and will prompt you to go digging if you want.

However, logging the network and ref values will aid quick debugging.

<img width="751" alt="image" src="https://user-images.githubusercontent.com/23022/181800661-db2217ab-d456-425b-bdb8-f2c6b4852107.png">
