### PR TITLE
Convert shield definitions to JSON

### DIFF
--- a/data/shield_defs.json
+++ b/data/shield_defs.json
@@ -1,0 +1,18805 @@
+{
+  "am:national": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AT:A-road": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AT:S-road": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AU:ACT": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AU:ACT:ALT": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:ACT:ALT_NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:ACT:ALT_S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:ACT:NH": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:ACT:NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:ACT:S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "AU:ACT:T": {
+    "backgroundImage": ["shield_pent_brown_2", "shield_pent_brown_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "AU:NSW": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AU:NSW:ALT": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:NSW:ALT_NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:NSW:ALT_S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:NSW:NH": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:NSW:NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:NSW:S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "AU:NSW:T": {
+    "backgroundImage": ["shield_pent_brown_2", "shield_pent_brown_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "AU:NT": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AU:NT:ALT": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:NT:ALT_NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:NT:ALT_S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:NT:NH": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:NT:NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:NT:S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "AU:NT:T": {
+    "backgroundImage": ["shield_pent_brown_2", "shield_pent_brown_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "AU:QLD": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AU:QLD:ALT": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:QLD:ALT_NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:QLD:ALT_S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:QLD:MR": {
+    "shape": "vertical_hexagon",
+    "offset": 4,
+    "fillColor": "white",
+    "strokeColor": "blue",
+    "radius": 0,
+    "rectWidth": 20,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "AU:QLD:NH": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:QLD:NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:QLD:S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "AU:QLD:SSTR": {
+    "shape": "rectangle",
+    "fillColor": "brown",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AU:QLD:T": {
+    "backgroundImage": ["shield_pent_brown_2", "shield_pent_brown_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "AU:SA": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AU:SA:ALT": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:SA:ALT_NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:SA:ALT_S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:SA:NH": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:SA:NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:SA:S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "AU:SA:T": {
+    "backgroundImage": ["shield_pent_brown_2", "shield_pent_brown_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "AU:TAS": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AU:TAS:ALT": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:TAS:ALT_NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:TAS:ALT_S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:TAS:NH": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:TAS:NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:TAS:S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "AU:TAS:T": {
+    "backgroundImage": ["shield_pent_brown_2", "shield_pent_brown_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "AU:VIC": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AU:VIC:ALT": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:VIC:ALT_NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:VIC:ALT_S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:VIC:NH": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:VIC:NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:VIC:S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "AU:VIC:T": {
+    "backgroundImage": ["shield_pent_brown_2", "shield_pent_brown_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "AU:WA": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AU:WA:ALT": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:WA:ALT_NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:WA:ALT_S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "AU:WA:NH": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:WA:NR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "AU:WA:S": {
+    "backgroundImage": ["shield_fishhead_blue_2", "shield_fishhead_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "AU:WA:T": {
+    "backgroundImage": ["shield_pent_brown_2", "shield_pent_brown_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "AX:main": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "AX:province": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "ba:Autoceste": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "ba:Magistralne ceste": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "BD:national": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "BD:regional": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "BE:A-road": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "BE:B-road": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "BE:N-road": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "BE:R-road": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "bg:national": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "by:national": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CA:AB:primary": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "CA:AB:secondary": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "rectWidth": 30,
+    "textColor": "black"
+  },
+  "CA:BC": {
+    "backgroundImage": ["shield_ca_bc_2", "shield_ca_bc_3"],
+    "textColor": "blue",
+    "padding": {
+      "left": 3.5,
+      "right": 3.5,
+      "top": 5,
+      "bottom": 4
+    }
+  },
+  "CA:MB:PR": {
+    "shape": "oval",
+    "fillColor": "black",
+    "strokeColor": "white",
+    "rectWidth": 30,
+    "textColor": "white"
+  },
+  "CA:MB:PTH": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "CA:MB:Winnipeg": {
+    "backgroundImage": "shield_ca_mb_winnipeg",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 4,
+      "bottom": 3
+    }
+  },
+  "CA:NB:primary": {
+    "backgroundImage": "shield_ca_nb",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 5,
+      "bottom": 5
+    },
+    "colorLighten": "green"
+  },
+  "CA:NB:secondary": {
+    "backgroundImage": "shield_ca_nb",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 5,
+      "bottom": 5
+    },
+    "colorLighten": "blue"
+  },
+  "CA:NB:tertiary": {
+    "backgroundImage": "shield_ca_nb",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "CA:NS:H": {
+    "backgroundImage": "shield_ca_ns_h",
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6.5,
+      "bottom": 4
+    }
+  },
+  "CA:NS:R": {
+    "shape": "rectangle",
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CA:NS:T": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    }
+  },
+  "CA:NT": {
+    "backgroundImage": "shield_ca_nt",
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 9,
+      "bottom": 3
+    }
+  },
+  "CA:ON:Brant": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Brant:Highway": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["HWY"]
+  },
+  "CA:ON:Bruce": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Chatham-Kent": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Cornwall": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Dufferin": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Durham": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Durham:Highway": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["HWY"]
+  },
+  "CA:ON:Elgin": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Essex": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Frontenac:Central Frontenac": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Frontenac:Frontenac Islands": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Frontenac:North Frontenac": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Frontenac:South Frontenac": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Greater Sudbury": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Grey": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Haldimand": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Haldimand:Highway": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["HWY"]
+  },
+  "CA:ON:Haliburton": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Halton": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "green",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Hamilton": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Hastings:Carlow/Mayo": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Hastings:Hastings Highlands": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Hastings:Limerick": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Hastings:Tyendinaga": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Hastings:Wollaston": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "CA:ON:Huron": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Kawartha Lakes": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Kingston": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Lambton": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Lanark": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Leeds and Grenville": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Lennox and Addington": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Middlesex": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Muskoka": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Muskoka:West": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["WEST"]
+  },
+  "CA:ON:Niagara": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Norfolk": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Norfolk:Highway": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["HWY"]
+  },
+  "CA:ON:Northumberland": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Ottawa": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Oxford": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Peel": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "black",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Perth": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Peterborough": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Prescott and Russell": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:primary": {
+    "backgroundImage": "shield_ca_on_primary",
+    "textColor": "black",
+    "padding": {
+      "left": 3.5,
+      "right": 3.5,
+      "top": 6,
+      "bottom": 3
+    },
+    "overrideByRef": {
+      "QEW": {
+        "backgroundImage": "shield_ca_on_primary_qew",
+        "textColor": "blue"
+      }
+    }
+  },
+  "CA:ON:primary:Toll": {
+    "backgroundImage": "shield_ca_on_primary_toll",
+    "textColor": "white",
+    "padding": {
+      "left": 3.5,
+      "right": 3.5,
+      "top": 6,
+      "bottom": 3
+    }
+  },
+  "CA:ON:Prince Edward": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:private_toll": {
+    "shape": "pill",
+    "fillColor": "white",
+    "strokeColor": "blue",
+    "textColor": "black",
+    "modifiers": ["ETR"]
+  },
+  "CA:ON:Quinte West": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Renfrew": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:secondary": {
+    "shape": "trapezoid",
+    "angle": -10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 4,
+      "bottom": 2
+    }
+  },
+  "CA:ON:Simcoe": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "blue",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Stormont, Dundas and Glengarry": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:tertiary": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CA:ON:Waterloo": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:Waterloo:North Dumfries": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["TWP"]
+  },
+  "CA:ON:Waterloo:Wellesley": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "CA:ON:Waterloo:Wilmot": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["TWP"]
+  },
+  "CA:ON:Waterloo:Woolwich": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "CA:ON:Wellington": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:ON:York": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "CA:PE": {
+    "backgroundImage": "shield_ca_pe",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "CA:QC:A": {
+    "backgroundImage": ["shield_ca_qc_a_2", "shield_ca_qc_a_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 5.5,
+      "bottom": 4
+    }
+  },
+  "CA:QC:R": {
+    "backgroundImage": "shield_ca_qc_r",
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "CA:SK:primary": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "CA:SK:secondary": {
+    "backgroundImage": "shield_ca_sk_secondary",
+    "textColor": "green",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 11,
+      "bottom": 2
+    }
+  },
+  "CA:SK:tertiary": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "blue",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "CA:transcanada": {
+    "backgroundImage": "shield_ca_tch",
+    "textColor": "green",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 5,
+      "bottom": 4
+    }
+  },
+  "CA:transcanada:namedRoute": {
+    "norefImage": "shield_ca_tch",
+    "notext": true
+  },
+  "CA:YT": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "red",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "overrideByRef": {
+      "2": {
+        "shape": "rectangle",
+        "fillColor": "white",
+        "strokeColor": "#ce9d00",
+        "padding": {
+          "left": 3,
+          "right": 3,
+          "top": 3,
+          "bottom": 3
+        }
+      },
+      "3": {
+        "shape": "rectangle",
+        "fillColor": "white",
+        "strokeColor": "#ce9d00",
+        "padding": {
+          "left": 3,
+          "right": 3,
+          "top": 3,
+          "bottom": 3
+        }
+      },
+      "5": {
+        "shape": "rectangle",
+        "fillColor": "white",
+        "strokeColor": "blue",
+        "padding": {
+          "left": 3,
+          "right": 3,
+          "top": 3,
+          "bottom": 3
+        }
+      },
+      "6": {
+        "shape": "rectangle",
+        "fillColor": "white",
+        "strokeColor": "green",
+        "padding": {
+          "left": 3,
+          "right": 3,
+          "top": 3,
+          "bottom": 3
+        }
+      },
+      "11": {
+        "shape": "rectangle",
+        "fillColor": "white",
+        "strokeColor": "blue",
+        "padding": {
+          "left": 3,
+          "right": 3,
+          "top": 3,
+          "bottom": 3
+        }
+      }
+    }
+  },
+  "CL:national": {
+    "backgroundImage": ["shield_cl_national_2", "shield_cl_national_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    }
+  },
+  "CL:regional": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:AH": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:AH:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:BJ": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:BJ:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:CQ": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:CQ:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:expressway": {
+    "backgroundImage": [
+      "shield_cn_national_expressway_2",
+      "shield_cn_national_expressway_3",
+      "shield_cn_national_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:FJ": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:FJ:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:FJ:Ningde": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GD": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GD:Dianbai": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GD:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:GD:Gaozhou": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GD:Huazhou": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GD:Maoming": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GD:Maonan": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GD:Xinyi": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GS": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GS:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:GX": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GX:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:GZ": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:GZ:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:HA": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:HA:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:HA:Luoyang": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:HA:Mengjin": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:HB": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:HB:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:HE": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:HE:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:HI": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:HI:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:HL": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:HL:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:HN": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:HN:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:JL": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:JL:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:JS": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:JS:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:JS:Liyang": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:JS:Wuzhong": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:JS:Xuzhou": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:JX": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:JX:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:LN": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:LN:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:national": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:NM": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:NM:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:NX": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:NX:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:QH": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:QH:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:SC": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:SC:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:SD": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:SD:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:SH": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:SH:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:SN": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:SN:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:SX": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:SX:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:TJ": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:TJ:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:XJ": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:XJ:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:XZ": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:XZ:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:YN": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:YN:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "CN:ZJ": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "CN:ZJ:expressway": {
+    "backgroundImage": [
+      "shield_cn_regional_expressway_2",
+      "shield_cn_regional_expressway_3",
+      "shield_cn_regional_expressway_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 2
+    }
+  },
+  "co:national": {
+    "backgroundImage": ["shield_co_national_2", "shield_co_national_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 6
+    }
+  },
+  "CZ:national": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "cz:national": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "default": {
+    "textColor": "black",
+    "textHaloColor": "#faf6f2",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "dk:national": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "DZ:highway": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "DZ:national": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "DZ:regional": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "e-road": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "ee:national": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "ES:A-road": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "fi:link": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "fi:national": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "fi:regional": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "fi:trunk": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "FR:A-road": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "FR:N-road": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "GH:inter-regional": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "GH:national": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "GH:regional": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "GR:motorway": {
+    "shape": "vertical_hexagon",
+    "offset": 3,
+    "fillColor": "green",
+    "strokeColor": "white",
+    "radius": 0,
+    "rectWidth": 34,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "GR:national": {
+    "shape": "vertical_hexagon",
+    "offset": 3,
+    "fillColor": "green",
+    "strokeColor": "white",
+    "radius": 0,
+    "rectWidth": 34,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "HK": {
+    "backgroundImage": "shield_escutcheon_yellow_2",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    }
+  },
+  "HT:RD-road": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "HT:RN-road": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "HU:national": {
+    "shape": "home_plate",
+    "offset": 4,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "rectWidth": 30,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "ID:national": {
+    "backgroundImage": ["shield_id_national"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 4,
+      "bottom": 2
+    }
+  },
+  "ID:toll": {
+    "backgroundImage": ["shield_id_national"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 4,
+      "bottom": 2
+    },
+    "modifiers": ["TOL"]
+  },
+  "IQ:national": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "ir:freeways": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "IS": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "IT:A-road": {
+    "backgroundImage": [
+      "shield_oct_green_2",
+      "shield_oct_green_3",
+      "shield_oct_green_4"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "JP:E": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "JP:national": {
+    "backgroundImage": ["shield_tri_convex_blue_2", "shield_tri_convex_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 1,
+      "bottom": 5
+    }
+  },
+  "JP:prefectural": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:aichi": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:akita": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:aomori": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:chiba": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:ehime": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:fukui": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:fukuoka": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:fukushima": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:gifu": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:gunma": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:hiroshima": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:hokkaido": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:hyogo": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:ibaraki": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:ishikawa": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:iwate": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:kagawa": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:kagoshima": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:kanagawa": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:kochi": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:kumamoto": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:kyoto": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:mie": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:miyagi": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:miyazaki": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:nagano": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:nagasaki": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:nara": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:niigata": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:oita": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:okayama": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:okinawa": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:osaka": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:saga": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:saitama": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:shiga": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:shimane": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:shizuoka": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:tochigi": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:tokushima": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:tokyo": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:tottori": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:toyama": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:wakayama": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:yamagata": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:yamaguchi": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "JP:prefectural:yamanashi": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "rectWidth": 24,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "KR:expressway": {
+    "backgroundImage": ["shield_kr_expressway_2", "shield_kr_expressway_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 8,
+      "bottom": 4
+    }
+  },
+  "KR:local": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "textColor": "blue"
+  },
+  "KR:national": {
+    "shape": "oval",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "rectWidth": 30,
+    "textColor": "white"
+  },
+  "lt:national": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "LU:A-road": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "LU:B-road": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "LU:CR-road": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "LU:N-road": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "lv:national": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "lv:regional": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "md:national": {
+    "backgroundImage": "shield_ro_trunk_2",
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "ME:Magistralni putevi": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "mk:national": {
+    "shape": "vertical_hexagon",
+    "offset": 3,
+    "fillColor": "green",
+    "strokeColor": "white",
+    "radius": 0,
+    "rectWidth": 34,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "MY:E": {
+    "shape": "vertical_hexagon",
+    "offset": 3,
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "rectWidth": 34,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "my:federal": {
+    "shape": "vertical_hexagon",
+    "offset": 3,
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "rectWidth": 34,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "NL:A": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:binnenstedelijke_ring": {
+    "backgroundImage": "shield_nl_city",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:N": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:R:IJmuiden": {
+    "shape": "rectangle",
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:R:Ommen": {
+    "shape": "rectangle",
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:R:Schouwen": {
+    "shape": "rectangle",
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:R:Sluis": {
+    "shape": "rectangle",
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:R:Spaarnwoude": {
+    "shape": "rectangle",
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:R:Voorthuizen": {
+    "shape": "rectangle",
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:S:Amsterdam": {
+    "backgroundImage": "shield_nl_city",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:S:Den Haag": {
+    "backgroundImage": "shield_nl_city",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:S:Nijmegen": {
+    "backgroundImage": "shield_nl_city",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:S:Parkstad": {
+    "backgroundImage": "shield_nl_city",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:S:Rotterdam": {
+    "backgroundImage": "shield_nl_city",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NL:S:Zaanstad": {
+    "backgroundImage": "shield_nl_city",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "np:national": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "np:regional": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "NZ:SH": {
+    "backgroundImage": ["shield_fishhead_red_2", "shield_fishhead_red_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "NZ:UR": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "NZ:WRR": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "PH:E": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "PH:N": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "PK:motorway": {
+    "backgroundImage": "shield_pk_motorway",
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    }
+  },
+  "PK:national": {
+    "shape": "horizontal_hexagon",
+    "angle": 30,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 2
+    },
+    "textColor": "white"
+  },
+  "pl:expressways": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "pl:motorways": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "pl:national": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "PT:national": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "PT:regional": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "RO:A": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "RS:national": {
+    "shape": "vertical_hexagon",
+    "offset": 3,
+    "fillColor": "green",
+    "strokeColor": "white",
+    "radius": 0,
+    "rectWidth": 34,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "ru:national": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:AB": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:AC": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:BD": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:C": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:D": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:E": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:F": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:G": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:H": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:I": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:K": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:LS": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:LV": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:M": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:N": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:O": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:RV": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:S": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:T": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:U": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:W": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:X": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:Y": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SE:Z": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "SI:AC": {
+    "shape": "vertical_hexagon",
+    "offset": 3,
+    "fillColor": "green",
+    "strokeColor": "white",
+    "radius": 0,
+    "rectWidth": 34,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "sk:national": {
+    "shape": "rectangle",
+    "fillColor": "red",
+    "strokeColor": "white",
+    "rectWidth": 34,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "TR:motorway": {
+    "shape": "vertical_hexagon",
+    "offset": 2,
+    "fillColor": "orange",
+    "strokeColor": "black",
+    "radius": 0,
+    "rectWidth": 34,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "TW:city": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "TW:county": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "TW:district": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "TW:expressway": {
+    "backgroundImage": "shield_tri_convex_red_blue_2",
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 1,
+      "bottom": 5
+    }
+  },
+  "TW:freeway": {
+    "backgroundImage": "shield_tw_freeway",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "TW:provincial": {
+    "backgroundImage": ["shield_tri_convex_blue_2", "shield_tri_convex_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 1,
+      "bottom": 5
+    }
+  },
+  "TW:township": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "ua:international": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:AK": {
+    "backgroundImage": "shield_us_ak",
+    "textColor": "black",
+    "padding": {
+      "left": 5,
+      "right": 1,
+      "top": 1,
+      "bottom": 8
+    }
+  },
+  "US:AL": {
+    "backgroundImage": ["shield_us_al_2", "shield_us_al_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 6
+    }
+  },
+  "US:AL:Autauga": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Baldwin": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Barbour": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Bibb": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Blount": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Bullock": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Butler": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Calhoun": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Chambers": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Cherokee": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Chilton": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Choctaw": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Clarke": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Clay": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Cleburne": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Coffee": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Colbert": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Conecuh": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Coosa": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Covington": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Crenshaw": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Cullman": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Dale": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Dallas": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:DeKalb": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Elmore": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Escambia": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Etowah": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Fayette": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Franklin": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Geneva": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Greene": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Hale": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Henry": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Houston": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Jackson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Jefferson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Lamar": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Lauderdale": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Lawrence": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Lee": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Limestone": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Lowndes": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Macon": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Madison": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Marengo": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Marion": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Marshall": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Mobile": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Monroe": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Montgomery": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Morgan": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Perry": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Pike": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Pikens": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Randolph": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Russell": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Saint_Clair": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Shelby": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Sumter": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Talladega": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Tallapoosa": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Truck": {
+    "backgroundImage": ["shield_us_al_2", "shield_us_al_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 6
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:AL:Tuscaloosa": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Walker": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Washington": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Wilcox": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AL:Winston": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR": {
+    "backgroundImage": ["shield_us_ar_2", "shield_us_ar_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 4,
+      "bottom": 5
+    },
+    "overrideByRef": {
+      "980": {
+        "backgroundImage": "shield_us_ar_980",
+        "textColor": "white"
+      }
+    }
+  },
+  "US:AR:Baxter": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:AR:Calhoun": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Carroll": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Clay": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Columbia": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Craighead": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Cross": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Dallas": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Greene": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Hempstead": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Izard": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:AR:Jackson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Jefferson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Johnson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Lafayette": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Lawrence": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Lee": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:AR:Little_River": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Madison": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Miller": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Mississippi": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Nevada": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Ouachita": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Phillips": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Polk": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Saint_Francis": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Union": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Washington": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AR:Woodruff": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AS": {
+    "backgroundImage": "shield_us_as",
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 9.5,
+      "bottom": 2
+    }
+  },
+  "US:AZ": {
+    "backgroundImage": ["shield_us_az_2", "shield_us_az_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 3,
+      "top": 3,
+      "bottom": 4
+    }
+  },
+  "US:AZ:Apache": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:AZ:Business": {
+    "backgroundImage": ["shield_us_az_2", "shield_us_az_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 3,
+      "top": 3,
+      "bottom": 4
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:AZ:Coconino": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AZ:Loop": {
+    "backgroundImage": ["shield_us_az_2", "shield_us_az_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 3,
+      "top": 3,
+      "bottom": 4
+    },
+    "modifiers": ["LOOP"]
+  },
+  "US:AZ:Mohave": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:AZ:Spur": {
+    "backgroundImage": ["shield_us_az_2", "shield_us_az_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 3,
+      "top": 3,
+      "bottom": 4
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:AZ:Yavapai": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:BIA": {
+    "backgroundImage": "shield_us_bia",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 4,
+      "bottom": 5
+    }
+  },
+  "US:CA": {
+    "backgroundImage": ["shield_us_ca_2", "shield_us_ca_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 4
+    }
+  },
+  "US:CA:Business": {
+    "backgroundImage": ["shield_us_ca_2", "shield_us_ca_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 4
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:CA:CR": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CA:Mendocino": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:CA:San_Francisco:49_Mile_Scenic_Drive": {
+    "backgroundImage": "shield_us_ca_sf_49",
+    "notext": true
+  },
+  "US:CO": {
+    "backgroundImage": "shield_us_co",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 9.5,
+      "bottom": 2
+    }
+  },
+  "US:CO:Archuleta": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Chaffee": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Conejos": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Douglas": {
+    "backgroundImage": ["shield_pent_green_2", "shield_pent_green_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:E470": {
+    "backgroundImage": "shield_us_co_e470",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 9.5,
+      "bottom": 2
+    }
+  },
+  "US:CO:Fremont": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:CO:Grand": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Gunnison": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Jackson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:La_Plata": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Lake": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Larimer": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Moffat": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Ouray": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:CO:Park": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Rio_Blanco": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Rio_Grande": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Routt": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:CO:Saguache": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:San_Juan": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CO:Teller": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:CT": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:DC": {
+    "backgroundImage": "shield_us_dc",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 10,
+      "bottom": 4
+    }
+  },
+  "US:DE": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "US:DE:Alternate": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black",
+    "modifiers": ["ALT"]
+  },
+  "US:DE:Business": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black",
+    "modifiers": ["BUS"]
+  },
+  "US:DE:Truck": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black",
+    "modifiers": ["TRK"]
+  },
+  "US:FL": {
+    "backgroundImage": ["shield_us_fl_2", "shield_us_fl_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 4.5,
+      "top": 6,
+      "bottom": 4
+    }
+  },
+  "US:FL:CR": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:FL:Toll": {
+    "backgroundImage": "shield_us_fl_toll",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 5,
+      "top": 7.5,
+      "bottom": 4.5
+    }
+  },
+  "US:FL:Turnpike": {
+    "norefImage": "shield_us_fl_turnpike",
+    "notext": true
+  },
+  "US:GA": {
+    "backgroundImage": ["shield_us_ga_2", "shield_us_ga_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 5,
+      "bottom": 4
+    },
+    "overrideByRef": {
+      "515": {
+        "textColor": "blue",
+        "colorLighten": "blue"
+      },
+      "520": {
+        "textColor": "green",
+        "colorLighten": "green"
+      }
+    }
+  },
+  "US:GA:Alternate": {
+    "backgroundImage": ["shield_us_ga_2", "shield_us_ga_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 5,
+      "bottom": 4
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:GA:Business": {
+    "backgroundImage": ["shield_us_ga_2", "shield_us_ga_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 5,
+      "bottom": 4
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:GA:Bypass": {
+    "backgroundImage": ["shield_us_ga_2", "shield_us_ga_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 5,
+      "bottom": 4
+    },
+    "modifiers": ["BYP"]
+  },
+  "US:GA:Connector": {
+    "backgroundImage": ["shield_us_ga_2", "shield_us_ga_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 5,
+      "bottom": 4
+    },
+    "modifiers": ["CONN"]
+  },
+  "US:GA:Loop": {
+    "backgroundImage": ["shield_us_ga_2", "shield_us_ga_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 5,
+      "bottom": 4
+    },
+    "modifiers": ["LOOP"]
+  },
+  "US:GA:Spur": {
+    "backgroundImage": ["shield_us_ga_2", "shield_us_ga_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 5,
+      "bottom": 4
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:GA:Truck:Bypass": {
+    "backgroundImage": ["shield_us_ga_2", "shield_us_ga_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 5,
+      "bottom": 4
+    },
+    "modifiers": ["TRK", "BYP"]
+  },
+  "US:GU": {
+    "backgroundImage": ["shield_us_gu_2", "shield_us_gu_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 1,
+      "right": 1,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "US:HI": {
+    "backgroundImage": ["shield_tri_convex_2", "shield_tri_convex_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 5,
+      "bottom": 1
+    },
+    "verticalReflect": true
+  },
+  "US:I": {
+    "backgroundImage": ["shield_us_interstate_2", "shield_us_interstate_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 5
+    }
+  },
+  "US:I:Alternate": {
+    "backgroundImage": ["shield_us_interstate_2", "shield_us_interstate_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:I:Business:Loop": {
+    "backgroundImage": [
+      "shield_us_interstate_business_2",
+      "shield_us_interstate_business_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 5
+    }
+  },
+  "US:I:Business:Spur": {
+    "backgroundImage": [
+      "shield_us_interstate_business_2",
+      "shield_us_interstate_business_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 5
+    }
+  },
+  "US:I:Downtown:Loop": {
+    "backgroundImage": [
+      "shield_us_interstate_business_2",
+      "shield_us_interstate_business_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 5
+    }
+  },
+  "US:I:Downtown:Spur": {
+    "backgroundImage": [
+      "shield_us_interstate_business_2",
+      "shield_us_interstate_business_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 5
+    }
+  },
+  "US:I:Express": {
+    "backgroundImage": ["shield_us_interstate_2", "shield_us_interstate_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 5
+    },
+    "modifiers": ["EXPR"]
+  },
+  "US:I:Express:Toll": {
+    "backgroundImage": ["shield_us_interstate_2", "shield_us_interstate_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 5
+    },
+    "modifiers": ["EXPR"]
+  },
+  "US:I:Future": {
+    "backgroundImage": ["shield_us_interstate_2", "shield_us_interstate_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 5
+    },
+    "modifiers": ["FUT"]
+  },
+  "US:I:Truck": {
+    "backgroundImage": ["shield_us_interstate_2", "shield_us_interstate_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 6,
+      "bottom": 5
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:IA": {
+    "shape": "pill",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "US:IA:CR": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ID": {
+    "backgroundImage": ["shield_us_id_2", "shield_us_id_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 5,
+      "right": 1,
+      "top": 1,
+      "bottom": 8
+    }
+  },
+  "US:IL": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:IL:Adams": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Boone": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Bureau": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Champaign": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Christian": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Clay": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Clinton": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Coles": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Cook:Chicago:Skyway": {
+    "norefImage": "shield_us_il_skyway",
+    "notext": true
+  },
+  "US:IL:Cumberland": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:De_Witt": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:DeKalb": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Douglas": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:DuPage": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Edgar": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Effingham": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Fayette": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Henderson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Henry": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Iroquois": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Kankakee": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Kendall": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Knox": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:La_Salle": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Lake": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Livingston": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Logan": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Macon": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Mason": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:McDonough": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:McHenry": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:McLean": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Menard": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Peoria": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Piatt": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Rock_Island": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Saint_Clair": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Sangamon": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Schuyler": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Shelby": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Winnebago": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IL:Woodford": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:IN": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:IN:Toll": {
+    "norefImage": "shield_us_in_toll",
+    "notext": true
+  },
+  "US:KS": {
+    "backgroundImage": ["shield_us_ks_2", "shield_us_ks_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "US:KS:Clay": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Cowley": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Decatur": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Douglas": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Harvey": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Leavenworth": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Linn": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:McPherson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Ness": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Rawlins": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Riley": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Sheridan": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:KS:Turnpike": {
+    "norefImage": "shield_us_ks_turnpike",
+    "notext": true
+  },
+  "US:KY": {
+    "shape": "pill",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "US:KY:AA": {
+    "backgroundImage": "shield_us_ky_parkway",
+    "textColor": "blue",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "refsByWayName": {
+      "Audubon Parkway": "AU",
+      "Bluegrass Parkway": "BG",
+      "Bluegrass Pkwy": "BG",
+      "Cumberland Parkway": "LN",
+      "Cumberland Pkwy": "LN",
+      "Hal Rogers Parkway": "HR",
+      "Hal Rogers Pkwy": "HR",
+      "Mountain Parkway": "MP",
+      "Mountain Pkwy": "MP",
+      "Purchase Parkway": "JC",
+      "Purchase Pkwy": "JC",
+      "Western Kentucky Parkway": "WK",
+      "Western Kentucky Pkwy": "WK"
+    }
+  },
+  "US:KY:Business": {
+    "shape": "pill",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black",
+    "modifiers": ["BUS"]
+  },
+  "US:KY:Parkway": {
+    "backgroundImage": "shield_us_ky_parkway",
+    "textColor": "blue",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "refsByWayName": {
+      "Audubon Parkway": "AU",
+      "Bluegrass Parkway": "BG",
+      "Bluegrass Pkwy": "BG",
+      "Cumberland Parkway": "LN",
+      "Cumberland Pkwy": "LN",
+      "Hal Rogers Parkway": "HR",
+      "Hal Rogers Pkwy": "HR",
+      "Mountain Parkway": "MP",
+      "Mountain Pkwy": "MP",
+      "Purchase Parkway": "JC",
+      "Purchase Pkwy": "JC",
+      "Western Kentucky Parkway": "WK",
+      "Western Kentucky Pkwy": "WK"
+    }
+  },
+  "US:LA": {
+    "backgroundImage": ["shield_us_la_2", "shield_us_la_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2.5,
+      "right": 2.5,
+      "top": 7,
+      "bottom": 3
+    }
+  },
+  "US:LA:Bienville": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Business": {
+    "backgroundImage": ["shield_us_la_2", "shield_us_la_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2.5,
+      "right": 2.5,
+      "top": 7,
+      "bottom": 3
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:LA:Caddo": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Cameron": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:De_Soto": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Grant": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Iberia": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Lincoln": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Livingston": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Natchitoches": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Ouachita": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Rapides": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Red_River": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Richland": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Saint_Mary": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Spur": {
+    "backgroundImage": ["shield_us_la_2", "shield_us_la_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2.5,
+      "right": 2.5,
+      "top": 7,
+      "bottom": 3
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:LA:Terrebonne": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Truck": {
+    "backgroundImage": ["shield_us_la_2", "shield_us_la_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2.5,
+      "right": 2.5,
+      "top": 7,
+      "bottom": 3
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:LA:Union": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Webster": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:LA:Winn": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MA": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MD": {
+    "backgroundImage": ["shield_us_md_2", "shield_us_md_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 7,
+      "bottom": 3
+    }
+  },
+  "US:MD:Alternate": {
+    "backgroundImage": ["shield_us_md_2", "shield_us_md_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 7,
+      "bottom": 3
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:MD:Business": {
+    "backgroundImage": ["shield_us_md_2", "shield_us_md_3"],
+    "textColor": "green",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 7,
+      "bottom": 3
+    },
+    "colorLighten": "green",
+    "modifiers": ["BUS"]
+  },
+  "US:MD:Bypass": {
+    "backgroundImage": ["shield_us_md_2", "shield_us_md_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 7,
+      "bottom": 3
+    },
+    "modifiers": ["BYP"]
+  },
+  "US:ME": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:ME:Business": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:MI": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "rectWidth": 24,
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    },
+    "overrideByRef": {
+      "185": {
+        "shape": "diamond",
+        "fillColor": "brown",
+        "strokeColor": "white",
+        "padding": {
+          "left": 4.5,
+          "right": 4.5,
+          "top": 5,
+          "bottom": 5
+        }
+      }
+    }
+  },
+  "US:MI:Benzie": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MI:CR": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MI:Delta": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MI:Gogebic": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MI:Iron": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MI:Kalkaska": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MI:Luce": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MI:Manistee": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MI:Marquette": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MI:Montcalm": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MI:Oscoda": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MI:Roscommon": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MI:Schoolcraft": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN": {
+    "backgroundImage": ["shield_us_mn_2", "shield_us_mn_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 7,
+      "bottom": 3
+    }
+  },
+  "US:MN:Aitkin:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Aitkin:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Aitkin:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Anoka:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Anoka:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Anoka:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Becker:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Becker:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Becker:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Beltrami:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Beltrami:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Beltrami:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Benton:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Benton:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Benton:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Big_Stone:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Big_Stone:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Big_Stone:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Blue_Earth:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Blue_Earth:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Blue_Earth:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Brown:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Brown:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Brown:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Carlton:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Carlton:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Carlton:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Carver:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Carver:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Carver:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Cass:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Cass:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Cass:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Chippewa:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Chippewa:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Chippewa:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Chisago:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Chisago:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Chisago:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Clay:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Clay:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Clay:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Clearwater:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Clearwater:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Clearwater:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Cook:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Cook:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Cook:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Cottonwood:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Cottonwood:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Cottonwood:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Crow_Wing:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Crow_Wing:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Crow_Wing:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Dakota:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Dakota:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Dakota:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Dodge:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Dodge:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Dodge:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Douglas:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Douglas:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Douglas:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Faribault:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Faribault:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Faribault:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Fillmore:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Fillmore:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Fillmore:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Freeborn:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Freeborn:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Freeborn:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Goodhue:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Goodhue:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Goodhue:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Grant:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Grant:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Grant:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Hennepin:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Hennepin:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Hennepin:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Houston:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Houston:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Houston:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Hubbard:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Hubbard:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Hubbard:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Isanti:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Isanti:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Isanti:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Itasca:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Itasca:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Itasca:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Jackson:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Jackson:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Jackson:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Kanabec:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Kanabec:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Kanabec:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Kandiyohi:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Kandiyohi:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Kandiyohi:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Kittson:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Kittson:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Kittson:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Koochiching:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Koochiching:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Koochiching:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Lac_qui_Parle:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Lac_qui_Parle:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Lac_qui_Parle:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Lake:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Lake:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Lake:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Lake_of_the_Woods:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Lake_of_the_Woods:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Lake_of_the_Woods:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Le_Sueur:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Le_Sueur:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Le_Sueur:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Lincoln:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Lincoln:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Lincoln:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Lyon:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Lyon:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Lyon:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Mahnomen:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Mahnomen:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Mahnomen:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Marshall:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Marshall:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Marshall:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Martin:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Martin:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Martin:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:McLeod:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:McLeod:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:McLeod:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Meeker:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Meeker:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Meeker:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Mille_Lacs:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Mille_Lacs:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Mille_Lacs:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Morrison:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Morrison:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Morrison:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Mower:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Mower:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Mower:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Murray:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Murray:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Murray:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Nicollet:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Nicollet:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Nicollet:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Nobles:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Nobles:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Nobles:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Norman:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Norman:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Norman:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Olmsted:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Olmsted:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Olmsted:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Otter_Tail:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Otter_Tail:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Otter_Tail:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Pennington:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Pennington:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Pennington:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Pine:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Pine:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Pine:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Pipestone:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Pipestone:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Pipestone:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Polk:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Polk:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Polk:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Pope:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Pope:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Pope:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Ramsey:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Ramsey:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Ramsey:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Red_Lake:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Red_Lake:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Red_Lake:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Redwood:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Redwood:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Redwood:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Renville:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Renville:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Renville:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Rice:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Rice:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Rice:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Rock:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Rock:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Rock:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Roseau:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Roseau:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Roseau:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Saint_Louis:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Saint_Louis:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Saint_Louis:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Scott:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Scott:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Scott:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Sherburne:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Sherburne:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Sherburne:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Sibley:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Sibley:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Sibley:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Stearns:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Stearns:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Stearns:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Steele:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Steele:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Steele:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Stevens:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Stevens:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Stevens:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Swift:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Swift:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Swift:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Todd:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Todd:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Todd:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Traverse:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Traverse:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Traverse:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Wabasha:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Wabasha:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Wabasha:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Wadena:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Wadena:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Wadena:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Waseca:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Waseca:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Waseca:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Washington:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Washington:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Washington:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Watonwan:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Watonwan:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Watonwan:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Wilkin:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Wilkin:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Wilkin:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Winona:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Winona:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Winona:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Wright:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Wright:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Wright:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MN:Yellow_Medicine:CR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MN:Yellow_Medicine:CSAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MN:Yellow_Medicine:Park_Access": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "radius": 2,
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:MO": {
+    "backgroundImage": ["shield_us_mo_2", "shield_us_mo_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4.5,
+      "top": 3,
+      "bottom": 5.5
+    }
+  },
+  "US:MO:Alternate": {
+    "backgroundImage": ["shield_us_mo_2", "shield_us_mo_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4.5,
+      "top": 3,
+      "bottom": 5.5
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:MO:Bollinger": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MO:Business": {
+    "backgroundImage": ["shield_us_mo_2", "shield_us_mo_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4.5,
+      "top": 3,
+      "bottom": 5.5
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:MO:Butler": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MO:Cape_Girardeau": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MO:Dunklin": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MO:Lewis": {
+    "shape": "rectangle",
+    "fillColor": "brown",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MO:Madison": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MO:Mississippi": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MO:Perry": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MO:Spur": {
+    "backgroundImage": ["shield_us_mo_2", "shield_us_mo_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4.5,
+      "top": 3,
+      "bottom": 5.5
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:MO:Stoddard": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MO:Supplemental": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MO:Supplemental:Spur": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:MO:Taney": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MO:Taney:Branson": {
+    "overrideByRef": {
+      "Red Route": {
+        "shape": "bar_in_rectangle",
+        "fillColor": "red",
+        "strokeColor": "white"
+      },
+      "Yellow Route": {
+        "shape": "bar_in_rectangle",
+        "fillColor": "yellow",
+        "strokeColor": "green"
+      },
+      "Blue Route": {
+        "shape": "bar_in_rectangle",
+        "fillColor": "blue",
+        "strokeColor": "white"
+      }
+    }
+  },
+  "US:MO:Wayne": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MP": {
+    "backgroundImage": ["shield_us_mp_2", "shield_us_mp_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 2,
+      "bottom": 2
+    }
+  },
+  "US:MS": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "US:MS:Alcorn": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MS:Calhoun": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MS:Carroll": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MS:Lafayette": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MS:Lee": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MS:Prentiss": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MS:Smith": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MS:Tippah": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MS:Union": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MS:Yalobusha": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MT": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:MT:Dawson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MT:Richland": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:MT:secondary": {
+    "backgroundImage": "shield_us_mt_secondary",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 0,
+      "bottom": 6
+    }
+  },
+  "US:NC": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "rectWidth": 24,
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "US:NC:Business": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "rectWidth": 24,
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:NC:Bypass": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "rectWidth": 24,
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    },
+    "modifiers": ["BYP"]
+  },
+  "US:NC:Mecklenburg:Charlotte": {
+    "backgroundImage": ["shield_pent_green_2", "shield_pent_green_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NC:Truck": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "rectWidth": 24,
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:ND": {
+    "backgroundImage": ["shield_us_nd_2", "shield_us_nd_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 5,
+      "top": 4,
+      "bottom": 4
+    }
+  },
+  "US:ND:Alternate": {
+    "backgroundImage": ["shield_us_nd_2", "shield_us_nd_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 5,
+      "top": 4,
+      "bottom": 4
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:ND:Barnes": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Benson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Bottineau": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Burke": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Business": {
+    "backgroundImage": ["shield_us_nd_2", "shield_us_nd_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 5,
+      "top": 4,
+      "bottom": 4
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:ND:Cass": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Cavalier": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Dickey": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Divide": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Eddy": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:ND:Foster": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Grand_Forks": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Griggs": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Kidder": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:ND:LaMoure": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:McHenry": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:McIntosh": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:McKenzie": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:McLean": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Mercer": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Morton": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Mountrail": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Nelson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Pembina": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Ramsey": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Ransom": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Renville": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Richland": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Sargent": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Sioux": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Steele": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Stutsman": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Towner": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:ND:Traill": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Truck": {
+    "backgroundImage": ["shield_us_nd_2", "shield_us_nd_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 5,
+      "top": 4,
+      "bottom": 4
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:ND:Walsh": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Ward": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Wells": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:ND:Williams": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NE": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    }
+  },
+  "US:NE:Business": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:NE:Link": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["LINK"]
+  },
+  "US:NE:Rec": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["REC"]
+  },
+  "US:NE:Spur": {
+    "shape": "trapezoid",
+    "angle": 10,
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 4
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:NH": {
+    "backgroundImage": ["shield_us_nh_2", "shield_us_nh_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3.5,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    }
+  },
+  "US:NH:Bypass": {
+    "backgroundImage": ["shield_us_nh_2", "shield_us_nh_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3.5,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["BYP"]
+  },
+  "US:NJ": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "US:NJ:ACE": {
+    "backgroundImage": "shield_us_nj_ace_noref",
+    "notext": true
+  },
+  "US:NJ:ACE:Connector": {
+    "backgroundImage": "shield_us_nj_ace_noref",
+    "notext": true,
+    "modifiers": ["CONN"]
+  },
+  "US:NJ:Atlantic": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Bergen": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:NJ:Burlington": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Camden": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Cape_May": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:CR": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:CR:Spur": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:NJ:CR:Truck": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:NJ:Cumberland": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Essex": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Gloucester": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:GSP": {
+    "backgroundImage": "shield_us_nj_gsp_noref",
+    "notext": true
+  },
+  "US:NJ:Hudson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Hunterdon": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Mercer": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Middlesex": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Monmouth": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Morris": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:NJTP": {
+    "backgroundImage": "shield_us_nj_njtp_noref",
+    "notext": true
+  },
+  "US:NJ:Ocean": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Passaic": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Salem": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Somerset": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Sussex": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Union": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NJ:Warren": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM": {
+    "shape": "pill",
+    "fillColor": "white",
+    "strokeColor": "pink",
+    "textColor": "black"
+  },
+  "US:NM:Cibola": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Doña_Ana": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Eddy": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Frontage": {
+    "backgroundImage": "shield_us_nm_frontage",
+    "textColor": "black",
+    "padding": {
+      "left": 1.5,
+      "right": 1.5,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "US:NM:Guadalupe": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Lea": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Lincoln": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Luna": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:McKinley": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Mora": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Otero": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Rio_Arriba": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:San_Juan": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:San_Juan:NCM": {
+    "backgroundImage": "shield_pent_3",
+    "textColor": "pink",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    },
+    "colorLighten": "pink"
+  },
+  "US:NM:Sandoval": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Santa_Fe": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Sierra": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Taos": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Torrance": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NM:Union": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NPS:Blue_Ridge": {
+    "norefImage": "shield_us_nps_brp",
+    "notext": true
+  },
+  "US:NV": {
+    "backgroundImage": "shield_us_nv",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 12
+    }
+  },
+  "US:NV:Clark": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NV:Washoe": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY": {
+    "backgroundImage": ["shield_us_ny_2", "shield_us_ny_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "US:NY:Albany": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Allegany": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Broome": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Cattaraugus": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Chautauqua": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Chemung": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Chenango": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Clinton": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Columbia": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Delaware": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Dutchess": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Erie": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Essex": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Franklin": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Fulton": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Greene": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Hamilton": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Herkimer": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Jefferson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Lewis": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Livingston": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Madison": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Montgomery": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Oneida": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Onondaga": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Orange": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Oswego": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Otsego": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Parkway": {
+    "backgroundImage": ["shield_us_ny_parkway_2", "shield_us_ny_parkway_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 5,
+      "bottom": 5
+    },
+    "refsByWayName": {
+      "Bear Mountain Parkway": "BMP",
+      "Bronx and Pelham Parkway": "PP",
+      "Bronx River Parkway": "BRP",
+      "Cross County Parkway": "CCP",
+      "Hutchinson River Parkway": "HRP",
+      "Korean War Veterans Parkway": "KWVP",
+      "Mosholu Parkway": "MP",
+      "Pelham Parkway": "PP",
+      "Saw Mill River Parkway": "SMP",
+      "Sprain Brook Parkway": "SBP",
+      "Taconic State Parkway": "TSP"
+    }
+  },
+  "US:NY:Parkway:NYC": {
+    "backgroundImage": "shield_us_ny_parkway_nyc",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 8
+    }
+  },
+  "US:NY:Putnam": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Rensselaer": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Rockland": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Saint_Lawrence": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Saratoga": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Schoharie": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Schuyler": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:STE": {
+    "norefImage": "shield_us_ny_ste",
+    "notext": true
+  },
+  "US:NY:Steuben": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Suffolk": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Sullivan": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Thruway": {
+    "norefImage": "shield_us_ny_thruway",
+    "notext": true
+  },
+  "US:NY:Tioga": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Tompkins": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Ulster": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Warren": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Washington": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:NY:Yates": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OH": {
+    "backgroundImage": ["shield_us_oh_2", "shield_us_oh_3"],
+    "norefImage": "shield_us_oh_turnpike",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 4,
+      "bottom": 6
+    }
+  },
+  "US:OH:ASD": {
+    "backgroundImage": ["shield_us_oh_asd"],
+    "textColor": "green",
+    "padding": {
+      "left": 6,
+      "right": 3,
+      "top": 4,
+      "bottom": 7
+    }
+  },
+  "US:OH:ASD:TWP": {
+    "backgroundImage": ["shield_us_oh_asd"],
+    "textColor": "green",
+    "padding": {
+      "left": 6,
+      "right": 3,
+      "top": 4,
+      "bottom": 7
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:ATH": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:ATH:Trimble": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:BEL": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:BEL:Kirkwood": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:Business": {
+    "backgroundImage": ["shield_us_oh_2", "shield_us_oh_3"],
+    "norefImage": "shield_us_oh_turnpike",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 4,
+      "bottom": 6
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:OH:Bypass": {
+    "backgroundImage": ["shield_us_oh_2", "shield_us_oh_3"],
+    "norefImage": "shield_us_oh_turnpike",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 4,
+      "bottom": 6
+    },
+    "modifiers": ["BYP"]
+  },
+  "US:OH:CAR": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:COL": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OH:COS": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:COS:Adams": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:COS:Jackson": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:FAI": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:FAI:Greenfield": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:FAI:Violet": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:FUL": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:GAL": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:GUE": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:HAR": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:HAR:Dudley": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:HAS": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:HEN": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:HOC": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:HOC:Falls": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "green",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "textColor": "black"
+  },
+  "US:OH:HOL": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:HOL:Berlin": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:HOL:Clark": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:HOL:Knox": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:HOL:Monroe": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:HOL:Paint": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:HOL:Salt_Creek": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:JEF": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OH:JEF:Knox": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:JEF:Springfield": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:KNO": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:KNO:Liberty": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:KNO:Milford": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LAW": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:LIC": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:LIC:Jersey": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:LOG:Bokescreek": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:LOG:Harrison": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Jefferson": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Lake": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Liberty": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:McArthur": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Miami": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Monroe": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Perry": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Pleasant": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:LOG:Richland": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Rushcreek": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Stokes": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Union": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:LOG:Washington": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MAD": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MAH": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OH:MED": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MED:Harrisville": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MED:Sharon": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MED:Wadsworth": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MED:York": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:MOE": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MRG": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MRG:York": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MRW": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MRW:Bennington": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MRW:Canaan": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:MRW:Chester": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MRW:Franklin": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:MRW:Harmony": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:MRW:South_Bloomfield": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:MRW:Westfield": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:NOB": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:OTT": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OH:PAU": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:PAU:Latty": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:PAU:Washington": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:PER": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:PER:Bearfield": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:PER:Coal": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:PER:Hopewell": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:PER:Monday_Creek": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:SAN:Fremont": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:SCI": {
+    "backgroundImage": ["shield_us_oh_sci_2", "shield_us_oh_sci_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 4,
+      "bottom": 6
+    }
+  },
+  "US:OH:SEN": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OH:STA": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OH:SUM": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OH:TRU": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:TRU:Kinsman": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:TUS": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OH:TUS:Salem": {
+    "backgroundImage": ["shield_us_oh_tus_salem"],
+    "textColor": "black",
+    "padding": {
+      "left": 1,
+      "right": 4,
+      "top": 1,
+      "bottom": 4
+    }
+  },
+  "US:OH:UNI": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:VIN": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:WAS": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:WAS:Aurelius": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:WAS:Salem": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TWP"]
+  },
+  "US:OH:WAY": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:WAY:East_Union": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:WAY:Paint": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:WAY:Salt_Creek": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:WIL": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:WYA": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OH:WYA:township": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:OK": {
+    "backgroundImage": ["shield_us_ok_2", "shield_us_ok_3"],
+    "textColor": "black",
+    "textHaloColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 7,
+      "bottom": 3
+    }
+  },
+  "US:OK:Business": {
+    "backgroundImage": ["shield_us_ok_2", "shield_us_ok_3"],
+    "textColor": "black",
+    "textHaloColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 7,
+      "bottom": 3
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:OK:Loop": {
+    "backgroundImage": ["shield_us_ok_2", "shield_us_ok_3"],
+    "textColor": "black",
+    "textHaloColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 7,
+      "bottom": 3
+    },
+    "modifiers": ["LOOP"]
+  },
+  "US:OK:Spur": {
+    "backgroundImage": ["shield_us_ok_2", "shield_us_ok_3"],
+    "textColor": "black",
+    "textHaloColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 7,
+      "bottom": 3
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:OK:Toll": {
+    "backgroundImage": ["shield_us_ok_2", "shield_us_ok_3"],
+    "textColor": "black",
+    "textHaloColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 7,
+      "bottom": 3
+    }
+  },
+  "US:OK:Truck": {
+    "backgroundImage": ["shield_us_ok_2", "shield_us_ok_3"],
+    "textColor": "black",
+    "textHaloColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 7,
+      "bottom": 3
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:OR": {
+    "backgroundImage": ["shield_us_or_2", "shield_us_or_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 4,
+      "bottom": 6.5
+    }
+  },
+  "US:OR:Business": {
+    "backgroundImage": ["shield_us_or_2", "shield_us_or_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 4,
+      "bottom": 6.5
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:OR:Douglas": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OR:Grant": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OR:Lake": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OR:Lane": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:OR:Morrow": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:PA": {
+    "backgroundImage": ["shield_us_pa_2", "shield_us_pa_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "US:PA:Allegheny:Belt": {
+    "overrideByRef": {
+      "Red Belt": {
+        "shape": "disc_in_rectangle",
+        "fillColor": "red",
+        "strokeColor": "black"
+      },
+      "Orange Belt": {
+        "shape": "disc_in_rectangle",
+        "fillColor": "orange",
+        "strokeColor": "black"
+      },
+      "Yellow Belt": {
+        "shape": "disc_in_rectangle",
+        "fillColor": "yellow",
+        "strokeColor": "black"
+      },
+      "Green Belt": {
+        "shape": "disc_in_rectangle",
+        "fillColor": "green",
+        "strokeColor": "white"
+      },
+      "Blue Belt": {
+        "shape": "disc_in_rectangle",
+        "fillColor": "blue",
+        "strokeColor": "white"
+      },
+      "Purple Belt": {
+        "shape": "disc_in_rectangle",
+        "fillColor": "purple",
+        "strokeColor": "white"
+      }
+    }
+  },
+  "US:PA:Alternate": {
+    "backgroundImage": ["shield_us_pa_2", "shield_us_pa_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 5,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:PA:Business": {
+    "backgroundImage": ["shield_us_pa_2", "shield_us_pa_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 5,
+      "bottom": 5
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:PA:Truck": {
+    "backgroundImage": ["shield_us_pa_2", "shield_us_pa_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 5,
+      "bottom": 5
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:PA:Turnpike": {
+    "backgroundImage": ["shield_us_pa_turnpike_2", "shield_us_pa_turnpike_3"],
+    "norefImage": "shield_us_pa_turnpike_noref",
+    "textColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "US:PR:primary": {
+    "backgroundImage": ["shield_escutcheon_blue_2", "shield_escutcheon_blue_3"],
+    "textColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    }
+  },
+  "US:PR:primary_urban": {
+    "backgroundImage": ["shield_escutcheon_2", "shield_escutcheon_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    }
+  },
+  "US:PR:secondary": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:PR:tertiary": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "US:RI": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:SC": {
+    "backgroundImage": "shield_us_sc",
+    "textColor": "blue",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 3
+    }
+  },
+  "US:SC:Alternate": {
+    "backgroundImage": "shield_us_sc",
+    "textColor": "blue",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 3
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:SC:Business": {
+    "backgroundImage": "shield_us_sc",
+    "textColor": "blue",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 3
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:SC:Truck": {
+    "backgroundImage": "shield_us_sc",
+    "textColor": "blue",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 6,
+      "bottom": 3
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:SD": {
+    "backgroundImage": ["shield_us_sd_2", "shield_us_sd_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 3,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "US:SD:Beadle": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Bon_Homme": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Brookings": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Brown": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:SD:Charles_Mix": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Clark": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Codington": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Corson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Custer": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Day": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Deuel": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Edmunds": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Fall_River": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Faulk": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Grant": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Hamlin": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Harding": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Hyde": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Kingsbury": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Lake": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Lincoln": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Marshall": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:McCook": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:McPherson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Meade": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Minnehaha": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Moody": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Perkins": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Roberts": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Spink": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Stanley": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Tripp": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:SD:Turner": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Union": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:SD:Yankton": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TN:McMinn": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TN:primary": {
+    "backgroundImage": "shield_us_tn_primary",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    }
+  },
+  "US:TN:primary:Business": {
+    "backgroundImage": "shield_us_tn_primary",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:TN:primary:Bypass": {
+    "backgroundImage": "shield_us_tn_primary",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    },
+    "modifiers": ["BYP"]
+  },
+  "US:TN:primary:Truck": {
+    "backgroundImage": "shield_us_tn_primary",
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:TN:secondary": {
+    "backgroundImage": "shield_tri_rounded",
+    "textColor": "black",
+    "padding": {
+      "left": 7,
+      "right": 7,
+      "top": 2,
+      "bottom": 7
+    }
+  },
+  "US:TN:secondary:Alternate": {
+    "backgroundImage": "shield_tri_rounded",
+    "textColor": "black",
+    "padding": {
+      "left": 7,
+      "right": 7,
+      "top": 2,
+      "bottom": 7
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:TN:secondary:Scenic": {
+    "backgroundImage": "shield_tri_rounded",
+    "textColor": "black",
+    "padding": {
+      "left": 7,
+      "right": 7,
+      "top": 2,
+      "bottom": 7
+    },
+    "modifiers": ["SCEN"]
+  },
+  "US:TN:secondary:Truck": {
+    "backgroundImage": "shield_tri_rounded",
+    "textColor": "black",
+    "padding": {
+      "left": 7,
+      "right": 7,
+      "top": 2,
+      "bottom": 7
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:TX": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:TX:Anderson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Andrews:Andrews:Loop": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "blue",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["LOOP"]
+  },
+  "US:TX:Beltway": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["BELT"]
+  },
+  "US:TX:Blanco": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Brazoria": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:TX:Brooks": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Brown": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:TX:Burleson": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:TX:Burnet": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Business": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:TX:Caldwell": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Cass": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Colorado": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:TX:Comanche": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:TX:CTRMA": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "textColor": "white"
+  },
+  "US:TX:CTRMA:Express": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "yellow",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "textColor": "white",
+    "modifiers": ["EXPR"]
+  },
+  "US:TX:Express:Toll": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["EXPR"]
+  },
+  "US:TX:FM": {
+    "backgroundImage": "shield_us_tx_outline",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 0,
+      "top": 7,
+      "bottom": 10
+    }
+  },
+  "US:TX:FM:Business": {
+    "backgroundImage": "shield_us_tx_outline",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 0,
+      "top": 7,
+      "bottom": 10
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:TX:Fort_Bend:FBCTRA": {
+    "backgroundImage": "shield_us_tx_fbctra",
+    "textColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 2,
+      "bottom": 8
+    },
+    "refsByWayName": {
+      "Fort Bend Parkway Toll Road": "FBP",
+      "Fort Bend Westpark Tollway": "WPT"
+    }
+  },
+  "US:TX:Grimes": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Harris:HCTRA": {
+    "backgroundImage": "shield_pent_purple_yellow_3",
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    },
+    "refsByWayName": {
+      "East Sam Houston Tollway North": "SHT",
+      "East Sam Houston Tollway South": "SHT",
+      "North Sam Houston Tollway East": "SHT",
+      "North Sam Houston Tollway West": "SHT",
+      "South Sam Houston Tollway East": "SHT",
+      "South Sam Houston Tollway West": "SHT",
+      "West Sam Houston Tollway North": "SHT",
+      "West Sam Houston Tollway South": "SHT",
+      "Fort Bend Toll Road": "FBTR",
+      "Hardy Toll Road": "HTR",
+      "Tomball Tollway": "TBT",
+      "Westpark Tollway": "WPT"
+    }
+  },
+  "US:TX:Houston": {
+    "shape": "rectangle",
+    "fillColor": "green",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:TX:Jackson": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Jim_Wells": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Kent": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Kleberg": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Lavaca": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Loop": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["LOOP"]
+  },
+  "US:TX:Loop:Express:Toll": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["EXPR", "LOOP"]
+  },
+  "US:TX:Loop:Toll": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["LOOP"]
+  },
+  "US:TX:Loving": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Milam": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Mitchell": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Montgomery:MCTRA": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "blue",
+    "strokeColor": "red",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    },
+    "textColor": "white"
+  },
+  "US:TX:Morris": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:NASA": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["NASA"]
+  },
+  "US:TX:Nolan": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:NTTA": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:TX:PA": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["P.A."]
+  },
+  "US:TX:Panola": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Park": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["PARK"]
+  },
+  "US:TX:Recreational": {
+    "backgroundImage": "shield_us_tx_outline",
+    "textColor": "brown",
+    "padding": {
+      "left": 3,
+      "right": 0,
+      "top": 7,
+      "bottom": 10
+    },
+    "colorLighten": "brown",
+    "modifiers": ["R"]
+  },
+  "US:TX:Reeves": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:RM": {
+    "backgroundImage": "shield_us_tx_outline",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 0,
+      "top": 7,
+      "bottom": 10
+    }
+  },
+  "US:TX:Robertson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Rusk": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Schleicher": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Scurry": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Shackelford": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Somervell": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Spur": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:TX:Stonewall": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Sutton": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Toll": {
+    "shape": "rectangle",
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:TX:Uvalde": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:TX:Ward": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["CR"]
+  },
+  "US:TX:Winkler": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:US": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    }
+  },
+  "US:US:Alternate": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:US:Alternate:Truck:Business": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["ALT", "TRK", "BUS"]
+  },
+  "US:US:Business": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:US:Business:Alternate": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["BUS", "ALT"]
+  },
+  "US:US:Business:Truck": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["BUS", "TRK"]
+  },
+  "US:US:Bypass": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["BYP"]
+  },
+  "US:US:Connector": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["CONN"]
+  },
+  "US:US:Historic": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "brown",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "colorLighten": "brown"
+  },
+  "US:US:Spur": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:US:Truck": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:US:Truck:Bypass": {
+    "backgroundImage": ["shield_badge_2", "shield_badge_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 5
+    },
+    "modifiers": ["TRK", "BYP"]
+  },
+  "US:UT": {
+    "backgroundImage": ["shield_us_ut_2", "shield_us_ut_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 5.5,
+      "bottom": 5
+    }
+  },
+  "US:UT:Wayne": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:VA": {
+    "backgroundImage": [
+      "shield_escutcheon_rounded_2",
+      "shield_escutcheon_rounded_3"
+    ],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    }
+  },
+  "US:VA:Alternate": {
+    "backgroundImage": [
+      "shield_escutcheon_rounded_2",
+      "shield_escutcheon_rounded_3"
+    ],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:VA:Business": {
+    "backgroundImage": [
+      "shield_escutcheon_rounded_2",
+      "shield_escutcheon_rounded_3"
+    ],
+    "textColor": "black",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 7
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:VA:Secondary": {
+    "shape": "pill",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "US:VI": {
+    "shape": "pill",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "US:VT": {
+    "backgroundImage": ["shield_us_vt_2", "shield_us_vt_3"],
+    "textColor": "green",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 5,
+      "bottom": 2
+    }
+  },
+  "US:VT:Alternate": {
+    "backgroundImage": ["shield_us_vt_2", "shield_us_vt_3"],
+    "textColor": "green",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 5,
+      "bottom": 2
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:VT:Town": {
+    "shape": "oval",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "US:WA": {
+    "backgroundImage": "shield_us_wa",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 3,
+      "bottom": 7
+    }
+  },
+  "US:WA:Alternate": {
+    "backgroundImage": "shield_us_wa",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 3,
+      "bottom": 7
+    },
+    "modifiers": ["ALT"]
+  },
+  "US:WA:Business": {
+    "backgroundImage": "shield_us_wa",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 3,
+      "bottom": 7
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:WA:Spur": {
+    "backgroundImage": "shield_us_wa",
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 4,
+      "top": 3,
+      "bottom": 7
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:WI": {
+    "backgroundImage": ["shield_us_wi_2", "shield_us_wi_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 6
+    }
+  },
+  "US:WI:Adams": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Ashland": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Barron": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Bayfield": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Brown": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Buffalo": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Burnett": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Business": {
+    "backgroundImage": ["shield_us_wi_2", "shield_us_wi_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 6
+    },
+    "modifiers": ["BUS"]
+  },
+  "US:WI:Calumet": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Chippewa": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Clark": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Columbia": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Crawford": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Dane": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Dodge": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Door": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Douglas": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Dunn": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Eau_Claire": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Florence": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Fond_du_Lac": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Forest": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Grant": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Green": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Green_Lake": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Iowa": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Iron": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Jackson": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Jefferson": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Juneau": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Kenosha": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Kewaunee": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:La_Crosse": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Lafayette": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Langlade": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Lincoln": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Manitowoc": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Marathon": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Marinette": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Marquette": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Marquette:Truck": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    },
+    "modifiers": ["TRK"]
+  },
+  "US:WI:Menominee": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Milwaukee": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Monroe": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Oconto": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Oneida": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Outagamie": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Ozaukee": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Pepin": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Pierce": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Polk": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Portage": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Price": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Racine": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Richland": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Rock": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Rusk": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Rustic": {
+    "backgroundImage": "shield_us_wi_rustic",
+    "textColor": "yellow",
+    "padding": {
+      "left": 1.5,
+      "right": 4,
+      "top": 9,
+      "bottom": 4
+    }
+  },
+  "US:WI:Saint_Croix": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Sauk": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Sawyer": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Shawano": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Sheboygan": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Spur": {
+    "backgroundImage": ["shield_us_wi_2", "shield_us_wi_3"],
+    "textColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 6
+    },
+    "modifiers": ["SPUR"]
+  },
+  "US:WI:Taylor": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Trempealeau": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Vernon": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Vilas": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Walworth": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Washburn": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Washington": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Waukesha": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Waupaca": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Waushara": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Winnebago": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WI:Wood": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WV": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WV:County": {
+    "shape": "pill",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "US:WY": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "US:WY:Big_Horn": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Carbon": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Converse": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Crook": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Fremont": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Hot_Springs": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Johnson": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Lincoln": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Natrona": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Niobrara": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Park": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Sheridan": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Sublette": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Sweetwater": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Uinta": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Washakie": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "US:WY:Weston": {
+    "backgroundImage": [
+      "shield_pent_blue_yellow_2",
+      "shield_pent_blue_yellow_3"
+    ],
+    "textColor": "yellow",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 5
+    }
+  },
+  "UY": {
+    "shape": "home_plate",
+    "offset": 5,
+    "fillColor": "blue",
+    "strokeColor": "white",
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 2,
+      "bottom": 6
+    }
+  },
+  "VE:L:AM": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:AN": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:AP": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:AR": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:BA": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:BO": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:CA": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:CO": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:DA": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:DC": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:FA": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:GU": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:LA": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:ME": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:MI": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:MO": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:NE": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:PO": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:SU": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:TA": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:TR": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:VA": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:YA": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:L:ZU": {
+    "shape": "circle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "textColor": "black"
+  },
+  "VE:R:AM": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:AN": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:AP": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:AR": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:BA": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:BO": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:CA": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:CO": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:DA": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:DC": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:FA": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:GU": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:LA": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:ME": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:MI": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:MO": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:NE": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:PO": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:SU": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:TA": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:TR": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:VA": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:YA": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:R:ZU": {
+    "shape": "diamond",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 4.5,
+      "right": 4.5,
+      "top": 5,
+      "bottom": 5
+    }
+  },
+  "VE:T:AM": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:AN": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:AP": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:AR": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:BA": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:BO": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:CA": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:CO": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:DA": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:DC": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:FA": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:GU": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:LA": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:ME": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:MI": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:MO": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:NE": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:PO": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:SU": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:TA": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:TR": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:VA": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:YA": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "VE:T:ZU": {
+    "backgroundImage": "shield_ve_t",
+    "textColor": "black",
+    "padding": {
+      "left": 4,
+      "right": 4,
+      "top": 3,
+      "bottom": 5
+    }
+  },
+  "vn:expressway": {
+    "shape": "rectangle",
+    "fillColor": "yellow",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "vn:national": {
+    "shape": "rectangle",
+    "fillColor": "white",
+    "strokeColor": "black",
+    "padding": {
+      "left": 3,
+      "right": 3,
+      "top": 3,
+      "bottom": 3
+    }
+  },
+  "XK:motorway": {
+    "shape": "vertical_hexagon",
+    "offset": 3,
+    "fillColor": "green",
+    "strokeColor": "white",
+    "radius": 0,
+    "rectWidth": 34,
+    "padding": {
+      "left": 2,
+      "right": 2,
+      "top": 4,
+      "bottom": 4
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "code_format": "run-s code_format:prettier code_format:svgo",
     "code_format:prettier": "prettier --write --list-different .",
     "code_format:svgo": "svgo -q -f icons/",
+    "compile_shield_defs": "node scripts/compile_shield_defs.js",
     "clean": "shx rm -rf dist",
     "presprites": "shx rm -rf dist/sprites",
     "sprites": "node scripts/sprites.js",

--- a/scripts/compile_shield_defs.js
+++ b/scripts/compile_shield_defs.js
@@ -1,0 +1,126 @@
+"use strict";
+
+import * as fs from "fs";
+import * as ShieldDef from "../src/js/shield_defs.js";
+import * as Color from "../src/constants/color.js";
+
+let sprites = JSON.parse(
+  fs.readFileSync(`${process.cwd()}/dist/sprites/sprite.json`)
+);
+
+// Reverse the color map to turn CSS values back into keywords.
+let colorKeywords = Object.fromEntries(
+  Object.entries(Color.shields).map((c) => c.reverse())
+);
+
+/**
+ * Converts any color-typed values in the object to color keywords.
+ */
+function convertColorsToKeywords(obj) {
+  for (let property of [
+    "colorLighten",
+    "fillColor",
+    "strokeColor",
+    "textColor",
+    "textHaloColor",
+  ]) {
+    if (property in obj) {
+      obj[property] =
+        colorKeywords[obj[property].toLowerCase()] || obj[property];
+    }
+  }
+  if ("overrideByRef" in obj) {
+    for (let ref of Object.keys(obj.overrideByRef)) {
+      convertColorsToKeywords(obj.overrideByRef[ref]);
+    }
+  }
+}
+
+/**
+ * Deletes redundant properties from the given object. Properties are redundant if they are hardcoded elsewhere in the codebase.
+ */
+function deleteRedundantProperties(obj) {
+  switch (obj.shape) {
+    case "oval":
+      if (
+        obj.padding.left === 2 &&
+        obj.padding.right === 2 &&
+        obj.padding.top === 2 &&
+        obj.padding.bottom === 2
+      ) {
+        delete obj.padding;
+      }
+      break;
+    case "circle":
+      if (
+        obj.padding.left === 2 &&
+        obj.padding.right === 2 &&
+        obj.padding.top === 2 &&
+        obj.padding.bottom === 2
+      ) {
+        delete obj.padding;
+      }
+      if (obj.rectWidth === 20) delete obj.rectWidth;
+      break;
+    case "rectangle":
+      if (obj.textColor === obj.strokeColor) delete obj.textColor;
+      if (obj.radius === 2) delete obj.radius;
+      //if (obj.padding.left === 3 && obj.padding.right === 3 && obj.padding.top === 3 && obj.padding.bottom === 3) {
+      //  delete obj.padding;
+      //}
+      break;
+    case "trapezoid":
+      if (obj.textColor === obj.strokeColor) delete obj.textColor;
+      if (obj.radius === 0) delete obj.radius;
+      break;
+    case "diamond":
+    case "home_plate":
+    case "vertical_hexagon":
+      if (obj.textColor === obj.strokeColor) delete obj.textColor;
+      if (obj.radius === 2) delete obj.radius;
+      break;
+    case "pill":
+      if (
+        obj.padding.left === 2 &&
+        obj.padding.right === 2 &&
+        obj.padding.top === 2 &&
+        obj.padding.bottom === 2
+      ) {
+        delete obj.padding;
+      }
+      break;
+    case "disc_in_rectangle":
+    case "bar_in_rectangle":
+      delete obj.notext;
+      break;
+  }
+  if ("overrideByRef" in obj) {
+    for (let ref of Object.keys(obj.overrideByRef)) {
+      deleteRedundantProperties(obj.overrideByRef[ref]);
+    }
+  }
+}
+
+// Inject a map of each sprite ID to a file name instead of the usual sprite metadata.
+let shieldImageNames = Object.fromEntries(
+  Object.keys(sprites).map((sprite) => [sprite, sprite])
+);
+let shields = ShieldDef.loadShields(shieldImageNames);
+for (let network of Object.keys(shields)) {
+  let shield = shields[network];
+  convertColorsToKeywords(shield);
+  deleteRedundantProperties(shield);
+  shields[network] = shield;
+}
+
+// Sort the definitions by network.
+let sortedShields = Object.fromEntries(
+  Object.entries(shields).sort((a, b) =>
+    a[0].toLowerCase() < b[0].toLowerCase() ? -1 : 1
+  )
+);
+
+fs.writeFileSync(
+  `${process.cwd()}/data/shield_defs.json`,
+  JSON.stringify(sortedShields, null, 2)
+);

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -24,6 +24,10 @@ export const shields = {};
 function ovalShield(fillColor, strokeColor, textColor, rectWidth) {
   textColor = textColor ?? strokeColor;
   return {
+    shape: "oval",
+    fillColor,
+    strokeColor,
+    rectWidth,
     backgroundDraw: (ref) =>
       ShieldDraw.ellipse(fillColor, strokeColor, ref, rectWidth),
     textLayoutConstraint: ShieldText.ellipseTextConstraint,
@@ -46,7 +50,10 @@ function ovalShield(fillColor, strokeColor, textColor, rectWidth) {
  * @returns a shield definition object
  */
 function circleShield(fillColor, strokeColor, textColor) {
-  return ovalShield(fillColor, strokeColor, textColor, 20);
+  return {
+    ...ovalShield(fillColor, strokeColor, textColor, 20),
+    shape: "circle",
+  };
 }
 
 /**
@@ -69,6 +76,11 @@ function roundedRectShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 2;
   return {
+    shape: "rectangle",
+    fillColor,
+    strokeColor,
+    rectWidth,
+    radius,
     backgroundDraw: (ref) =>
       ShieldDraw.roundedRectangle(
         fillColor,
@@ -112,6 +124,12 @@ function trapezoidShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 0;
   return {
+    shape: "trapezoid",
+    angle,
+    fillColor,
+    strokeColor,
+    radius,
+    rectWidth,
     backgroundDraw: (ref) =>
       ShieldDraw.trapezoid(
         angle,
@@ -148,6 +166,11 @@ function diamondShield(fillColor, strokeColor, textColor, radius, rectWidth) {
   textColor = textColor ?? strokeColor;
   radius = radius ?? 2;
   return {
+    shape: "diamond",
+    fillColor,
+    strokeColor,
+    radius,
+    rectWidth,
     backgroundDraw: (ref) =>
       ShieldDraw.diamond(fillColor, strokeColor, ref, radius, 1, rectWidth),
     textLayoutConstraint: ShieldText.ellipseTextConstraint,
@@ -183,6 +206,12 @@ function homePlateShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 2;
   return {
+    shape: "home_plate",
+    offset,
+    fillColor,
+    strokeColor,
+    radius,
+    rectWidth,
     backgroundDraw: (ref) =>
       ShieldDraw.homePlate(
         offset,
@@ -227,6 +256,12 @@ function hexagonVerticalShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 2;
   return {
+    shape: "vertical_hexagon",
+    offset,
+    fillColor,
+    strokeColor,
+    radius,
+    rectWidth,
     backgroundDraw: (ref) =>
       ShieldDraw.hexagonVertical(
         offset,
@@ -271,6 +306,12 @@ function hexagonHorizontalShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 2;
   return {
+    shape: "horizontal_hexagon",
+    angle,
+    fillColor,
+    strokeColor,
+    radius,
+    rectWidth,
     backgroundDraw: (ref) =>
       ShieldDraw.hexagonHorizontal(
         angle,
@@ -304,6 +345,10 @@ function hexagonHorizontalShield(
 function pillShield(fillColor, strokeColor, textColor, rectWidth) {
   textColor = textColor ?? strokeColor;
   return {
+    shape: "pill",
+    fillColor,
+    strokeColor,
+    rectWidth,
     backgroundDraw: (ref) =>
       ShieldDraw.roundedRectangle(
         fillColor,
@@ -333,6 +378,9 @@ function pillShield(fillColor, strokeColor, textColor, rectWidth) {
  */
 function paBeltShield(fillColor, strokeColor) {
   return {
+    shape: "disc_in_rectangle",
+    fillColor,
+    strokeColor,
     notext: true,
     backgroundDraw: (ref) => ShieldDraw.paBelt(fillColor, strokeColor),
   };
@@ -347,6 +395,9 @@ function paBeltShield(fillColor, strokeColor) {
  */
 function bransonRouteShield(fillColor, strokeColor) {
   return {
+    shape: "bar_in_rectangle",
+    fillColor,
+    strokeColor,
     notext: true,
     backgroundDraw: (ref) => ShieldDraw.bransonRoute(fillColor, strokeColor),
   };


### PR DESCRIPTION
Added a build script that extracts the JavaScript shield definitions into a JSON file. This will pave the way for validating the definitions against a schema and filling gaps in alternative representations of the shield repertoire, such as this project’s taginfo project file. Eventually, the JSON data could be extracted into a separate package for easier reuse in other projects, regardless of their programming languages. In the meantime:

* [x] Add JSON-compiling script similar to taginfo.js
* [x] Convert color constants back to keywords
* [x] Convert shape functions to keywords
* [x] Convert common shape objects to keywords
* [ ] Convert text layouts to keywords
* [x] Sort definitions by `network` value
* [ ] Allow definitions to inherit properties from other definitions
* [ ] Split JSON file by country for easier maintenance
* [ ] Combine per-country JSON files into a single minified file for distribution
* [ ] Add schema and validate shield definitions against it; requires #594
* [ ] Remove shield_defs.js and compile_shield_defs.js
* [ ] Generate placeholder images for shape keywords for taginfo
* [ ] Generate shieldtest.js networks based on a property in individual shield definitions
* [ ] Update CONTRIBUTING.md

Fixes #118.