### PR TITLE
Iraq highway shields

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -126,6 +126,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .cn,
 .hk,
 .ir,
+.iq,
 .jp,
 .kr,
 .my,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2853,7 +2853,9 @@ export function loadShields(shieldImages) {
   // Iraq
   shields["IQ:national"] = roundedRectShield(
     Color.shields.green,
-    Color.shields.white
+    Color.shields.white,
+    Color.shields.white,
+    34
   );
 
   // Japan

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2850,6 +2850,12 @@ export function loadShields(shieldImages) {
     Color.shields.white
   );
 
+  // Iraq
+  shields["IQ:national"] = roundedRectShield(
+    Color.shields.green,
+    Color.shields.white
+  );
+
   // Japan
   shields["JP:E"] = roundedRectShield(Color.shields.green, Color.shields.white);
   shields["JP:national"] = triangleConvexDownShieldBlue;


### PR DESCRIPTION
Added a shield definition for Iraq (national) highways. Only highways have been mapped as relations so far; numbered freeways and roads don’t have relations yet. As in Iran (#463), route shields in Iraq bear both writing systems on separate panels, but this style is only showing the Western Arabic numerals that have been tagged in `ref`.

[<img src="https://user-images.githubusercontent.com/1231218/194745661-fa727fd7-3cfa-4a4a-b733-46c60b65d2f5.png" width="600" alt="highways">](https://zelonewolf.github.io/openstreetmap-americana/#8/32.706/44.497)