### PR TITLE
Distinguish Greek national roads from motorways

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3326,12 +3326,18 @@ export function loadShields(shieldImages) {
   );
 
   // Greece
-  shields["GR:motorway"] = shields["GR:national"] = hexagonVerticalShield(
+  shields["GR:motorway"] = hexagonVerticalShield(
     3,
     Color.shields.green,
     Color.shields.white,
     Color.shields.white,
     0,
+    34
+  );
+  shields["GR:national"] = roundedRectShield(
+    Color.shields.blue,
+    Color.shields.white,
+    Color.shields.white,
     34
   );
 


### PR DESCRIPTION
Greek national roads have a different shield than Greek motorways: white on a blue rectangle. #139 probably missed this distinction because the two main motorways were incorrectly tagged as `network=GR:national` until [today](https://www.openstreetmap.org/changeset/130621801).

[![Selianitika](https://upload.wikimedia.org/wikipedia/commons/d/d4/Selianitika_Iterchange_Olympia_Odos.jpg)](https://commons.wikimedia.org/wiki/File:Selianitika_Iterchange_Olympia_Odos.jpg)