### PR TITLE
Change to github pages from branch to workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
@@ -20,8 +23,10 @@ jobs:
           npm ci --include=dev
           cp src/configs/config.aws.js src/config.js
           npm run build
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+      - name: Upload 🏗
+        uses: actions/upload-pages-artifact@v1
         with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: dist/ # The folder the action should deploy.
+          path: ./dist
+      - name: Deploy 🚀
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Requires changing this setting in the repository: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow

Note that this is "in beta".

Allows deleting the gh-pages branch, which is a waste of space:

```bash
~¶ git clone https://github.com/zelonewolf/openstreetmap-americana ./main --single-branch --branch main 
[…]
Receiving objects: 100% (6807/6807), 2.57 MiB | 5.18 MiB/s, done.
~¶ git clone https://github.com/zelonewolf/openstreetmap-americana ./gh-pages --single-branch --branch gh-pages 
[…]
Receiving objects: 100% (2290/2290), 40.28 MiB | 5.63 MiB/s, done.
```