### PR TITLE
Atlantic City Expressway Connector shield

### DIFF
--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -85,7 +85,7 @@ function getRasterShieldBlank(shieldDef, routeDef) {
 
   //Special case where there's a defined fallback shield when no ref is tagged
   //Example: PA Turnpike
-  if (!isValidRef(routeDef.ref)) {
+  if (!isValidRef(routeDef.ref) && "norefImage" in shieldDef) {
     return shieldDef.norefImage;
   }
 

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1751,6 +1751,9 @@ export function loadShields(shieldImages) {
     backgroundImage: shieldImages.shield_us_nj_ace_noref,
     notext: true,
   };
+  shields["US:NJ:ACE:Connector"] = banneredShield(shields["US:NJ:ACE"], [
+    "CONN",
+  ]);
   shields["US:NJ:GSP"] = {
     backgroundImage: shieldImages.shield_us_nj_gsp_noref,
     notext: true,


### PR DESCRIPTION
Added a shield for the Atlantic City Expressway Connector. Fixed a regression introduced in #314 that prevented the shield definition’s `notext` option from taking effect because we kept looking for the `norefImage` option, which did not apply in this case.

[<img src="https://user-images.githubusercontent.com/1231218/203909051-a272320b-1441-4114-890b-43809c945914.png" width="400" alt="ACE Connector">](https://zelonewolf.github.io/openstreetmap-americana/#14/39.36775/-74.44771)

`norefImage` usage for the Pennsylvania Turnpike and its offshoots continues to work:

[<img src="https://user-images.githubusercontent.com/1231218/203909192-a1e748f7-8fe0-47f2-ae4c-b734c7223949.png" width="400" alt="Pennsylvania Turnpike">](https://zelonewolf.github.io/openstreetmap-americana/#13.27/40.23686/-79.60976)

Fixes #487.