### PR TITLE
Require shield icon PRs to add lines to test gallery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,8 @@ boilerplate in `scripts/taginfo_template.json`.
 2. If you are introducing a novel approach to depicting a layer or feature
    property from the OpenMapTiles schema, document how the corresponding
    OpenStreetMap key or tag is used in `scripts/taginfo_template.json`.
+3. If any shield background icons are introduced, add lines to `src/shieldtest.js`
+   to demonstrate overlaid text on each of them.
 
 [90]: https://prettier.io/
 [svgo]: https://github.com/svg/svgo/


### PR DESCRIPTION
Since the shield test gallery's introduction (#543), it's grown a little as more shield icons have been added. This PR makes it explicit that new shield icons meant for text overlay should be added to the gallery when submitting a PR.