### PR TITLE
Fix street name localization

### DIFF
--- a/src/layer/transportation_label.js
+++ b/src/layer/transportation_label.js
@@ -80,7 +80,7 @@ export const label = {
       ["literal", ["OpenHistorical Italic"]],
       ["literal", ["OpenHistorical"]],
     ],
-    "text-field": Label.localizedName,
+    "text-field": [...Label.localizedName],
     "text-max-angle": 20,
     "symbol-placement": "line",
     "text-size": [


### PR DESCRIPTION
Decoupled the `text-field` expression of `transportation_name` layers from other layers, since the available fields differ. The broader problem is that we’re overrelying on constants everywhere, but a deeper copy avoids the immediate issue that changing other layers’ localization to use, e.g., `name:de` overwrites any localization to `name_de` that has already taken place on this layer.

/ref #618