### PR TITLE
Lazily load mapbox-gl-rtl-text plugin

### DIFF
--- a/src/americana.js
+++ b/src/americana.js
@@ -310,6 +310,12 @@ function upgradeLegacyHash() {
 }
 upgradeLegacyHash();
 
+maplibregl.setRTLTextPlugin(
+  "https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.min.js",
+  null,
+  true
+);
+
 export const map = (window.map = new maplibregl.Map({
   container: "map", // container id
   hash: "map",


### PR DESCRIPTION
Load the [BSD-licensed](https://github.com/mapbox/mapbox-gl-rtl-text/blob/4ba8fa31f3ce449e8f7dee8191ab3e54a19982e9/LICENSE.md) mapbox-gl-rtl-text plugin from a CDN to ensure that Arabic- and Hebrew-language labels appear with the correct text shaping. The plugin is only loaded when needed.

[<img src="https://user-images.githubusercontent.com/1231218/204172293-14522a93-d173-422e-a7db-c9f631a3071f.png" width="400" alt="Algiers">](https://zelonewolf.github.io/openstreetmap-americana/#map=8/36.629/2.998&language=ar)

Fixes #580.