### PR TITLE
Add rendering for capital=3, same as capital=4

### DIFF
--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -20,6 +20,14 @@
     },
     {
       "key": "capital",
+      "value": "3",
+      "object_types": ["node"],
+      "description": "Marks the city with a state capital icon.",
+      "doc_url": "https://openmaptiles.org/schema/#capital",
+      "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/icons/star_state_capital.svg"
+    },
+    {
+      "key": "capital",
       "value": "4",
       "object_types": ["node"],
       "description": "Marks the city with a state capital icon.",

--- a/src/layer/place.js
+++ b/src/layer/place.js
@@ -12,6 +12,8 @@ const cityIcon = [
   ["get", "capital"],
   2,
   "star_nation_capital",
+  3,
+  "star_state_capital",
   4,
   "star_state_capital",
   "dot_city",


### PR DESCRIPTION
Cities with capital=3 are state capitals that are at least as important as state capitals with capital=4, so these cities should receive at least equal rendering. [Based on this OpenMapTiles comment.](https://github.com/openmaptiles/openmaptiles/pull/1401#issuecomment-1155742393).

Example: island of Sint Maarten / Saint-Martin, with a capital=3 city on each side.

| Before | After |
|---|---|
| ![Firefox_Screenshot_2022-10-10T21-08-51 519Z](https://user-images.githubusercontent.com/489845/194952727-277e41f1-b1b0-4585-a306-376a5f4086b0.png) | ![Firefox_Screenshot_2022-10-10T21-08-37 203Z](https://user-images.githubusercontent.com/489845/194952698-13f25dd0-3fac-4038-a733-59c1ee6179a5.png) |
