### PR TITLE
Shields of Algeria

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -120,6 +120,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .co,
 .uy,
 .ve,
+.dz,
 .gh,
 .am,
 .bd,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2728,6 +2728,16 @@ export function loadShields(shieldImages) {
 
   // AFRICA
 
+  // Algeria
+  shields["DZ:highway"] = shields["DZ:national"] = roundedRectShield(
+    Color.shields.red,
+    Color.shields.white
+  );
+  shields["DZ:regional"] = roundedRectShield(
+    Color.shields.yellow,
+    Color.shields.black
+  );
+
   // Ghana
   shields["GH:national"] =
     shields["GH:inter-regional"] =


### PR DESCRIPTION
Added shields for Algeria’s highways and national and provincial routes:

[<img src="https://user-images.githubusercontent.com/1231218/204073735-aaa65de2-aa56-420f-a400-eccf0d1901f2.png" width="400" alt="Blida">](https://zelonewolf.github.io/openstreetmap-americana/#10/36.4947/2.8154)

[<img src="https://user-images.githubusercontent.com/1231218/204073803-756b5006-7b2c-4185-bddf-b8f59a218631.png" width="400" alt="Chrea">](https://zelonewolf.github.io/openstreetmap-americana/#17/36.426988/2.876301)

Fixes #571.