### PR TITLE
Add shields for Mendocino County, California

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -925,6 +925,10 @@ export function loadShields(shieldImages) {
   };
   shields["US:CA:Business"] = banneredShield(shields["US:CA"], ["BUS"]);
   shields["US:CA:CR"] = pentagonShieldBlueYellow;
+  shields["US:CA:Mendocino"] = roundedRectShield(
+    Color.shields.green,
+    Color.shields.white
+  );
 
   // Colorado
   shields["US:CO"] = {


### PR DESCRIPTION
Roads signposted by Mendocino County, California have a white-on-green square shield: https://wiki.openstreetmap.org/wiki/Talk:California/State_Highway_Relations#Mendocino_County