### PR TITLE
Localize labels dynamically

### DIFF
--- a/src/americana.js
+++ b/src/americana.js
@@ -2,6 +2,8 @@
 
 import config from "./config.js";
 
+import * as Label from "./constants/label.js";
+
 import * as Util from "./js/util.js";
 import * as Shield from "./js/shield.js";
 import * as ShieldDef from "./js/shield_defs.js";
@@ -29,274 +31,299 @@ import * as search from "./search.js";
 import SampleControl from "openmapsamples-maplibre/OpenMapSamplesControl.js";
 import { default as OpenMapTilesSamples } from "openmapsamples/samples/OpenMapTiles/index.js";
 
-/*
- This is a list of the layers in the Americana style, from bottom to top.
-*/
-var americanaLayers = [];
+function buildLayers() {
+  // Layers from bottom to top
+  let layers = [];
 
-americanaLayers.push(
-  lyrBackground.base,
-  lyrPark.fill,
-  lyrAeroway.fill,
-  lyrPark.parkFill,
+  layers.push(
+    lyrBackground.base,
+    lyrPark.fill,
+    lyrAeroway.fill,
+    lyrPark.parkFill,
 
-  lyrBoundary.countyCasing,
-  lyrBoundary.stateCasing,
-  lyrBoundary.countryCasing,
+    lyrBoundary.countyCasing,
+    lyrBoundary.stateCasing,
+    lyrBoundary.countryCasing,
 
-  lyrWater.water,
-  lyrWater.waterway,
-  lyrWater.waterwayIntermittent,
+    lyrWater.water,
+    lyrWater.waterway,
+    lyrWater.waterwayIntermittent,
 
-  lyrPark.outline,
-  lyrAeroway.outline,
-  lyrPark.parkOutline,
+    lyrPark.outline,
+    lyrAeroway.outline,
+    lyrPark.parkOutline,
 
-  lyrBoundary.city,
-  lyrBoundary.county,
-  lyrBoundary.state,
-  lyrBoundary.country,
+    lyrBoundary.city,
+    lyrBoundary.county,
+    lyrBoundary.state,
+    lyrBoundary.country,
 
-  lyrBackground.pierArea,
-  lyrBackground.pierLine,
+    lyrBackground.pierArea,
+    lyrBackground.pierLine,
 
-  lyrRail.railTunnel.dashes(),
-  lyrRail.railServiceTunnel.dashes(),
+    lyrRail.railTunnel.dashes(),
+    lyrRail.railServiceTunnel.dashes(),
 
-  lyrRail.narrowGaugeTunnel.dashes(),
-  lyrRail.narrowGaugeServiceTunnel.dashes(),
+    lyrRail.narrowGaugeTunnel.dashes(),
+    lyrRail.narrowGaugeServiceTunnel.dashes(),
 
-  lyrRail.lightRailTramTunnel.dashes(),
-  lyrRail.lightRailTramServiceTunnel.dashes(),
+    lyrRail.lightRailTramTunnel.dashes(),
+    lyrRail.lightRailTramServiceTunnel.dashes(),
 
-  lyrRail.funicularTunnel.dashes(),
+    lyrRail.funicularTunnel.dashes(),
 
-  lyrRail.railwayTunnel.fill(),
+    lyrRail.railwayTunnel.fill(),
 
-  lyrConstruction.road,
+    lyrConstruction.road,
 
-  lyrRoad.roadTunnel.casing(),
+    lyrRoad.roadTunnel.casing(),
 
-  lyrRoad.roadTunnel.fill(),
+    lyrRoad.roadTunnel.fill(),
 
-  lyrOneway.tunnel,
-  lyrOneway.tunnelLink,
+    lyrOneway.tunnel,
+    lyrOneway.tunnelLink,
 
-  lyrFerry.ferry,
+    lyrFerry.ferry,
 
-  lyrAeroway.runway,
-  lyrAeroway.runwayArea,
-  lyrAeroway.taxiway,
-  lyrAeroway.taxiwayArea,
+    lyrAeroway.runway,
+    lyrAeroway.runwayArea,
+    lyrAeroway.taxiway,
+    lyrAeroway.taxiwayArea,
 
-  lyrRoad.motorwayLink.casing(),
-  lyrRoad.trunkLink.casing(),
+    lyrRoad.motorwayLink.casing(),
+    lyrRoad.trunkLink.casing(),
 
-  lyrRoad.roadLinkSimpleCasing.casing(),
+    lyrRoad.roadLinkSimpleCasing.casing(),
 
-  lyrRoad.motorway.casing(),
-  lyrRoad.trunk.casing(),
-  lyrRoad.primaryExpressway.casing(),
-  lyrRoad.secondaryExpressway.casing(),
-  lyrRoad.tertiaryExpressway.casing(),
+    lyrRoad.motorway.casing(),
+    lyrRoad.trunk.casing(),
+    lyrRoad.primaryExpressway.casing(),
+    lyrRoad.secondaryExpressway.casing(),
+    lyrRoad.tertiaryExpressway.casing(),
 
-  lyrRoad.roadSimpleCasing.casing(),
+    lyrRoad.roadSimpleCasing.casing(),
 
-  lyrRoad.motorwayLink.fill(),
-  lyrRoad.roadLinkSimpleFill.fill(),
-  lyrRoad.primaryLink.fill(),
-  lyrRoad.primaryLinkToll.fill(),
-  lyrRoad.secondaryLink.fill(),
-  lyrRoad.secondaryLinkToll.fill(),
-  lyrRoad.tertiaryLink.fill(),
-  lyrRoad.tertiaryLinkToll.fill(),
+    lyrRoad.motorwayLink.fill(),
+    lyrRoad.roadLinkSimpleFill.fill(),
+    lyrRoad.primaryLink.fill(),
+    lyrRoad.primaryLinkToll.fill(),
+    lyrRoad.secondaryLink.fill(),
+    lyrRoad.secondaryLinkToll.fill(),
+    lyrRoad.tertiaryLink.fill(),
+    lyrRoad.tertiaryLinkToll.fill(),
 
-  lyrRoad.minor.fill(),
-  lyrRoad.minorToll.fill(),
-  lyrRoad.tertiary.fill(),
-  lyrRoad.tertiaryToll.fill(),
-  lyrRoad.secondary.fill(),
-  lyrRoad.secondaryToll.fill(),
-  lyrRoad.primary.fill(),
-  lyrRoad.primaryToll.fill(),
-  lyrRoad.roadSimpleFill.fill(),
-  lyrRoad.motorway.fill(),
+    lyrRoad.minor.fill(),
+    lyrRoad.minorToll.fill(),
+    lyrRoad.tertiary.fill(),
+    lyrRoad.tertiaryToll.fill(),
+    lyrRoad.secondary.fill(),
+    lyrRoad.secondaryToll.fill(),
+    lyrRoad.primary.fill(),
+    lyrRoad.primaryToll.fill(),
+    lyrRoad.roadSimpleFill.fill(),
+    lyrRoad.motorway.fill(),
 
-  lyrRoad.road.surface(),
+    lyrRoad.road.surface(),
 
-  lyrRail.rail.dashes(),
-  lyrRail.railService.dashes(),
+    lyrRail.rail.dashes(),
+    lyrRail.railService.dashes(),
 
-  lyrRail.narrowGauge.dashes(),
-  lyrRail.narrowGaugeService.dashes(),
+    lyrRail.narrowGauge.dashes(),
+    lyrRail.narrowGaugeService.dashes(),
 
-  lyrRail.lightRailTram.dashes(),
-  lyrRail.lightRailTramService.dashes(),
+    lyrRail.lightRailTram.dashes(),
+    lyrRail.lightRailTramService.dashes(),
 
-  lyrRail.funicular.dashes(),
+    lyrRail.funicular.dashes(),
 
-  lyrRail.railway.fill(),
+    lyrRail.railway.fill(),
 
-  lyrOneway.road,
-  lyrOneway.link
-);
-
-americanaLayers.push(lyrBuilding.building);
-
-var bridgeLayers = [
-  lyrRail.bridgeCasing,
-
-  lyrRoad.trunkLinkBridge.casing(),
-  lyrRoad.motorwayLinkBridge.casing(),
-
-  lyrRoad.roadLinkSimpleCasingBridge.casing(),
-
-  lyrRoad.tertiaryExpresswayBridge.casing(),
-  lyrRoad.secondaryExpresswayBridge.casing(),
-  lyrRoad.primaryExpresswayBridge.casing(),
-  lyrRoad.trunkBridge.casing(),
-  lyrRoad.motorwayBridge.casing(),
-
-  lyrRoad.roadSimpleCasingBridge.casing(),
-
-  lyrRoad.tertiaryLinkBridge.fill(),
-  lyrRoad.tertiaryLinkTollBridge.fill(),
-  lyrRoad.secondaryLinkBridge.fill(),
-  lyrRoad.secondaryLinkTollBridge.fill(),
-  lyrRoad.primaryLinkBridge.fill(),
-  lyrRoad.primaryLinkTollBridge.fill(),
-  lyrRoad.roadLinkSimpleFillBridge.fill(),
-  lyrRoad.motorwayLinkBridge.fill(),
-
-  lyrRoad.minorBridge.fill(),
-  lyrRoad.minorTollBridge.fill(),
-  lyrRoad.tertiaryBridge.fill(),
-  lyrRoad.tertiaryTollBridge.fill(),
-  lyrRoad.secondaryBridge.fill(),
-  lyrRoad.secondaryTollBridge.fill(),
-  lyrRoad.primaryBridge.fill(),
-  lyrRoad.primaryTollBridge.fill(),
-  lyrRoad.roadSimpleFillBridge.fill(),
-  lyrRoad.motorwayBridge.fill(),
-
-  lyrRoad.roadBridge.surface(),
-
-  lyrRail.railBridge.dashes(),
-  lyrRail.railServiceBridge.dashes(),
-
-  lyrRail.narrowGaugeBridge.dashes(),
-  lyrRail.narrowGaugeServiceBridge.dashes(),
-
-  lyrRail.lightRailTramBridge.dashes(),
-  lyrRail.lightRailTramServiceBridge.dashes(),
-
-  lyrRail.funicularBridge.dashes(),
-
-  lyrRail.railwayBridge.fill(),
-
-  lyrOneway.bridge,
-  lyrOneway.bridgeLink,
-];
-
-//Render bridge without layer on the lowest bridge layer
-bridgeLayers.forEach((layer) =>
-  americanaLayers.push(
-    Util.filteredClone(layer, ["!", ["has", "layer"]], "_layer_bottom")
-  )
-);
-
-//One layer at a time to handle stacked bridges
-for (let i = 1; i <= 4; i++) {
-  bridgeLayers.forEach((layer) =>
-    americanaLayers.push(Util.restrictLayer(layer, i))
+    lyrOneway.road,
+    lyrOneway.link
   );
+
+  layers.push(lyrBuilding.building);
+
+  var bridgeLayers = [
+    lyrRail.bridgeCasing,
+
+    lyrRoad.trunkLinkBridge.casing(),
+    lyrRoad.motorwayLinkBridge.casing(),
+
+    lyrRoad.roadLinkSimpleCasingBridge.casing(),
+
+    lyrRoad.tertiaryExpresswayBridge.casing(),
+    lyrRoad.secondaryExpresswayBridge.casing(),
+    lyrRoad.primaryExpresswayBridge.casing(),
+    lyrRoad.trunkBridge.casing(),
+    lyrRoad.motorwayBridge.casing(),
+
+    lyrRoad.roadSimpleCasingBridge.casing(),
+
+    lyrRoad.tertiaryLinkBridge.fill(),
+    lyrRoad.tertiaryLinkTollBridge.fill(),
+    lyrRoad.secondaryLinkBridge.fill(),
+    lyrRoad.secondaryLinkTollBridge.fill(),
+    lyrRoad.primaryLinkBridge.fill(),
+    lyrRoad.primaryLinkTollBridge.fill(),
+    lyrRoad.roadLinkSimpleFillBridge.fill(),
+    lyrRoad.motorwayLinkBridge.fill(),
+
+    lyrRoad.minorBridge.fill(),
+    lyrRoad.minorTollBridge.fill(),
+    lyrRoad.tertiaryBridge.fill(),
+    lyrRoad.tertiaryTollBridge.fill(),
+    lyrRoad.secondaryBridge.fill(),
+    lyrRoad.secondaryTollBridge.fill(),
+    lyrRoad.primaryBridge.fill(),
+    lyrRoad.primaryTollBridge.fill(),
+    lyrRoad.roadSimpleFillBridge.fill(),
+    lyrRoad.motorwayBridge.fill(),
+
+    lyrRoad.roadBridge.surface(),
+
+    lyrRail.railBridge.dashes(),
+    lyrRail.railServiceBridge.dashes(),
+
+    lyrRail.narrowGaugeBridge.dashes(),
+    lyrRail.narrowGaugeServiceBridge.dashes(),
+
+    lyrRail.lightRailTramBridge.dashes(),
+    lyrRail.lightRailTramServiceBridge.dashes(),
+
+    lyrRail.funicularBridge.dashes(),
+
+    lyrRail.railwayBridge.fill(),
+
+    lyrOneway.bridge,
+    lyrOneway.bridgeLink,
+  ];
+
+  //Render bridge without layer on the lowest bridge layer
+  bridgeLayers.forEach((layer) =>
+    layers.push(
+      Util.filteredClone(layer, ["!", ["has", "layer"]], "_layer_bottom")
+    )
+  );
+
+  //One layer at a time to handle stacked bridges
+  for (let i = 1; i <= 4; i++) {
+    bridgeLayers.forEach((layer) => layers.push(Util.restrictLayer(layer, i)));
+  }
+
+  //If layer is more than 5, just give up and render on a single layer.
+  bridgeLayers.forEach((layer) =>
+    layers.push(
+      Util.filteredClone(
+        layer,
+        [">=", ["coalesce", ["get", "layer"], 0], 5],
+        "_layer_top"
+      )
+    )
+  );
+
+  layers.push(
+    //The labels at the end of the list draw on top of the layers at the beginning.
+    lyrWater.waterwayLabel,
+    lyrWater.waterLabel,
+    lyrWater.waterPointLabel,
+
+    lyrTransportationLabel.bridgeSpacer,
+    lyrTransportationLabel.label,
+
+    lyrPark.label,
+    lyrPark.parkLabel,
+    /* The ref label shows up at lower zoom levels and when the long name doesn't fit */
+    lyrAeroway.airportRefLabel,
+    lyrAeroway.minorAirportRefLabel,
+    lyrAeroway.airportLabel,
+    lyrAeroway.minorAirportLabel,
+    lyrAeroway.airportGate,
+
+    lyrHighwayShield.shield,
+
+    lyrHighwayExit.exits,
+
+    lyrPlace.state,
+    lyrPlace.village,
+    lyrPlace.town,
+    lyrPlace.city,
+    lyrPlace.countryOther,
+    lyrPlace.country3,
+    lyrPlace.country2,
+    lyrPlace.country1,
+    lyrPlace.continent
+  );
+
+  // Resolve localized name placeholders.
+  let localizedNameExpression = Label.getLocalizedNameExpression(false);
+  let legacyLocalizedNameExpression = Label.getLocalizedNameExpression(true);
+  for (let layer of layers) {
+    if (
+      "metadata" in layer &&
+      "layout" in layer &&
+      layer.metadata["americana:text-field-localized"] === true
+    ) {
+      // https://github.com/openmaptiles/openmaptiles/issues/769
+      layer.layout["text-field"] =
+        layer["source-layer"] === "transportation_name"
+          ? legacyLocalizedNameExpression
+          : localizedNameExpression;
+    }
+  }
+
+  return layers;
 }
 
-//If layer is more than 5, just give up and render on a single layer.
-bridgeLayers.forEach((layer) =>
-  americanaLayers.push(
-    Util.filteredClone(
-      layer,
-      [">=", ["coalesce", ["get", "layer"], 0], 5],
-      "_layer_top"
-    )
-  )
-);
+function buildStyle() {
+  var getUrl = window.location;
+  var baseUrl = getUrl.protocol + "//" + getUrl.host + getUrl.pathname;
 
-americanaLayers.push(
-  //The labels at the end of the list draw on top of the layers at the beginning.
-  lyrWater.waterwayLabel,
-  lyrWater.waterLabel,
-  lyrWater.waterPointLabel,
-
-  lyrTransportationLabel.bridgeSpacer,
-  lyrTransportationLabel.label,
-
-  lyrPark.label,
-  lyrPark.parkLabel,
-  /* The ref label shows up at lower zoom levels and when the long name doesn't fit */
-  lyrAeroway.airportRefLabel,
-  lyrAeroway.minorAirportRefLabel,
-  lyrAeroway.airportLabel,
-  lyrAeroway.minorAirportLabel,
-  lyrAeroway.airportGate,
-
-  lyrHighwayShield.shield,
-
-  lyrHighwayExit.exits,
-
-  lyrPlace.state,
-  lyrPlace.village,
-  lyrPlace.town,
-  lyrPlace.city,
-  lyrPlace.countryOther,
-  lyrPlace.country3,
-  lyrPlace.country2,
-  lyrPlace.country1,
-  lyrPlace.continent
-);
-
-console.debug(`Loaded ${americanaLayers.length} layers`);
-
-var getUrl = window.location;
-var baseUrl = getUrl.protocol + "//" + getUrl.host + getUrl.pathname;
-
-var style = {
-  id: "streets",
-  name: "Americana",
-  glyphs: "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
-  layers: americanaLayers,
-  sources: {
-    openmaptiles: {
-      url: config.OPENMAPTILES_URL,
-      type: "vector",
+  return {
+    id: "streets",
+    name: "Americana",
+    glyphs: "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
+    layers: buildLayers(),
+    sources: {
+      openmaptiles: {
+        url: config.OPENMAPTILES_URL,
+        type: "vector",
+      },
     },
-  },
-  sprite: new URL("sprites/sprite", baseUrl).href,
-  light: {
-    anchor: "viewport",
-    color: "white",
-    intensity: 0.12,
-  },
-  version: 8,
-};
+    sprite: new URL("sprites/sprite", baseUrl).href,
+    light: {
+      anchor: "viewport",
+      color: "white",
+      intensity: 0.12,
+    },
+    version: 8,
+  };
+}
 
 export const map = (window.map = new maplibregl.Map({
   container: "map", // container id
   hash: true,
   antialias: true,
-  style: style,
+  style: buildStyle(),
   center: [-94, 40.5], // starting position [lng, lat]
   zoom: 4, // starting zoom
   attributionControl: false,
 }));
 
-map.on("styledata", function () {
+map.on("styledata", function (event) {
+  if (event.dataType === "style") {
+    console.debug(`Loaded ${map.getStyle().layers.length} layers`);
+  }
   ShieldDef.loadShields(map.style.imageManager.images);
 });
 
 map.on("styleimagemissing", function (e) {
   Shield.missingIconHandler(map, e);
+});
+
+window.addEventListener("languagechange", (event) => {
+  console.log(`Changed to ${navigator.languages}`);
+  map.setStyle(buildStyle());
 });
 
 let attributionConfig = {

--- a/src/americana.js
+++ b/src/americana.js
@@ -320,9 +320,6 @@ export const map = (window.map = new maplibregl.Map({
 }));
 
 map.on("styledata", function (event) {
-  if (event.dataType === "style") {
-    console.debug(`Loaded ${map.getStyle().layers.length} layers`);
-  }
   ShieldDef.loadShields(map.style.imageManager.images);
 });
 

--- a/src/americana.js
+++ b/src/americana.js
@@ -300,9 +300,18 @@ function buildStyle() {
   };
 }
 
+function upgradeLegacyHash() {
+  let hash = window.location.hash.substr(1);
+  if (!hash.includes("=")) {
+    hash = `#map=${hash}`;
+  }
+  window.location.hash = hash;
+}
+upgradeLegacyHash();
+
 export const map = (window.map = new maplibregl.Map({
   container: "map", // container id
-  hash: true,
+  hash: "map",
   antialias: true,
   style: buildStyle(),
   center: [-94, 40.5], // starting position [lng, lat]
@@ -324,6 +333,10 @@ map.on("styleimagemissing", function (e) {
 window.addEventListener("languagechange", (event) => {
   console.log(`Changed to ${navigator.languages}`);
   map.setStyle(buildStyle());
+});
+
+window.addEventListener("hashchange", (event) => {
+  upgradeLegacyHash();
 });
 
 let attributionConfig = {

--- a/src/americana.js
+++ b/src/americana.js
@@ -337,6 +337,12 @@ window.addEventListener("languagechange", (event) => {
 
 window.addEventListener("hashchange", (event) => {
   upgradeLegacyHash();
+  let oldLanguage = Label.getLanguageFromURL(new URL(event.oldURL));
+  let newLanguage = Label.getLanguageFromURL(new URL(event.newURL));
+  if (oldLanguage !== newLanguage) {
+    console.log(`Changed to ${newLanguage}`);
+    map.setStyle(buildStyle());
+  }
 });
 
 let attributionConfig = {

--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -8,7 +8,7 @@
  *  that include underscores, for layers that have not transitioned to the
  *  colon syntax.
  */
-function getLocalizedNameExpression(includesLegacyFields) {
+export function getLocalizedNameExpression(includesLegacyFields) {
   let userLocales = navigator.languages ?? [navigator.language];
   let locales = [];
   let localeSet = new Set(); // avoid duplicates
@@ -39,5 +39,5 @@ function getLocalizedNameExpression(includesLegacyFields) {
   return ["coalesce", ...nameFields.map((f) => ["get", f])];
 }
 
-export const localizedName = getLocalizedNameExpression(false);
-export const legacyLocalizedName = getLocalizedNameExpression(true);
+// Placeholder to be resolved by buildLayers()
+export const localizedName = "$$localizedName";

--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -1,6 +1,13 @@
 "use strict";
 
 /**
+ * Returns a list of languages as a comma-delimited string from the given URL hash.
+ */
+export function getLanguageFromURL(url) {
+  return new URLSearchParams(url.hash.substr(1)).get("language");
+}
+
+/**
  * Returns a `coalesce` expression that resolves to the feature's name in a
  * language that the user prefers.
  *
@@ -9,7 +16,10 @@
  *  colon syntax.
  */
 export function getLocalizedNameExpression(includesLegacyFields) {
-  let userLocales = navigator.languages ?? [navigator.language];
+  // Check the language "parameter" in the hash.
+  let parameter = getLanguageFromURL(window.location)?.split(",");
+  // Fall back to the user's language preference.
+  let userLocales = parameter ?? navigator.languages ?? [navigator.language];
   let locales = [];
   let localeSet = new Set(); // avoid duplicates
   for (let locale of userLocales) {

--- a/src/layer/aeroway.js
+++ b/src/layer/aeroway.js
@@ -221,7 +221,9 @@ export const airportLabel = {
     ...iconLayout,
   },
   source: "openmaptiles",
-  metadata: {},
+  metadata: {
+    "americana:text-field-localized": true,
+  },
   "source-layer": "aerodrome_label",
 };
 
@@ -244,7 +246,9 @@ export const minorAirportLabel = {
     "text-size": 10,
   },
   source: "openmaptiles",
-  metadata: {},
+  metadata: {
+    "americana:text-field-localized": true,
+  },
   "source-layer": "aerodrome_label",
 };
 

--- a/src/layer/park.js
+++ b/src/layer/park.js
@@ -49,7 +49,9 @@ export const label = {
     "symbol-sort-key": ["get", "rank"],
   },
   source: "openmaptiles",
-  metadata: {},
+  metadata: {
+    "americana:text-field-localized": true,
+  },
   "source-layer": "park",
 };
 
@@ -101,6 +103,8 @@ export const parkLabel = {
     "symbol-sort-key": ["get", "rank"],
   },
   source: "openmaptiles",
-  metadata: {},
+  metadata: {
+    "americana:text-field-localized": true,
+  },
   "source-layer": "poi",
 };

--- a/src/layer/place.js
+++ b/src/layer/place.js
@@ -80,6 +80,9 @@ export const village = {
   minzoom: 11,
   maxzoom: 14,
   "source-layer": "place",
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 
 export const town = {
@@ -143,6 +146,9 @@ export const town = {
   minzoom: 4,
   maxzoom: 13,
   "source-layer": "place",
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 
 export const city = {
@@ -202,6 +208,9 @@ export const city = {
   minzoom: 4,
   maxzoom: 12,
   "source-layer": "place",
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 
 export const state = {
@@ -243,6 +252,9 @@ export const state = {
   maxzoom: 7,
   minzoom: 3,
   "source-layer": "place",
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 export const countryOther = {
   id: "country_other",
@@ -272,6 +284,9 @@ export const countryOther = {
   },
   source: "openmaptiles",
   "source-layer": "place",
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 export const country3 = {
   id: "country_3",
@@ -302,6 +317,9 @@ export const country3 = {
   },
   source: "openmaptiles",
   "source-layer": "place",
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 export const country2 = {
   id: "country_2",
@@ -332,6 +350,9 @@ export const country2 = {
   },
   source: "openmaptiles",
   "source-layer": "place",
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 export const country1 = {
   id: "country_1",
@@ -370,6 +391,9 @@ export const country1 = {
   },
   source: "openmaptiles",
   "source-layer": "place",
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 export const continent = {
   id: "continent",
@@ -390,4 +414,7 @@ export const continent = {
   source: "openmaptiles",
   maxzoom: 1,
   "source-layer": "place",
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };

--- a/src/layer/transportation_label.js
+++ b/src/layer/transportation_label.js
@@ -80,7 +80,7 @@ export const label = {
       ["literal", ["Metropolis Regular Italic"]],
       ["literal", ["Metropolis Light"]],
     ],
-    "text-field": Label.legacyLocalizedName,
+    "text-field": Label.localizedName,
     "text-max-angle": 20,
     "symbol-placement": "line",
     "text-size": [
@@ -119,6 +119,9 @@ export const label = {
   },
   source: "openmaptiles",
   "source-layer": "transportation_name",
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 
 // A spacer label on each bridge to push any waterway label away from the bridge.

--- a/src/layer/water.js
+++ b/src/layer/water.js
@@ -112,6 +112,9 @@ export const waterwayLabel = {
     "text-letter-spacing": 0.15,
   },
   paint: labelPaintProperties,
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 
 //Lake labels rendered as a linear feature
@@ -137,6 +140,9 @@ export const waterLabel = {
     "text-letter-spacing": 0.25,
   },
   paint: labelPaintProperties,
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };
 
 //Lake labels rendered as a point feature
@@ -163,4 +169,7 @@ export const waterPointLabel = {
     "text-letter-spacing": 0.25,
   },
   paint: labelPaintProperties,
+  metadata: {
+    "americana:text-field-localized": true,
+  },
 };


### PR DESCRIPTION
The format of the hash at the end of the application’s URL has changed from `#zoom/latitude/longitude` to `#map=zoom/latitude/longitude`, which is consistent with both openstreetmap.org and iD. For easier map sharing and debugging, the application now accepts a `language=` parameter as part of the hash. For example, `#map=12/29.95/-90.08` zooms to New Orleans, but `#language=fr&map=12/29.95/-90.08` zooms to _La Nouvelle Orléans_, and `#language=vi,es&map=12/29.95/-90.08` zooms to _Nueva Orleans_.

The application is now capable of rebuilding the entire style at an arbitrary time after the page loads. It rebuilds the style any time the user’s language preference changes or the URL hash’s `language` parameter changes. The only dynamic part of the style is label localization. Rebuilding the layers is challenging because of the codebase’s extensive use of global variables, but this PR uses a `metadata` field to persist an indication of the intention to localize a given layer’s `text-field` property, which is resolved just before setting the style.

Fixes #20 and fixes #579.