### PR TITLE
Suppress shields for recreational TLA networks

### DIFF
--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -62,11 +62,15 @@ function compoundShieldSize(dimension, bannerCount) {
   };
 }
 
-function isValidRef(ref) {
-  if (ref == null || ref.length == 0 || ref.length > 6) {
-    return false;
-  }
-  return true;
+export function isValidNetwork(network) {
+  // On recreational route relations, network=* indicates the network's scope,
+  // not the network itself.
+  // https://github.com/ZeLonewolf/openstreetmap-americana/issues/94
+  return !/^[lrni][chimpw]n$/.test(network);
+}
+
+export function isValidRef(ref) {
+  return ref !== null && ref.length !== 0 && ref.length <= 6;
 }
 
 /**
@@ -267,7 +271,9 @@ function getShieldDef(routeDef) {
   if (shieldDef == null) {
     // Default to plain black text with halo and no background shield
     console.debug("Generic shield for", JSON.stringify(routeDef));
-    return isValidRef(routeDef.ref) ? ShieldDef.shields["default"] : null;
+    return isValidNetwork(routeDef.network) && isValidRef(routeDef.ref)
+      ? ShieldDef.shields.default
+      : null;
   }
 
   if (shieldDef.overrideByRef) {

--- a/test/spec/shield.js
+++ b/test/spec/shield.js
@@ -1,0 +1,25 @@
+"use strict";
+
+import chai, { expect } from "chai";
+import * as Shield from "../../src/js/shield.js";
+
+describe("shield", function () {
+  describe("#isValidNetwork", function () {
+    it("rejects a recreational network", function () {
+      expect(Shield.isValidNetwork("BAB")).to.be.true;
+      expect(Shield.isValidNetwork("rwn")).to.be.false;
+    });
+  });
+  describe("#isValidRef", function () {
+    it("rejects a null ref", function () {
+      expect(Shield.isValidRef(null)).to.be.false;
+    });
+    it("rejects an empty ref", function () {
+      expect(Shield.isValidRef("")).to.be.false;
+    });
+    it("rejects a long ref", function () {
+      expect(Shield.isValidRef("ABC123")).to.be.true;
+      expect(Shield.isValidRef("Equator")).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Reject three-letter-acronym recreational `network` values when deciding whether to render a shield. Also added unit tests for `network` and `ref` validation.

[<img src="https://user-images.githubusercontent.com/1231218/209582225-e42c6fdb-6db3-4854-b87f-adccaf4f221d.png" width="400" alt="MMT">](https://zelonewolf.github.io/openstreetmap-americana/#map=15/39.46359/-76.58835)

Fixes #631.