### PR TITLE
Add debug variable to specify shield text halo color

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,9 @@ The `loadShields` function in js/shield_defs.js contains a definition object for
 - **`textLayoutConstraint`** – A strategy for constraining the text within the background image, useful for shields of certain shapes. By default, the text will expand to fill a rectangle bounded by the specified padding while maintaining the same aspect ratio.
 - **`verticalReflect`** – Set this property to `true` to draw the shield image upside-down.
 
-If special code is necessary to style a specific `ref` in a particular network, `overrideByRef` can be used to define and override any of the above properties. `overrideByRef` is an object mapping `ref` values to partial shield definition objects, containing whichever properties are to be overridden for that particular `ref` value. If necessary, this can be used to override the entire shield definition.
+In addition to `textHaloColor`, the config variable **`SHIELD_TEXT_HALO_COLOR`** can be used to override the text halo color on all shields. This can be helpful to avoid collisions with other design features when determining padding values. For example, set `SHIELD_TEXT_HALO_COLOR` in src/config.js to `"magenta"` to display a magenta halo around all shield text.
+
+If special code is necessary to style a specific `ref` in a particular network, **`overrideByRef`** can be used to define and override any of the above properties. `overrideByRef` is an object mapping `ref` values to partial shield definition objects, containing whichever properties are to be overridden for that particular `ref` value. If necessary, this can be used to override the entire shield definition.
 
 Additionally, **`refsByWayName`** is an object mapping way names to text that can be superimposed on the background as a fallback for a missing `ref` value. (`refsByWayName` implies `notext`.) This temporary fallback is designed for use in [limited situations](https://wiki.openstreetmap.org/wiki/United_States/Unusual_highway_networks). In the future, it is expected that these initialisms will be encoded on the server side by processing appropriate tagging which holds the initialism in the database.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,7 @@ The `loadShields` function in js/shield_defs.js contains a definition object for
 - **`textLayoutConstraint`** – A strategy for constraining the text within the background image, useful for shields of certain shapes. By default, the text will expand to fill a rectangle bounded by the specified padding while maintaining the same aspect ratio.
 - **`verticalReflect`** – Set this property to `true` to draw the shield image upside-down.
 
-In addition to `textHaloColor`, the config variable **`SHIELD_TEXT_HALO_COLOR`** can be used to override the text halo color on all shields. This can be helpful to avoid collisions with other design features when determining padding values. For example, set `SHIELD_TEXT_HALO_COLOR` in src/config.js to `"magenta"` to display a magenta halo around all shield text.
+In addition to `textHaloColor`, the config variable **`SHIELD_TEXT_HALO_COLOR_OVERRIDE`** can be used to override the text halo color on all shields. This can be helpful to avoid collisions with other design features when determining padding values. For example, set `SHIELD_TEXT_HALO_COLOR_OVERRIDE` in src/config.js to `"magenta"` to display a magenta halo around all shield text.
 
 If special code is necessary to style a specific `ref` in a particular network, **`overrideByRef`** can be used to define and override any of the above properties. `overrideByRef` is an object mapping `ref` values to partial shield definition objects, containing whichever properties are to be overridden for that particular `ref` value. If necessary, this can be used to override the entire shield definition.
 

--- a/src/configs/config.aws.js
+++ b/src/configs/config.aws.js
@@ -5,9 +5,14 @@ Planetiler tile server, hosted at AWS
 */
 const OPENMAPTILES_URL =
   "https://6ug7hetxl9.execute-api.us-east-2.amazonaws.com/data/v3.json";
-const SHIELD_TEXT_HALO_COLOR = null;
+
+/*
+Uncomment this variable to override the shield text halo color.  Useful while testing shield design changes.
+Accepts an HTML color name, hex code, or other CSS color value.
+*/
+//const SHIELD_TEXT_HALO_COLOR_OVERRIDE = "magenta";
 
 export default {
   OPENMAPTILES_URL,
-  SHIELD_TEXT_HALO_COLOR,
+  //SHIELD_TEXT_HALO_COLOR_OVERRIDE,
 };

--- a/src/configs/config.aws.js
+++ b/src/configs/config.aws.js
@@ -7,12 +7,12 @@ const OPENMAPTILES_URL =
   "https://6ug7hetxl9.execute-api.us-east-2.amazonaws.com/data/v3.json";
 
 /*
-Uncomment this variable to override the shield text halo color.  Useful while testing shield design changes.
+Uncomment this variable to override the shield text halo color. Useful while testing shield design changes.
 Accepts an HTML color name, hex code, or other CSS color value.
 */
-//const SHIELD_TEXT_HALO_COLOR_OVERRIDE = "magenta";
+const SHIELD_TEXT_HALO_COLOR_OVERRIDE = null;
 
 export default {
   OPENMAPTILES_URL,
-  //SHIELD_TEXT_HALO_COLOR_OVERRIDE,
+  SHIELD_TEXT_HALO_COLOR_OVERRIDE,
 };

--- a/src/configs/config.aws.js
+++ b/src/configs/config.aws.js
@@ -5,7 +5,9 @@ Planetiler tile server, hosted at AWS
 */
 const OPENMAPTILES_URL =
   "https://6ug7hetxl9.execute-api.us-east-2.amazonaws.com/data/v3.json";
+const SHIELD_TEXT_HALO_COLOR = null;
 
 export default {
   OPENMAPTILES_URL,
+  SHIELD_TEXT_HALO_COLOR,
 };

--- a/src/configs/config.localhost.js
+++ b/src/configs/config.localhost.js
@@ -6,12 +6,12 @@
 const OPENMAPTILES_URL = "http://localhost:8080/data/v3.json";
 
 /*
-Uncomment this variable to override the shield text halo color.  Useful while testing shield design changes.
+Uncomment this variable to override the shield text halo color. Useful while testing shield design changes.
 Accepts an HTML color name, hex code, or other CSS color value.
 */
-//const SHIELD_TEXT_HALO_COLOR_OVERRIDE = "magenta";
+const SHIELD_TEXT_HALO_COLOR_OVERRIDE = null;
 
 export default {
   OPENMAPTILES_URL,
-  //SHIELD_TEXT_HALO_COLOR_OVERRIDE,
+  SHIELD_TEXT_HALO_COLOR_OVERRIDE,
 };

--- a/src/configs/config.localhost.js
+++ b/src/configs/config.localhost.js
@@ -4,9 +4,14 @@
   Locally-run openmaptiles build
 */
 const OPENMAPTILES_URL = "http://localhost:8080/data/v3.json";
-const SHIELD_TEXT_HALO_COLOR = null;
+
+/*
+Uncomment this variable to override the shield text halo color.  Useful while testing shield design changes.
+Accepts an HTML color name, hex code, or other CSS color value.
+*/
+//const SHIELD_TEXT_HALO_COLOR_OVERRIDE = "magenta";
 
 export default {
   OPENMAPTILES_URL,
-  SHIELD_TEXT_HALO_COLOR,
+  //SHIELD_TEXT_HALO_COLOR_OVERRIDE,
 };

--- a/src/configs/config.localhost.js
+++ b/src/configs/config.localhost.js
@@ -4,7 +4,9 @@
   Locally-run openmaptiles build
 */
 const OPENMAPTILES_URL = "http://localhost:8080/data/v3.json";
+const SHIELD_TEXT_HALO_COLOR = null;
 
 export default {
   OPENMAPTILES_URL,
+  SHIELD_TEXT_HALO_COLOR,
 };

--- a/src/configs/config.maptiler.js
+++ b/src/configs/config.maptiler.js
@@ -18,9 +18,11 @@ const ATTRIBUTION_LOGO = `
 </a>`;
 const ATTRIBUTION_TEXT =
   '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a>';
+const SHIELD_TEXT_HALO_COLOR = null;
 
 export default {
   OPENMAPTILES_URL,
   ATTRIBUTION_LOGO,
   ATTRIBUTION_TEXT,
+  SHIELD_TEXT_HALO_COLOR,
 };

--- a/src/configs/config.maptiler.js
+++ b/src/configs/config.maptiler.js
@@ -18,11 +18,16 @@ const ATTRIBUTION_LOGO = `
 </a>`;
 const ATTRIBUTION_TEXT =
   '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a>';
-const SHIELD_TEXT_HALO_COLOR = null;
+
+/*
+Uncomment this variable to override the shield text halo color.  Useful while testing shield design changes.
+Accepts an HTML color name, hex code, or other CSS color value.
+*/
+//const SHIELD_TEXT_HALO_COLOR_OVERRIDE = "magenta";
 
 export default {
   OPENMAPTILES_URL,
   ATTRIBUTION_LOGO,
   ATTRIBUTION_TEXT,
-  SHIELD_TEXT_HALO_COLOR,
+  //SHIELD_TEXT_HALO_COLOR_OVERRIDE,
 };

--- a/src/configs/config.maptiler.js
+++ b/src/configs/config.maptiler.js
@@ -20,14 +20,14 @@ const ATTRIBUTION_TEXT =
   '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a>';
 
 /*
-Uncomment this variable to override the shield text halo color.  Useful while testing shield design changes.
+Uncomment this variable to override the shield text halo color. Useful while testing shield design changes.
 Accepts an HTML color name, hex code, or other CSS color value.
 */
-//const SHIELD_TEXT_HALO_COLOR_OVERRIDE = "magenta";
+const SHIELD_TEXT_HALO_COLOR_OVERRIDE = null;
 
 export default {
   OPENMAPTILES_URL,
   ATTRIBUTION_LOGO,
   ATTRIBUTION_TEXT,
-  //SHIELD_TEXT_HALO_COLOR_OVERRIDE,
+  SHIELD_TEXT_HALO_COLOR_OVERRIDE,
 };

--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -214,8 +214,8 @@ function drawShieldText(ctx, shieldDef, routeDef) {
   textLayout.yBaseline +=
     bannerCount * ShieldDef.bannerSizeH + ShieldDef.topPadding;
 
-  if (config.SHIELD_TEXT_HALO_COLOR) {
-    ctx.strokeStyle = config.SHIELD_TEXT_HALO_COLOR;
+  if (config.SHIELD_TEXT_HALO_COLOR_OVERRIDE) {
+    ctx.strokeStyle = config.SHIELD_TEXT_HALO_COLOR_OVERRIDE;
     ShieldText.drawShieldHaloText(ctx, routeDef.ref, textLayout);
   } else if (shieldDef.textHaloColor) {
     ctx.strokeStyle = shieldDef.textHaloColor;

--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import config from "../config.js";
+
 import * as ShieldDef from "./shield_defs.js";
 import * as ShieldText from "./shield_text.js";
 import * as ShieldDraw from "./shield_canvas_draw.js";
@@ -212,7 +214,10 @@ function drawShieldText(ctx, shieldDef, routeDef) {
   textLayout.yBaseline +=
     bannerCount * ShieldDef.bannerSizeH + ShieldDef.topPadding;
 
-  if (shieldDef.textHaloColor) {
+  if (config.SHIELD_TEXT_HALO_COLOR) {
+    ctx.strokeStyle = config.SHIELD_TEXT_HALO_COLOR;
+    ShieldText.drawShieldHaloText(ctx, routeDef.ref, textLayout);
+  } else if (shieldDef.textHaloColor) {
     ctx.strokeStyle = shieldDef.textHaloColor;
     ShieldText.drawShieldHaloText(ctx, routeDef.ref, textLayout);
   }


### PR DESCRIPTION
Adds a debug variable that overrides the text halo color on shields. This can be helpful to ensure text doesn't collide with other design features when determining padding values for shield definitions.

```
const SHIELD_TEXT_HALO_COLOR = null;
```
![Screenshot from 2022-09-03 18-11-58](https://user-images.githubusercontent.com/1732117/188289114-a3dd2370-9b45-4207-8249-e615ab0a652e.png)
```
const SHIELD_TEXT_HALO_COLOR = "magenta";
```
![Screenshot from 2022-09-03 18-12-14](https://user-images.githubusercontent.com/1732117/188289116-ac12f46b-05f0-47b3-9e7d-c2fa6c465cce.png)