### PR TITLE
Change place label halos from pure white, to background fill color

### DIFF
--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -15,6 +15,7 @@ export const borderCasing = `hsl(${hueBorderCasing}, 35%, 86%)`;
 export const parkFill = "hsl(136, 41%, 89%)";
 export const parkOutline = "hsl(136, 41%, 79%)";
 export const parkLabel = "hsl(136, 71%, 29%)";
+export const parkLabelHalo = "hsl(90, 27%, 94%)";
 
 export const airportFill = "hsl(250, 41%, 95%)";
 export const airportOutline = "hsl(250, 41%, 79%)";

--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -1,5 +1,5 @@
-export const backgroundHsl = "30, 44%, 96%";
-export const backgroundFill = `hsl(${backgroundHsl})`;
+export const backgroundFill = `hsl(30, 44%, 96%)`;
+export const backgroundFillTranslucent = `hsla(30, 44%, 96%, 0.8)`;
 
 export const waterFill = "hsl(211, 42%, 70%)";
 export const waterLine = "hsl(211, 73%, 78%)";

--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -1,4 +1,5 @@
-export const backgroundFill = "#faf6f2";
+export const backgroundHsl = "30, 44%, 96%";
+export const backgroundFill = `hsl(${backgroundHsl})`;
 
 export const waterFill = "hsl(211, 42%, 70%)";
 export const waterLine = "hsl(211, 73%, 78%)";

