### PR TITLE
Use user-preferred language in labels

### DIFF
--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -11,14 +11,9 @@
   },
   "tags": [
     {
-      "key": "name:en",
-      "object_types": ["node", "way", "relation", "area"],
-      "description": "Labels are in English if available."
-    },
-    {
       "key": "name",
       "object_types": ["node", "way", "relation", "area"],
-      "description": "Labels fall back to the local language if name:en is unavailable."
+      "description": "Labels fall back to the local language if none of the user-preferred languages is available."
     },
     {
       "key": "capital",

--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -11,6 +11,16 @@
   },
   "tags": [
     {
+      "key": "name:en",
+      "object_types": ["node", "way", "relation", "area"],
+      "description": "Labels are in English if available."
+    },
+    {
+      "key": "name",
+      "object_types": ["node", "way", "relation", "area"],
+      "description": "Labels fall back to the local language if name:en is unavailable."
+    },
+    {
       "key": "capital",
       "value": "yes",
       "object_types": ["node"],

--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -2,8 +2,7 @@
 
 // Name fields in order of preference
 export const localizedName = (function () {
-  let userLocales =
-    "languages" in navigator ? [...navigator.languages] : [navigator.language];
+  let userLocales = navigator.languages ?? [navigator.language];
   let locales = [];
   let localeSet = new Set(); // avoid duplicates
   for (let locale of userLocales) {

--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -1,9 +1,24 @@
 "use strict";
 
 // Name fields in order of preference
-export const localizedName = [
-  "coalesce",
-  ["get", "name:en"],
-  ["get", "name:latin"],
-  ["get", "name"],
-];
+export const localizedName = (function () {
+  let userLocales =
+    "languages" in navigator ? [...navigator.languages] : [navigator.language];
+  let locales = [];
+  let localeSet = new Set(); // avoid duplicates
+  for (let locale of userLocales) {
+    // Add progressively less specific variants of each user-specified locale.
+    let components = locale.split("-");
+    while (components.length > 0) {
+      let parent = components.join("-");
+      if (!localeSet.has(parent)) locales.push(parent);
+      localeSet.add(parent);
+      components.pop();
+    }
+  }
+  if (locales.at(-1) === "en") {
+    locales.push("latin");
+  }
+  let nameFields = [...locales.map((l) => `name:${l}`), "name"];
+  return ["coalesce", ...nameFields.map((f) => ["get", f])];
+})();

--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -1,7 +1,14 @@
 "use strict";
 
-// Name fields in order of preference
-export const localizedName = (function () {
+/**
+ * Returns a `coalesce` expression that resolves to the feature's name in a
+ * language that the user prefers.
+ *
+ * @param {boolean} includesLegacyFields - Whether to include the older fields
+ *  that include underscores, for layers that have not transitioned to the
+ *  colon syntax.
+ */
+function getLocalizedNameExpression(includesLegacyFields) {
   let userLocales = navigator.languages ?? [navigator.language];
   let locales = [];
   let localeSet = new Set(); // avoid duplicates
@@ -18,6 +25,19 @@ export const localizedName = (function () {
   if (locales.at(-1) === "en") {
     locales.push("latin");
   }
-  let nameFields = [...locales.map((l) => `name:${l}`), "name"];
+  let nameFields = [
+    ...locales.flatMap((l) => {
+      let fields = [`name:${l}`];
+      // transportation_label uses an underscore instead of a colon.
+      // https://github.com/openmaptiles/openmaptiles/issues/769
+      if (includesLegacyFields && (l === "de" || l === "en"))
+        fields.push(`name_${l}`);
+      return fields;
+    }),
+    "name",
+  ];
   return ["coalesce", ...nameFields.map((f) => ["get", f])];
-})();
+}
+
+export const localizedName = getLocalizedNameExpression(false);
+export const legacyLocalizedName = getLocalizedNameExpression(true);

--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // Name fields in order of preference
-export const name_en = [
+export const localizedName = [
   "coalesce",
   ["get", "name:en"],
   ["get", "name:latin"],

--- a/src/layer/aeroway.js
+++ b/src/layer/aeroway.js
@@ -1,13 +1,7 @@
 "use strict";
 
+import * as Label from "../constants/label.js";
 import * as Color from "../constants/color.js";
-
-const name_en = [
-  "coalesce",
-  ["get", "name:en"],
-  ["get", "name:latin"],
-  ["get", "name"],
-];
 
 const minorAirport = [
   "any",
@@ -221,7 +215,7 @@ export const airportLabel = {
   },
   layout: {
     visibility: "visible",
-    "text-field": name_en,
+    "text-field": Label.localizedName,
     "text-font": ["Metropolis Bold"],
     "text-size": 10,
     ...iconLayout,
@@ -245,7 +239,7 @@ export const minorAirportLabel = {
   },
   layout: {
     visibility: "visible",
-    "text-field": name_en,
+    "text-field": Label.localizedName,
     "text-font": ["Metropolis Bold"],
     "text-size": 10,
   },

--- a/src/layer/park.js
+++ b/src/layer/park.js
@@ -1,14 +1,7 @@
 "use strict";
 
+import * as Label from "../constants/label.js";
 import * as Color from "../constants/color.js";
-
-// Name fields in order of preference
-const name_en = [
-  "coalesce",
-  ["get", "name:en"],
-  ["get", "name:latin"],
-  ["get", "name"],
-];
 
 export const fill = {
   id: "protected-area-fill",
@@ -50,7 +43,7 @@ export const label = {
   },
   layout: {
     visibility: "visible",
-    "text-field": name_en,
+    "text-field": Label.localizedName,
     "text-font": ["Metropolis Bold"],
     "text-size": 10,
     "symbol-sort-key": ["get", "rank"],
@@ -102,7 +95,7 @@ export const parkLabel = {
   },
   layout: {
     visibility: "visible",
-    "text-field": name_en,
+    "text-field": Label.localizedName,
     "text-font": ["Metropolis Bold"],
     "text-size": 10,
     "symbol-sort-key": ["get", "rank"],

--- a/src/layer/place.js
+++ b/src/layer/place.js
@@ -1,4 +1,4 @@
-import * as label from "../constants/label.js";
+import * as Label from "../constants/label.js";
 
 const cityLabelPaint = {
   "text-color": "#444",
@@ -59,7 +59,7 @@ export const village = {
         [11, 0.5],
       ],
     },
-    "text-field": label.name_en,
+    "text-field": Label.localizedName,
     "text-anchor": "bottom",
     "text-variable-anchor": [
       "bottom",
@@ -122,7 +122,7 @@ export const town = {
         [11, 0.7],
       ],
     },
-    "text-field": label.name_en,
+    "text-field": Label.localizedName,
     "text-anchor": "bottom",
     "text-variable-anchor": [
       "bottom",
@@ -181,7 +181,7 @@ export const city = {
         [11, 0.9],
       ],
     },
-    "text-field": label.name_en,
+    "text-field": Label.localizedName,
     "text-anchor": "bottom",
     "text-variable-anchor": [
       "bottom",
@@ -223,7 +223,7 @@ export const state = {
         [6, 14],
       ],
     },
-    "text-field": label.name_en,
+    "text-field": Label.localizedName,
     "text-padding": 1,
     "text-transform": "uppercase",
     "text-letter-spacing": 0.04,
@@ -266,7 +266,7 @@ export const countryOther = {
         [7, 15],
       ],
     },
-    "text-field": label.name_en,
+    "text-field": Label.localizedName,
     "text-max-width": 6.25,
     "text-transform": "none",
   },
@@ -296,7 +296,7 @@ export const country3 = {
         [7, 17],
       ],
     },
-    "text-field": label.name_en,
+    "text-field": Label.localizedName,
     "text-max-width": 6.25,
     "text-transform": "none",
   },
@@ -326,7 +326,7 @@ export const country2 = {
         [5, 17],
       ],
     },
-    "text-field": label.name_en,
+    "text-field": Label.localizedName,
     "text-max-width": 6.25,
     "text-transform": "none",
   },
@@ -357,7 +357,7 @@ export const country1 = {
         [6, 19],
       ],
     },
-    "text-field": label.name_en,
+    "text-field": Label.localizedName,
     "text-max-width": ["step", ["zoom"], 6.25, 3, 12],
     "text-transform": "none",
     "text-offset": [
@@ -383,7 +383,7 @@ export const continent = {
   layout: {
     "text-font": ["Metropolis Light"],
     "text-size": 13,
-    "text-field": label.name_en,
+    "text-field": Label.localizedName,
     "text-justify": "center",
     "text-transform": "uppercase",
   },

--- a/src/layer/transportation_label.js
+++ b/src/layer/transportation_label.js
@@ -1,5 +1,6 @@
 "use strict";
 
+import * as Label from "../constants/label.js";
 import * as Color from "../constants/color.js";
 
 const highwaySelector = ["match", ["get", "class"]];
@@ -79,12 +80,7 @@ export const label = {
       ["literal", ["Metropolis Regular Italic"]],
       ["literal", ["Metropolis Light"]],
     ],
-    "text-field": [
-      "concat",
-      ["get", "name:latin"],
-      " ",
-      ["get", "name:nonlatin"],
-    ],
+    "text-field": Label.legacyLocalizedName,
     "text-max-angle": 20,
     "symbol-placement": "line",
     "text-size": [

--- a/src/layer/water.js
+++ b/src/layer/water.js
@@ -1,5 +1,6 @@
 "use strict";
 
+import * as Label from "../constants/label.js";
 import * as Color from "../constants/color.js";
 
 const bigRivers = ["river", "canal"];
@@ -75,16 +76,9 @@ const labelPaintProperties = {
   "text-halo-blur": 0.25,
 };
 
-const nameField = [
-  "coalesce",
-  ["get", "name:en"],
-  ["get", "name_en"],
-  ["get", "name"],
-];
-
 const labelLayoutProperties = {
   "symbol-placement": "line",
-  "text-field": nameField,
+  "text-field": Label.localizedName,
   "text-font": ["Metropolis Bold Italic"],
   "text-max-angle": 55,
 };
@@ -153,7 +147,7 @@ export const waterPointLabel = {
   "source-layer": "water_name",
   filter: ["all", ["==", ["geometry-type"], "Point"]],
   layout: {
-    "text-field": nameField,
+    "text-field": Label.localizedName,
     "text-font": ["Metropolis Bold Italic"],
     "text-size": [
       "interpolate",


### PR DESCRIPTION
All map labels now use the `name:*` field corresponding to the user’s preferred language if available, falling back to the user’s second preferred language and so on. If none of the preferred languages is available, labels fall back to the local language. English is no longer hard-coded.

Spanish and Traditional Chinese, falling back to the local language:

[<img src="https://user-images.githubusercontent.com/1231218/204113811-7c09aca3-3754-4504-8984-651ecf779835.png" width="400" alt="Spanish">](https://zelonewolf.github.io/openstreetmap-americana/#6/34.18/-118.798) [<img src="https://user-images.githubusercontent.com/1231218/204113874-2397276a-3282-4159-a130-137205e86125.png" width="400" alt="Chinese">](https://zelonewolf.github.io/openstreetmap-americana/#6/34.18/-118.798)

Working towards #20.