### PR TITLE
Nix `name:latin` fallback from English

### DIFF
--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -13,7 +13,7 @@
     {
       "key": "name",
       "object_types": ["node", "way", "relation", "area"],
-      "description": "Labels fall back to the local language if none of the user-preferred languages is available."
+      "description": "Labels fall back to the local language if none of the user-preferred languages is available. City labels include the local-language name in parentheses."
     },
     {
       "key": "capital",

--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -40,9 +40,6 @@ export function getLocales() {
  *  colon syntax.
  */
 export function getLocalizedNameExpression(locales, includesLegacyFields) {
-  if (locales.at(-1) === "en") {
-    locales.push("latin");
-  }
   let nameFields = [
     ...locales.flatMap((l) => {
       let fields = [`name:${l}`];

--- a/test/spec/label.js
+++ b/test/spec/label.js
@@ -89,15 +89,6 @@ describe("label", function () {
         ["get", "name"],
       ]);
     });
-    it("falls back from English to Romanization", function () {
-      expect(Label.getLocalizedNameExpression(["en-US", "en"], false)).to.eql([
-        "coalesce",
-        ["get", "name:en-US"],
-        ["get", "name:en"],
-        ["get", "name:latin"],
-        ["get", "name"],
-      ]);
-    });
     it("includes legacy fields", function () {
       expect(
         Label.getLocalizedNameExpression(["en-US", "en", "de"], true)


### PR DESCRIPTION
As currently implemented, `name:latin` is generally unsuitable for display: https://github.com/onthegomap/planetiler/issues/86#issuecomment-1050039099 https://github.com/onthegomap/planetiler/issues/86#issuecomment-1153166781. In some languages, it’s sort of like asking Cicero to sound out Shakespearean sonnets or the _Monday Night Football_ teleprompter. Removing this fallback also improves consistency between user-preferred languages.

Also updated the taginfo project file to note the new city label glosses.