### PR TITLE
Format semicolon-delimited value lists in labels

### DIFF
--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -175,7 +175,7 @@ export function replaceExpression(
  * Increasing this constant deepens recursion for replacing delimiters in the
  * list, potentially affecting style loading performance.
  */
-const maxValueListLength = 9;
+const maxValueListLength = 3;
 
 /**
  * Returns an expression interpreting the given string as a list of tag values,

--- a/src/index.html
+++ b/src/index.html
@@ -50,6 +50,9 @@
         width: 0;
         text-align: center;
       }
+      .legend-row > .label {
+        white-space: pre-line;
+      }
       .legend-row > .icon {
         white-space: nowrap;
       }

--- a/src/layer/highway_exit.js
+++ b/src/layer/highway_exit.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import * as Label from "../constants/label.js";
+
 export const exits = {
   id: "highway_exit",
   type: "symbol",
@@ -12,7 +14,7 @@ export const exits = {
   "source-layer": "transportation_name",
   minzoom: 14,
   layout: {
-    "text-field": ["get", "ref"],
+    "text-field": Label.listValuesExpression(["get", "ref"], "\n"),
     "text-font": ["OpenHistorical Bold"],
     "text-size": 9,
     "text-line-height": 1,

--- a/src/layer/transportation_label.js
+++ b/src/layer/transportation_label.js
@@ -80,7 +80,7 @@ export const label = {
       ["literal", ["OpenHistorical Italic"]],
       ["literal", ["OpenHistorical"]],
     ],
-    "text-field": [...Label.localizedName],
+    "text-field": [...Label.localizedNameInline],
     "text-max-angle": 20,
     "symbol-placement": "line",
     "text-size": [

--- a/test/spec/label.js
+++ b/test/spec/label.js
@@ -272,9 +272,9 @@ describe("label", function () {
     let evaluatedLabelAndGloss = (locales, properties) => {
       let evaluated = evaluatedExpression(locales, properties);
       if (typeof evaluated === "string") {
-        return [evaluated, null];
+        return [evaluated];
       }
-      return [evaluated.sections[0].text, evaluated.sections[4].text];
+      return [evaluated.sections[0].text, evaluated.sections[4]?.text];
     };
 
     let expectGloss = (
@@ -295,11 +295,12 @@ describe("label", function () {
     };
 
     it("puts an unlocalized name by itself", function () {
-      expect(
-        evaluatedExpression(["en"], {
-          name: "Null Island",
-        })
-      ).to.be.eql("Null Island");
+      let evaluated = evaluatedExpression(["en"], {
+        name: "Null Island",
+      });
+
+      expect(evaluated.sections.length).to.be.eql(1);
+      expect(evaluated.sections[0].text).to.be.eql("Null Island");
     });
     it("glosses an anglicized name with the local name", function () {
       let evaluated = evaluatedExpression(["en"], {
@@ -321,26 +322,19 @@ describe("label", function () {
       expect(evaluated.sections[5].scale).to.be.below(0.1);
     });
     it("deduplicates matching anglicized and local names", function () {
-      expectGloss("en", "Null Island", "Null Island", "Null Island", null);
-      expectGloss("en", "Null Island", "NULL Island", "Null Island", null);
-      expectGloss("en", "Montreal", "Montréal", "Montréal", null);
-      expectGloss("en", "Quebec City", "Québec", "Québec City", null);
-      expectGloss("en", "Da Nang", "Đà Nẵng", "Đà Nẵng", null);
-      expectGloss("en", "Nūll Island", "Ñüłl Íşlåńđ", "Ñüłl Íşlåńđ", null);
-      expectGloss("en", "New York City", "New York", "New York City", null);
-      expectGloss(
-        "en",
-        "Washington, D.C.",
-        "Washington",
-        "Washington, D.C.",
-        null
-      );
+      expectGloss("en", "Null Island", "Null Island", "Null Island");
+      expectGloss("en", "Null Island", "NULL Island", "Null Island");
+      expectGloss("en", "Montreal", "Montréal", "Montréal");
+      expectGloss("en", "Quebec City", "Québec", "Québec City");
+      expectGloss("en", "Da Nang", "Đà Nẵng", "Đà Nẵng");
+      expectGloss("en", "Nūll Island", "Ñüłl Íşlåńđ", "Ñüłl Íşlåńđ");
+      expectGloss("en", "New York City", "New York", "New York City");
+      expectGloss("en", "Washington, D.C.", "Washington", "Washington, D.C.");
       expectGloss(
         "en",
         "Santiago de Querétaro",
         "Querétaro",
-        "Santiago de Querétaro",
-        null
+        "Santiago de Querétaro"
       );
 
       // Suboptimal but expected cases
@@ -367,6 +361,171 @@ describe("label", function () {
       expectGloss("es", "Quebec", "Québec", "Quebec", "Québec");
       expectGloss("pl", "Ryga", "Rīga", "Ryga", "Rīga");
       expectGloss("pl", "Jurmała", "Jūrmala", "Jurmała", "Jūrmala");
+    });
+  });
+
+  describe("#replaceExpression", function () {
+    let evaluatedExpression = (
+      haystack,
+      needle,
+      replacement,
+      haystackStart,
+      numReplacements
+    ) =>
+      expression
+        .createExpression(
+          localizedTextField(
+            [
+              ...Label.replaceExpression(
+                haystack,
+                needle,
+                replacement,
+                haystackStart,
+                numReplacements
+              ),
+            ],
+            ["en"]
+          )
+        )
+        .value.expression.evaluate(expressionContext({}));
+
+    it("returns the haystack verbatim when there is nothing to replace", function () {
+      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, -1)).to.be.eql(
+        "ABC;DEF;GHI"
+      );
+      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, 0)).to.be.eql(
+        "ABC;DEF;GHI"
+      );
+    });
+
+    it("returns an empty haystack verbatim", function () {
+      expect(evaluatedExpression("", ";", "*", 0, -1)).to.be.eql("");
+      expect(evaluatedExpression("", ";", "*", 0, 0)).to.be.eql("");
+      expect(evaluatedExpression("", ";", "*", 0, 1)).to.be.eql("");
+      expect(evaluatedExpression("", ";", "*", 0, 2)).to.be.eql("");
+    });
+
+    it("replaces one occurrence", function () {
+      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, 1)).to.be.eql(
+        "ABC*DEF;GHI"
+      );
+    });
+
+    it("replaces multiple occurrences", function () {
+      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, 2)).to.be.eql(
+        "ABC*DEF*GHI"
+      );
+      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, 3)).to.be.eql(
+        "ABC*DEF*GHI"
+      );
+      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, 10)).to.be.eql(
+        "ABC*DEF*GHI"
+      );
+    });
+
+    it("replaces adjacent occurrences", function () {
+      expect(evaluatedExpression("ABC;;;DEF;GHI", ";", "*", 0, 2)).to.be.eql(
+        "ABC**;DEF;GHI"
+      );
+    });
+
+    it("replaces at the beginning of the haystack", function () {
+      expect(evaluatedExpression(";DEF;GHI", ";", "*", 0, 1)).to.be.eql(
+        "*DEF;GHI"
+      );
+    });
+
+    it("replaces at the end of the haystack", function () {
+      expect(evaluatedExpression("ABC;", ";", "*", 0, 1)).to.be.eql("ABC*");
+    });
+
+    it("replaces the whole haystack", function () {
+      expect(evaluatedExpression(";", ";", "*", 0, 1)).to.be.eql("*");
+      expect(evaluatedExpression(";;;", ";", "*", 0, 3)).to.be.eql("***");
+    });
+
+    it("is case-sensitive", function () {
+      expect(evaluatedExpression("ABC", "b", "*", 0, 1)).to.be.eql("ABC");
+    });
+
+    it("replaces multiple characters", function () {
+      expect(evaluatedExpression("ABC;;DEF", ";;", "/", 0, 1)).to.be.eql(
+        "ABC/DEF"
+      );
+    });
+
+    it("replaces needle expression", function () {
+      expect(
+        evaluatedExpression("ABC;DEF", ["concat", ";"], "*", 0, 1)
+      ).to.be.eql("ABC*DEF");
+    });
+
+    it("replaces replacement expression", function () {
+      expect(
+        evaluatedExpression("ABC;DEF", ";", ["slice", "*", 0], 0, 1)
+      ).to.be.eql("ABC*DEF");
+    });
+  });
+
+  describe("#listValuesExpression", function () {
+    let evaluatedExpression = (valueList, separator) =>
+      expression
+        .createExpression(
+          localizedTextField(
+            [...Label.listValuesExpression(valueList, separator)],
+            ["en"]
+          )
+        )
+        .value.expression.evaluate(expressionContext({}));
+
+    it("lists an empty list", function () {
+      expect(evaluatedExpression("", ", ")).to.be.eql("");
+    });
+
+    it("lists a single value", function () {
+      expect(evaluatedExpression("ABC", ", ")).to.be.eql("ABC");
+    });
+
+    it("lists empty values", function () {
+      expect(evaluatedExpression(";", ", ")).to.be.eql(", ");
+    });
+
+    it("lists multiple values", function () {
+      expect(evaluatedExpression("ABC;DEF", ", ")).to.be.eql("ABC, DEF");
+      expect(evaluatedExpression("ABC;DEF;GHI", ", ")).to.be.eql(
+        "ABC, DEF, GHI"
+      );
+    });
+
+    it("ignores an escaped semicolon", function () {
+      expect(evaluatedExpression("ABC;;DEF", ", ")).to.be.eql("ABC;DEF");
+      expect(evaluatedExpression("ABC;;DEF;GHI", ", ")).to.be.eql(
+        "ABC;DEF, GHI"
+      );
+      expect(evaluatedExpression("ABC;DEF;;GHI", ", ")).to.be.eql(
+        "ABC, DEF;GHI"
+      );
+      expect(evaluatedExpression("ABC;;DEF;;GHI", ", ")).to.be.eql(
+        "ABC;DEF;GHI"
+      );
+    });
+
+    it("lists a maximum number of values", function () {
+      // https://www.openstreetmap.org/node/9816809799
+      expect(
+        evaluatedExpression(
+          "马岔河村;菜园村;刘灿东村;后于口村;王石楼村;李岔河村;岔河新村;富康新村;前鱼口村",
+          "、"
+        )
+      ).to.be.eql(
+        "马岔河村、菜园村、刘灿东村、后于口村、王石楼村、李岔河村、岔河新村、富康新村、前鱼口村"
+      );
+      expect(
+        evaluatedExpression(
+          "one;two;three;four;five;six;seven;eight;nine;ten",
+          ", "
+        )
+      ).to.be.eql("one, two, three, four, five, six, seven, eight, nine;ten");
     });
   });
 });

--- a/test/spec/label.js
+++ b/test/spec/label.js
@@ -518,14 +518,14 @@ describe("label", function () {
           "、"
         )
       ).to.be.eql(
-        "马岔河村、菜园村、刘灿东村、后于口村、王石楼村、李岔河村、岔河新村、富康新村、前鱼口村"
+        "马岔河村、菜园村、刘灿东村;后于口村;王石楼村;李岔河村;岔河新村;富康新村;前鱼口村"
       );
       expect(
         evaluatedExpression(
           "one;two;three;four;five;six;seven;eight;nine;ten",
           ", "
         )
-      ).to.be.eql("one, two, three, four, five, six, seven, eight, nine;ten");
+      ).to.be.eql("one, two, three;four;five;six;seven;eight;nine;ten");
     });
   });
 });


### PR DESCRIPTION
Whenever a feature’s name contains multiple values separated by semicolons, the label now puts each value on a separate line or separates them with an elegant bullet, for up to nine values, honoring the `;;` escape sequence.

This implementation includes a general-purpose polyfill for a string replacement expression operator. We can use it for any purpose in an expression or filter but need to be careful about avoiding a combinatoric explosion in the size of an expression’s code. I’ve included a comprehensive battery of unit tests.

[<img src="https://user-images.githubusercontent.com/1231218/210672796-317ba77e-0d7a-4d96-a8b4-d5077a415f44.png" width="400" alt="Kaser">](https://zelonewolf.github.io/openstreetmap-americana/#language=mul&map=12/41.13779/-74.0456) <img src="https://user-images.githubusercontent.com/1231218/210672673-5c3a120a-2408-4cee-9454-1a2e65bda59b.png" width="255" alt="Kaser legend">
_[Kaser](https://www.openstreetmap.org/node/158859890) and [New Square](https://www.openstreetmap.org/node/158856497), New York_

[<img src="https://user-images.githubusercontent.com/1231218/210674176-897d39a2-498f-4d1a-827b-ab1a3c15efce.png" width="400" alt="Machahe">](https://zelonewolf.github.io/openstreetmap-americana/#map=13/35.90759/115.95543&language=mul) <img src="https://user-images.githubusercontent.com/1231218/210674089-a384632e-8fab-4090-aa84-66418cc50df5.png" width="204" alt="Machahe legend">
_[Machahe/Caiyuan/Liucandong/Houyukou/Wangshilou/Lichahe/Chahexin/Fukangxin/Qianyukou villages](https://www.openstreetmap.org/node/9816809799) in Liangshan County, Jining City, Shandong, China_

[<img src="https://user-images.githubusercontent.com/1231218/210675752-00fa54e7-b22d-45e6-8616-7842581f18fc.png" width="400" alt="Viet Heritage Garden">](https://zelonewolf.github.io/openstreetmap-americana/#map=15/37.32391/-121.85512&language=mul)
_[Viet Heritage Garden](https://www.openstreetmap.org/way/765864912), San José, California_

[<img src="https://user-images.githubusercontent.com/1231218/210675057-19b796c6-18ba-4f89-afb6-e4b15bb71c35.png" width="1000" alt="Columbus Cincinnati Road">](https://zelonewolf.github.io/openstreetmap-americana/#map=20.91/39.3028071/-84.3879331/-62.9&language=mul)
_[Columbus Cincinnati Road/Cincinnati–Columbus Road](https://www.openstreetmap.org/way/679125385) in West Chester Township, Butler County, Ohio_

[<img src="https://user-images.githubusercontent.com/1231218/210677193-d6efde70-3d67-4c3a-99b8-b4e3a6873dc5.png" width="400" alt="63A&B">](https://zelonewolf.github.io/openstreetmap-americana/#map=14/39.1059/-84.28081) <img src="https://user-images.githubusercontent.com/1231218/210677067-c3fdf38c-9bc9-4f93-bf3d-1375a4969452.png" width="316" alt="63A&B legend">
_Southbound Interstate 275 at [exits 63A/B](https://www.openstreetmap.org/node/246821345) in Union Township, Clermont County, Ohio_

Fixes #665.