### PR TITLE
Tweak build verbosity

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ build
 sprites
 js/maplibre-gl.js
 dist
+.pnp.*

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "config": "shx cp src/configs/config.maptiler.js src/config.js",
     "code_format": "run-s code_format:prettier code_format:svgo",
-    "code_format:prettier": "prettier --write .",
-    "code_format:svgo": "svgo -f icons/",
+    "code_format:prettier": "prettier --write --list-different .",
+    "code_format:svgo": "svgo -q -f icons/",
     "clean": "shx rm -rf dist",
     "presprites": "shx rm -rf dist/sprites",
     "sprites": "node scripts/sprites.js",

--- a/scripts/sprites.js
+++ b/scripts/sprites.js
@@ -19,6 +19,8 @@ const sprites = await Promise.all(
   })
 );
 
+console.log(`Building ${sprites.length} sprites`);
+
 const generated = await Sprites.generate(sprites, [1, 2]);
 
 for (const result of generated) {
@@ -28,4 +30,6 @@ for (const result of generated) {
 
   await fs.writeFile(outputPng, result.buffer);
   await fs.writeFile(outputJson, JSON.stringify(result.layout, null, 2));
+  const kb = (result.buffer.length / 1024).toFixed(1);
+  console.log(`Wrote ${kb}KiB to ${outputPng}`);
 }


### PR DESCRIPTION
- Make code_format shut up
  - prettier can print names of changed files
  - svgo can only print all or nothing, unfortunately
- Make sprites script report its output