### PR TITLE
Haiti national, departmental route shields

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -115,6 +115,7 @@ The lines may be combined if desired:
 See the end of this file for a list of available jurisdictions and their codes. */
 
 .ca,
+.ht,
 .us,
 .cl,
 .co,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -801,6 +801,12 @@ export function loadShields(shieldImages) {
   // Yukon
   shields["CA:YT"] = roundedRectShield(Color.shields.white, Color.shields.red);
 
+  // Haiti
+  shields["HT:RN-road"] = shields["HT:RD-road"] = roundedRectShield(
+    Color.shields.blue,
+    Color.shields.white
+  );
+
   // United States
 
   // Interstate Highways


### PR DESCRIPTION
Added shields for Haiti’s national and departmental routes.

[<img src="https://user-images.githubusercontent.com/1231218/204104751-a383f434-ae10-4f97-8bb6-63d5ce9dd934.png" width="400" alt="Miragoâne">](https://zelonewolf.github.io/openstreetmap-americana/#15/18.43615/-73.07778)

Fixes #574.