### PR TITLE
Restore green hexagon shield to test page

### DIFF
--- a/src/shieldtest.js
+++ b/src/shieldtest.js
@@ -69,7 +69,7 @@ let networks = [
   "ID:national",
 
   "AU:QLD:MR",
-  "GR:national",
+  "GR:motorway",
   "my:federal",
   "TR:motorway",
   "US:NY",


### PR DESCRIPTION
#640 changed the Greek national road shield to a blue rectangle. We were using this network as an example for green vertical hexagons, so the example is changed to `GR:motorway`.