### PR TITLE
Add New Mexico frontage road shield

### DIFF
--- a/icons/shield_us_nm_frontage.svg
+++ b/icons/shield_us_nm_frontage.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 5.292 5.292" xmlns="http://www.w3.org/2000/svg">
+ <path style="fill:#fff;fill-opacity:1;stroke:#000;stroke-width:.26458333;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M 5.1593749,0.13229166 H 0.13229166 V 5.1593749 l 0.79375001,10e-8 V 4.8947917 H 2.2489583 L 2.1166667,4.6302083 h 3.0427082 z"/>
+</svg>

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1748,6 +1748,16 @@ export function loadShields(shieldImages) {
     Color.shields.pink,
     Color.shields.black
   );
+  shields["US:NM:Frontage"] = {
+    backgroundImage: shieldImages.shield_us_nm_frontage,
+    textColor: Color.shields.black,
+    padding: {
+      left: 1.5,
+      right: 1.5,
+      top: 3,
+      bottom: 5,
+    },
+  };
   [
     "Cibola",
     "Doña_Ana",

--- a/src/shieldtest.js
+++ b/src/shieldtest.js
@@ -139,22 +139,25 @@ let networks = [
   "CN:AH:expressway",
 
   // Detailed Shapes
-  "US:AL",
-  "US:AR",
-
+  "US:NV",
   "US:AZ",
-  "US:GA",
-  "US:LA",
-  "US:MO",
+  "US:NM:Frontage",
 
   "US:ND",
-  "US:NV",
+  "US:SD",
+
+  "US:MO",
+  "US:AR",
+  "US:LA",
+  "US:TX:FM",
+
+  "US:AL",
+  "US:GA",
+
   "US:OH",
   "US:OH:ASD",
   "US:OH:SCI",
   "US:OH:TUS:Salem",
-  "US:SD",
-  "US:TX:FM",
   "US:WA",
   "CA:transcanada",
   "CA:NB:primary",


### PR DESCRIPTION
Adds shields for frontage roads of New Mexico.

Also reorders the state outline shields in the shield test gallery to try to maintain unbroken strings of adjacent states.

[![Screenshot from 2022-09-26 18-01-26](https://user-images.githubusercontent.com/1732117/192388682-e933f28a-c1c6-40bb-8bbd-66b874d6406b.png) ![Screenshot from 2022-09-26 18-01-40](https://user-images.githubusercontent.com/1732117/192388683-11f6fca1-1f59-42e2-aa0f-ef2cf515f046.png)](http://localhost:1776/#15.05/32.25803/-106.7308)