--- a/src/layer/park.js
+++ b/src/layer/park.js
@@ -37,8 +37,8 @@ export const label = {
   filter: ["has", "rank"],
   paint: {
     "text-color": Color.parkLabel,
-    "text-halo-blur": 1,
-    "text-halo-color": "rgba(255, 255, 255, 1)",
+    "text-halo-blur": 0.5,
+    "text-halo-color": Color.backgroundFill,
     "text-halo-width": 1,
   },
   layout: {
@@ -88,8 +88,8 @@ export const parkLabel = {
   filter: ["==", ["get", "class"], "park"],
   paint: {
     "text-color": Color.parkLabel,
-    "text-halo-blur": 1,
-    "text-halo-color": "rgba(255, 255, 255, 1)",
+    "text-halo-blur": 0.5,
+    "text-halo-color": Color.backgroundFill,
     "text-halo-width": 1,
   },
   layout: {

--- a/src/layer/park.js
+++ b/src/layer/park.js
@@ -37,8 +37,8 @@ export const label = {
   filter: ["has", "rank"],
   paint: {
     "text-color": Color.parkLabel,
-    "text-halo-blur": 0.5,
-    "text-halo-color": Color.backgroundFill,
+    "text-halo-blur": 1,
+    "text-halo-color": Color.parkLabelHalo,
     "text-halo-width": 1,
   },
   layout: {
@@ -88,8 +88,8 @@ export const parkLabel = {
   filter: ["==", ["get", "class"], "park"],
   paint: {
     "text-color": Color.parkLabel,
-    "text-halo-blur": 0.5,
-    "text-halo-color": Color.backgroundFill,
+    "text-halo-blur": 1,
+    "text-halo-color": Color.parkLabelHalo,
     "text-halo-width": 1,
   },
   layout: {

--- a/src/layer/place.js
+++ b/src/layer/place.js
@@ -1,8 +1,9 @@
 import * as Label from "../constants/label.js";
+import * as Color from "../constants/color.js";
 
 const cityLabelPaint = {
   "text-color": "#444",
-  "text-halo-color": "rgb(255,255,255)",
+  "text-halo-color": Color.backgroundFill,
   "text-halo-width": 2,
   "text-halo-blur": 0.5,
 };
@@ -210,7 +211,7 @@ export const state = {
   type: "symbol",
   paint: {
     "text-color": "hsl(45, 6%, 10%)",
-    "text-halo-color": "rgb(255,255,255)",
+    "text-halo-color": Color.backgroundFill,
     "text-halo-width": 2,
     "text-halo-blur": 0.5,
   },
@@ -250,8 +251,8 @@ export const countryOther = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 1,
-    "text-halo-color": "rgba(255,255,255,0.8)",
+    "text-halo-blur": 0.5,
+    "text-halo-color": Color.backgroundFill,
     "text-halo-width": 2.0,
   },
   filter: [
@@ -279,9 +280,9 @@ export const country3 = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 1,
-    "text-halo-color": "rgba(255,255,255,0.8)",
-    "text-halo-width": 2.0,
+    "text-halo-blur": 0.5,
+    "text-halo-color": Color.backgroundFill,
+    "text-halo-width": 2,
   },
   filter: [
     "all",
@@ -309,9 +310,9 @@ export const country2 = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 1,
-    "text-halo-color": "rgba(255,255,255,1)",
-    "text-halo-width": 3.0,
+    "text-halo-blur": 0.5,
+    "text-halo-color": Color.backgroundFill,
+    "text-halo-width": 2,
   },
   filter: [
     "all",
@@ -339,9 +340,9 @@ export const country1 = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 1,
-    "text-halo-color": "rgba(255,255,255,1)",
-    "text-halo-width": 3.0,
+    "text-halo-blur": 0.5,
+    "text-halo-color": Color.backgroundFill,
+    "text-halo-width": 2,
   },
   filter: [
     "all",
@@ -377,7 +378,7 @@ export const continent = {
   type: "symbol",
   paint: {
     "text-color": "#633",
-    "text-halo-color": "rgba(255,255,255,0.7)",
+    "text-halo-color": Color.backgroundFill,
     "text-halo-width": 1,
   },
   filter: ["==", ["get", "class"], "continent"],

--- a/src/layer/place.js
+++ b/src/layer/place.js
@@ -5,7 +5,7 @@ const cityLabelPaint = {
   "text-color": "#444",
   "text-halo-color": Color.backgroundFill,
   "text-halo-width": 2,
-  "text-halo-blur": 0.5,
+  "text-halo-blur": 0,
 };
 
 const cityIcon = [
@@ -212,8 +212,13 @@ export const state = {
   paint: {
     "text-color": "hsl(45, 6%, 10%)",
     "text-halo-color": Color.backgroundFill,
-    "text-halo-width": 2,
-    "text-halo-blur": 0.5,
+    "text-halo-width": [
+      'interpolate', ['exponential', 1.2],
+      ['zoom'],
+      3, 1.5,
+      7, 2.7,
+    ],
+    "text-halo-blur": 0,
   },
   filter: ["==", ["get", "class"], "state"],
   layout: {
@@ -251,9 +256,14 @@ export const countryOther = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 0.5,
+    "text-halo-blur": 0,
     "text-halo-color": Color.backgroundFill,
-    "text-halo-width": 2.0,
+    "text-halo-width": [
+      'interpolate', ['linear'],
+      ['zoom'],
+      3, 1.6,
+      7, 2.7,
+    ],
   },
   filter: [
     "all",
@@ -280,9 +290,14 @@ export const country3 = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 0.5,
+    "text-halo-blur": 0,
     "text-halo-color": Color.backgroundFill,
-    "text-halo-width": 2,
+    "text-halo-width": [
+      'interpolate', ['linear'],
+      ['zoom'],
+      3, 1.8,
+      7, 3,
+    ],
   },
   filter: [
     "all",
@@ -310,9 +325,14 @@ export const country2 = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 0.5,
+    "text-halo-blur": 0,
     "text-halo-color": Color.backgroundFill,
-    "text-halo-width": 2,
+    "text-halo-width": [
+      'interpolate', ['linear'],
+      ['zoom'],
+      2, 2,
+      5, 3,
+    ],
   },
   filter: [
     "all",
@@ -326,7 +346,7 @@ export const country2 = {
       stops: [
         [2, 11],
         [5, 17],
-      ],
+    ],
     },
     "text-field": Label.localizedName,
     "text-max-width": 6.25,
@@ -340,9 +360,15 @@ export const country1 = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 0.5,
+    "text-halo-blur": 0,
     "text-halo-color": Color.backgroundFill,
-    "text-halo-width": 2,
+    "text-halo-width": [
+      'interpolate', ['linear'],
+      ['zoom'],
+      1, 2,
+      4, 3,
+      6, 3,
+    ],
   },
   filter: [
     "all",

--- a/src/layer/place.js
+++ b/src/layer/place.js
@@ -6,9 +6,9 @@ const labelHaloColor = [
   ["linear"],
   ["zoom"],
   4,
-  `hsla(${Color.backgroundHsl}, 0.8)`,
+  Color.backgroundFillTranslucent,
   5,
-  `hsl(${Color.backgroundHsl})`,
+  Color.backgroundFill,
 ];
 
 const labelHaloBlur = ["interpolate", ["linear"], ["zoom"], 4, 0.5, 5, 0];

--- a/src/layer/place.js
+++ b/src/layer/place.js
@@ -1,11 +1,23 @@
 import * as Label from "../constants/label.js";
 import * as Color from "../constants/color.js";
 
+const labelHaloColor = [
+  "interpolate",
+  ["linear"],
+  ["zoom"],
+  4,
+  `hsla(${Color.backgroundHsl}, 0.8)`,
+  5,
+  `hsl(${Color.backgroundHsl})`,
+];
+
+const labelHaloBlur = ["interpolate", ["linear"], ["zoom"], 4, 0.5, 5, 0];
+
 const cityLabelPaint = {
   "text-color": "#444",
-  "text-halo-color": Color.backgroundFill,
+  "text-halo-color": labelHaloColor,
   "text-halo-width": 2,
-  "text-halo-blur": 0,
+  "text-halo-blur": labelHaloBlur,
 };
 
 const cityIcon = [
@@ -211,14 +223,17 @@ export const state = {
   type: "symbol",
   paint: {
     "text-color": "hsl(45, 6%, 10%)",
-    "text-halo-color": Color.backgroundFill,
+    "text-halo-color": labelHaloColor,
     "text-halo-width": [
-      'interpolate', ['exponential', 1.2],
-      ['zoom'],
-      3, 1.5,
-      7, 2.7,
+      "interpolate",
+      ["exponential", 1.2],
+      ["zoom"],
+      3,
+      1.5,
+      6,
+      2.5,
     ],
-    "text-halo-blur": 0,
+    "text-halo-blur": labelHaloBlur,
   },
   filter: ["==", ["get", "class"], "state"],
   layout: {
@@ -256,14 +271,9 @@ export const countryOther = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 0,
-    "text-halo-color": Color.backgroundFill,
-    "text-halo-width": [
-      'interpolate', ['linear'],
-      ['zoom'],
-      3, 1.6,
-      7, 2.7,
-    ],
+    "text-halo-blur": 0.5,
+    "text-halo-color": labelHaloColor,
+    "text-halo-width": ["interpolate", ["linear"], ["zoom"], 3, 1.5, 7, 2.5],
   },
   filter: [
     "all",
@@ -290,14 +300,9 @@ export const country3 = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 0,
-    "text-halo-color": Color.backgroundFill,
-    "text-halo-width": [
-      'interpolate', ['linear'],
-      ['zoom'],
-      3, 1.8,
-      7, 3,
-    ],
+    "text-halo-blur": labelHaloBlur,
+    "text-halo-color": labelHaloColor,
+    "text-halo-width": ["interpolate", ["linear"], ["zoom"], 3, 1.5, 7, 2.5],
   },
   filter: [
     "all",
@@ -325,14 +330,9 @@ export const country2 = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 0,
-    "text-halo-color": Color.backgroundFill,
-    "text-halo-width": [
-      'interpolate', ['linear'],
-      ['zoom'],
-      2, 2,
-      5, 3,
-    ],
+    "text-halo-blur": labelHaloBlur,
+    "text-halo-color": labelHaloColor,
+    "text-halo-width": ["interpolate", ["linear"], ["zoom"], 1, 1, 5, 2.4],
   },
   filter: [
     "all",
@@ -346,7 +346,7 @@ export const country2 = {
       stops: [
         [2, 11],
         [5, 17],
-    ],
+      ],
     },
     "text-field": Label.localizedName,
     "text-max-width": 6.25,
@@ -360,14 +360,18 @@ export const country1 = {
   type: "symbol",
   paint: {
     "text-color": "#334",
-    "text-halo-blur": 0,
-    "text-halo-color": Color.backgroundFill,
+    "text-halo-blur": labelHaloBlur,
+    "text-halo-color": labelHaloColor,
     "text-halo-width": [
-      'interpolate', ['linear'],
-      ['zoom'],
-      1, 2,
-      4, 3,
-      6, 3,
+      "interpolate",
+      ["linear"],
+      ["zoom"],
+      1,
+      1,
+      4,
+      2.5,
+      6,
+      3,
     ],
   },
   filter: [
@@ -404,7 +408,8 @@ export const continent = {
   type: "symbol",
   paint: {
     "text-color": "#633",
-    "text-halo-color": Color.backgroundFill,
+    "text-halo-color": labelHaloColor,
+    "text-halo-blur": labelHaloBlur,
     "text-halo-width": 1,
   },
   filter: ["==", ["get", "class"], "continent"],


### PR DESCRIPTION
Ever since @1ec5 improved the road labels halos in #203, I've found the pure white place label halos a bit distracting by comparison.  This PR tones down the place label halos just a bit by giving them a similar knockout style treatment as the road labels.  It's a fairly subtle difference, but I think it makes the labels feel more grounded and less like they are jumping out of the map, especially at lower zoom levels.

**Northeast Before:**
![northeast-before](https://user-images.githubusercontent.com/281482/205801880-94b289eb-7cf0-4e1e-9a3d-ffabd46f2bbc.jpg)

**Northeast After:**
![northeast-after](https://user-images.githubusercontent.com/281482/205801893-87e82829-deb9-4694-8b84-679fa493ebec.jpg)

**Europe Before:**
![europe-before](https://user-images.githubusercontent.com/281482/205802850-e2f61745-5509-4de3-9114-145969c9de2d.jpg)

**Europe After:**
![europe-after](https://user-images.githubusercontent.com/281482/205802877-7c3d7873-1364-47f1-a5a8-392383ac3575.jpg)
