### PR TITLE
Draw waterway labels before bridge, road labels

### DIFF
--- a/src/americana.js
+++ b/src/americana.js
@@ -310,8 +310,6 @@ var bridgeLayers = [
   lyrRoad.secondaryTollBridge.surface(),
   lyrRoad.primaryTollBridge.surface(),
 
-  lyrTransportationLabel.bridgeSpacer,
-
   lyrOneway.bridge,
   lyrOneway.bridgeLink,
 ];
@@ -339,11 +337,12 @@ bridgeLayers.forEach((layer) =>
 
 americanaLayers.push(
   //The labels at the end of the list draw on top of the layers at the beginning.
-  lyrTransportationLabel.label,
-
   lyrWater.waterwayLabel,
   lyrWater.waterLabel,
   lyrWater.waterPointLabel,
+
+  lyrTransportationLabel.bridgeSpacer,
+  lyrTransportationLabel.label,
 
   lyrPark.label,
   lyrPark.parkLabel,


### PR DESCRIPTION
Restored the behavior prior to #509 that waterway labels avoid bridges and road name labels.

The bridge spacer label needs to be drawn before the waterway label layer, but the waterway label layer is currently drawn after the road name label layer. Moving the bridge spacer label after the waterway label layer would cause road labels to avoid bridges too. (It would be desirable for route shields to avoid short bridges, where they could cause some ambiguity, but road names and route shields shouldn’t avoid long bridges, so this ordering would be inappropriate.)

Before and after:

[<img src="https://user-images.githubusercontent.com/1231218/181852285-8ffa1244-00e7-4d4c-a388-6fa14e23eb81.png" width="600" alt="Before">](https://zelonewolf.github.io/openstreetmap-americana/#13/39.79199/-84.18473) [<img src="https://user-images.githubusercontent.com/1231218/181852307-5ab821df-c96e-4748-bacf-898f94571bb6.png" width="600" alt="After">](http://localhost:1776/#13/39.79199/-84.18473)

Fixes #522. Net zero layer increase.