### PR TITLE
Intermittent water fix and refinements

### DIFF
--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -4,6 +4,7 @@ export const backgroundFillTranslucent = `hsla(30, 44%, 96%, 0.8)`;
 export const waterFill = "hsl(211, 50%, 85%)";
 export const waterFillTranslucent = "hsla(211, 50%, 85%, 0.5)";
 export const waterIntermittentFill = "hsla(211, 60%, 85%, 0.3)";
+export const waterIntermittentOutline = "hsl(211, 100%, 30%)";
 export const waterLine = "hsl(211, 42%, 70%)";
 export const waterLineBold = "hsl(211, 42%, 50%)";
 export const waterLabel = "hsl(211, 43%, 28%)";

--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -3,6 +3,7 @@ export const backgroundFillTranslucent = `hsla(30, 44%, 96%, 0.8)`;
 
 export const waterFill = "hsl(211, 50%, 85%)";
 export const waterFillTranslucent = "hsla(211, 50%, 85%, 0.5)";
+export const waterIntermittentFill = "hsla(211, 60%, 85%, 0.3)";
 export const waterLine = "hsl(211, 42%, 70%)";
 export const waterLineBold = "hsl(211, 42%, 50%)";
 export const waterLabel = "hsl(211, 43%, 28%)";

--- a/src/layer/water.js
+++ b/src/layer/water.js
@@ -87,15 +87,19 @@ export const waterLine = {
   id: "water_line",
   type: "line",
   filter: [
+    "all",
+    ["!=", ["get", "intermittent"], 1],
+    [
     "match",
     ["get", "class"],
-    bigRivers,
-    [">=", ["zoom"], 8],
-    mediumRivers,
-    [">=", ["zoom"], 16],
-    "lake",
-    ["all", ["!=", ["get", "intermittent"], 1], [">=", ["zoom"], 8]],
+      bigRivers,
+      [">=", ["zoom"], 8],
+      mediumRivers,
+      [">=", ["zoom"], 16],
+      "lake",
+      [">=", ["zoom"], 8],
     true,
+  ],
   ],
   paint: {
     "line-color": Color.waterLineBold,
@@ -112,11 +116,7 @@ export const waterLineIntermittent = {
   id: "water_line_intermittent",
   type: "line",
   minzoom: 8,
-  filter: [
-    "all",
-    ["==", ["get", "intermittent"], 1],
-    ["==", ["get", "class"], "lake"],
-  ],
+  filter: ["all", ["==", ["get", "intermittent"], 1]],
   paint: {
     "line-color": Color.waterLine,
     "line-dasharray": [6, 4],

--- a/src/layer/water.js
+++ b/src/layer/water.js
@@ -66,16 +66,15 @@ export const water = {
   id: "water",
   type: "fill",
   paint: {
-    "fill-color": Color.waterFill,
-    "fill-opacity": [
+    "fill-color": [
       "case",
       [
         "any",
         ["==", ["get", "intermittent"], 1],
         ["==", ["get", "brunnel"], "tunnel"],
       ],
-      0.3,
-      1,
+      Color.waterIntermittentFill,
+      Color.waterFill,
     ],
     "fill-outline-color": Color.waterFillTranslucent,
   },
@@ -90,16 +89,16 @@ export const waterLine = {
     "all",
     ["!=", ["get", "intermittent"], 1],
     [
-    "match",
-    ["get", "class"],
+      "match",
+      ["get", "class"],
       bigRivers,
       [">=", ["zoom"], 8],
       mediumRivers,
       [">=", ["zoom"], 16],
       "lake",
       [">=", ["zoom"], 8],
-    true,
-  ],
+      true,
+    ],
   ],
   paint: {
     "line-color": Color.waterLineBold,

--- a/src/layer/water.js
+++ b/src/layer/water.js
@@ -117,8 +117,9 @@ export const waterLineIntermittent = {
   minzoom: 8,
   filter: ["all", ["==", ["get", "intermittent"], 1]],
   paint: {
-    "line-color": Color.waterLine,
-    "line-dasharray": [6, 4],
+    "line-color": Color.waterIntermittentOutline,
+    "line-dasharray": [10, 6],
+    "line-width": 0.5,
   },
   layout: waterLine.layout,
   source: "openmaptiles",

--- a/src/layer/water.js
+++ b/src/layer/water.js
@@ -20,17 +20,12 @@ export const waterway = {
   paint: {
     "line-color": [
       "interpolate",
-      ["exponential", 2],
+      ["exponential", 0.5],
       ["zoom"],
       13,
       Color.waterLine,
-      14,
-      [
-        "case",
-        ["==", ["get", "intermittent"], 1],
-        Color.waterLine,
-        Color.waterFill,
-      ],
+      15,
+      Color.waterFill,
     ],
     "line-width": [
       "interpolate",


### PR DESCRIPTION
This PR is a collection of a few fixes and refinements to intermittent water styling.  I fixed #634 where a solid water line instead of a dashed one was rendering for intermittent river areas.  I slightly increased the intermittent water fill saturation for just a bit more distinction from the green park fill.  I explored moving to an opaque fill but didn't come up with anything satisfactory so left it translucent for now.  A pattern with partial transparency could be a future option.  I made the the dashed outline thinner and darker.  I find this better matches the hairline used for the regular water outline.  I also lightened intermittent waterway lines at high zoom so they match the regular waterway line color and blend in a bit better with intermittent water areas that may be drawn around them.  I'd love to hide them entirely under the areas but the area translucency prevents this.

Before:
![Screen Shot 2022-12-26 at 11 43 18 PM](https://user-images.githubusercontent.com/281482/209613377-19148222-f49a-44e5-a040-8663ea8215a7.png)
After:
![Screen Shot 2022-12-26 at 11 43 26 PM](https://user-images.githubusercontent.com/281482/209613384-240e2486-a999-4a3f-a29f-add4a0181cf0.png)


Before:
![Screen Shot 2022-12-26 at 11 45 28 PM](https://user-images.githubusercontent.com/281482/209614970-144b0f5d-6170-4fea-9056-e3a160ca7dc8.png)
After:
![Screen Shot 2022-12-26 at 11 45 24 PM](https://user-images.githubusercontent.com/281482/209614978-8fb1d8b7-f78a-407c-b242-d7fd82f2527e.png)


Before:
<img width="808" alt="Screen Shot 2022-12-27 at 12 02 53 AM" src="https://user-images.githubusercontent.com/281482/209614938-cc4a05b5-0d41-42c6-93ec-2c99f1eec65c.png">
After:
<img width="808" alt="Screen Shot 2022-12-27 at 12 02 49 AM" src="https://user-images.githubusercontent.com/281482/209614941-d9bc87f8-ef1e-4e91-a1e0-00a0e1de188f.png">



