### PR TITLE
Use inline delimiter in waterway labels

### DIFF
--- a/src/layer/water.js
+++ b/src/layer/water.js
@@ -136,7 +136,7 @@ const labelPaintProperties = {
 
 const labelLayoutProperties = {
   "symbol-placement": "line",
-  "text-field": Label.localizedName,
+  "text-field": Label.localizedNameInline,
   "text-font": ["OpenHistorical Italic"],
   "text-max-angle": 55,
 };


### PR DESCRIPTION
Use the inline, bullet-delimited version of the localized label on waterways.

[<img src="https://user-images.githubusercontent.com/1231218/210970913-04ac52db-ec86-4b99-8a5e-6899154d3a90.png" width="400" alt="Imjin River">](https://zelonewolf.github.io/openstreetmap-americana/#map=15/38.14831/126.96621&language=mul) [<img src="https://user-images.githubusercontent.com/1231218/210970985-1d06fa60-81a4-4d8e-a032-9b52826bca19.png" width="400" alt="Amu Darya">](https://zelonewolf.github.io/openstreetmap-americana/#map=12/38.04452/65.0214&language=mul)

Fixes #668.