### PR TITLE
Deduplicate names in gloss; gloss towns

### DIFF
--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -295,13 +295,18 @@ export const localizedName = [
 ];
 
 /**
+ * The separator to use in inline contexts.
+ */
+const inlineSeparator = " \u2022 ";
+
+/**
  * The names in the user's preferred language, all on the same line.
  */
 export const localizedNameInline = [
   "let",
   "localizedName",
   "",
-  listValuesExpression(["var", "localizedName"], " \u2022 "),
+  listValuesExpression(["var", "localizedName"], inlineSeparator),
 ];
 
 /**
@@ -442,7 +447,7 @@ export const localizedNameWithLocalGloss = [
       // bother rendering it.
       ["concat", ["slice", ["var", "localizedName"], 0, 1], " "],
       { "font-scale": 0.001 },
-      listValuesExpression(["get", "name"], " \u2022 ", [
+      listValuesExpression(["get", "name"], inlineSeparator, [
         "var",
         "localizedName",
       ]),

--- a/src/layer/place.js
+++ b/src/layer/place.js
@@ -135,7 +135,7 @@ export const town = {
         [11, 0.7],
       ],
     },
-    "text-field": Label.localizedName,
+    "text-field": Label.localizedNameWithLocalGloss,
     "text-anchor": "bottom",
     "text-variable-anchor": [
       "bottom",

--- a/test/spec/label.js
+++ b/test/spec/label.js
@@ -365,11 +365,11 @@ describe("label", function () {
   });
 
   describe("#listValuesExpression", function () {
-    let evaluatedExpression = (valueList, separator) =>
+    let evaluatedExpression = (valueList, separator, valueToOmit) =>
       expression
         .createExpression(
           localizedTextField(
-            [...Label.listValuesExpression(valueList, separator)],
+            [...Label.listValuesExpression(valueList, separator, valueToOmit)],
             ["en"]
           )
         )
@@ -394,6 +394,10 @@ describe("label", function () {
       );
       expect(evaluatedExpression(";ABC;DEF", ", ")).to.be.eql(", ABC, DEF");
       expect(evaluatedExpression("ABC;DEF;", ", ")).to.be.eql("ABC, DEF, ");
+    });
+
+    it("ignores a space after a semicolon", function () {
+      expect(evaluatedExpression("ABC; DEF", ", ")).to.be.eql("ABC, DEF");
     });
 
     it("ignores an escaped semicolon", function () {
@@ -433,6 +437,21 @@ describe("label", function () {
           ", "
         )
       ).to.be.eql("one, two, three;four;five;six;seven;eight;nine;ten");
+    });
+
+    it("omits a specified value", function () {
+      expect(evaluatedExpression("ABC;DEF;GHI", ", ", "")).to.be.eql(
+        "ABC, DEF, GHI"
+      );
+      expect(evaluatedExpression("ABC;DEF;GHI", ", ", "ABC")).to.be.eql(
+        "DEF, GHI"
+      );
+      expect(evaluatedExpression("ABC;DEF;GHI", ", ", "DEF")).to.be.eql(
+        "ABC, GHI"
+      );
+      expect(evaluatedExpression("ABC;DEF;GHI", ", ", "GHI")).to.be.eql(
+        "ABC, DEF"
+      );
     });
   });
 });

--- a/test/spec/label.js
+++ b/test/spec/label.js
@@ -364,109 +364,6 @@ describe("label", function () {
     });
   });
 
-  describe("#replaceExpression", function () {
-    let evaluatedExpression = (
-      haystack,
-      needle,
-      replacement,
-      haystackStart,
-      numReplacements
-    ) =>
-      expression
-        .createExpression(
-          localizedTextField(
-            [
-              ...Label.replaceExpression(
-                haystack,
-                needle,
-                replacement,
-                haystackStart,
-                numReplacements
-              ),
-            ],
-            ["en"]
-          )
-        )
-        .value.expression.evaluate(expressionContext({}));
-
-    it("returns the haystack verbatim when there is nothing to replace", function () {
-      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, -1)).to.be.eql(
-        "ABC;DEF;GHI"
-      );
-      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, 0)).to.be.eql(
-        "ABC;DEF;GHI"
-      );
-    });
-
-    it("returns an empty haystack verbatim", function () {
-      expect(evaluatedExpression("", ";", "*", 0, -1)).to.be.eql("");
-      expect(evaluatedExpression("", ";", "*", 0, 0)).to.be.eql("");
-      expect(evaluatedExpression("", ";", "*", 0, 1)).to.be.eql("");
-      expect(evaluatedExpression("", ";", "*", 0, 2)).to.be.eql("");
-    });
-
-    it("replaces one occurrence", function () {
-      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, 1)).to.be.eql(
-        "ABC*DEF;GHI"
-      );
-    });
-
-    it("replaces multiple occurrences", function () {
-      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, 2)).to.be.eql(
-        "ABC*DEF*GHI"
-      );
-      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, 3)).to.be.eql(
-        "ABC*DEF*GHI"
-      );
-      expect(evaluatedExpression("ABC;DEF;GHI", ";", "*", 0, 10)).to.be.eql(
-        "ABC*DEF*GHI"
-      );
-    });
-
-    it("replaces adjacent occurrences", function () {
-      expect(evaluatedExpression("ABC;;;DEF;GHI", ";", "*", 0, 2)).to.be.eql(
-        "ABC**;DEF;GHI"
-      );
-    });
-
-    it("replaces at the beginning of the haystack", function () {
-      expect(evaluatedExpression(";DEF;GHI", ";", "*", 0, 1)).to.be.eql(
-        "*DEF;GHI"
-      );
-    });
-
-    it("replaces at the end of the haystack", function () {
-      expect(evaluatedExpression("ABC;", ";", "*", 0, 1)).to.be.eql("ABC*");
-    });
-
-    it("replaces the whole haystack", function () {
-      expect(evaluatedExpression(";", ";", "*", 0, 1)).to.be.eql("*");
-      expect(evaluatedExpression(";;;", ";", "*", 0, 3)).to.be.eql("***");
-    });
-
-    it("is case-sensitive", function () {
-      expect(evaluatedExpression("ABC", "b", "*", 0, 1)).to.be.eql("ABC");
-    });
-
-    it("replaces multiple characters", function () {
-      expect(evaluatedExpression("ABC;;DEF", ";;", "/", 0, 1)).to.be.eql(
-        "ABC/DEF"
-      );
-    });
-
-    it("replaces needle expression", function () {
-      expect(
-        evaluatedExpression("ABC;DEF", ["concat", ";"], "*", 0, 1)
-      ).to.be.eql("ABC*DEF");
-    });
-
-    it("replaces replacement expression", function () {
-      expect(
-        evaluatedExpression("ABC;DEF", ";", ["slice", "*", 0], 0, 1)
-      ).to.be.eql("ABC*DEF");
-    });
-  });
-
   describe("#listValuesExpression", function () {
     let evaluatedExpression = (valueList, separator) =>
       expression
@@ -495,6 +392,8 @@ describe("label", function () {
       expect(evaluatedExpression("ABC;DEF;GHI", ", ")).to.be.eql(
         "ABC, DEF, GHI"
       );
+      expect(evaluatedExpression(";ABC;DEF", ", ")).to.be.eql(", ABC, DEF");
+      expect(evaluatedExpression("ABC;DEF;", ", ")).to.be.eql("ABC, DEF, ");
     });
 
     it("ignores an escaped semicolon", function () {
@@ -507,6 +406,14 @@ describe("label", function () {
       );
       expect(evaluatedExpression("ABC;;DEF;;GHI", ", ")).to.be.eql(
         "ABC;DEF;GHI"
+      );
+      expect(evaluatedExpression("ABC;;;DEF", ", ")).to.be.eql("ABC;, DEF");
+      expect(evaluatedExpression("ABC;;;;DEF", ", ")).to.be.eql("ABC;;DEF");
+    });
+
+    it("accepts an expression as the separator", function () {
+      expect(evaluatedExpression("ABC;DEF", ["concat", ", "])).to.be.eql(
+        "ABC, DEF"
       );
     });
 


### PR DESCRIPTION
Replaced the general-purpose function for generating string replacement expressions with a function for generating an expression that specifically scans a string for semicolon delimiters, escaped semicolons, and space padding after a semicolon. Compared to #666, this change decreases the overall minified style JSON size[^size] (a rough proxy for style complexity) from 954,393&nbsp;characters down to just 932,343&nbsp;characters.

With this optimization in place, a city’s local-language name gloss now omits any name that matches the city’s name in the user’s preferred language to avoid repetition. This brings the size back up to 943,759&nbsp;characters. Unfortunately, every multilingual `place=city` is currently tagged with a `name` that contains delimiters other than a semicolon, making this enhancement rather pointless. To make this deduplication worthwhile, this PR also enables a local-name gloss on `town`s too.

Previously, I mentioned in https://github.com/ZeLonewolf/openstreetmap-americana/issues/471#issue-1292150160 that American maps and atlases only gloss major city labels, but we’ve already been glossing every `city` label. Spot-checking shows that label density isn’t suffering too much from the more verbose town labels, and in any case we support zooming in. The one downside to enabling glosses on town labels is that the town label layer has to repeat the massive expression that we’ve been using for cities: we’re back up to 952,745&nbsp;characters&nbsp;– still less than we started out with, but only slightly.

[<img src="https://user-images.githubusercontent.com/1231218/211128681-f29f83cc-fcc1-4fe0-8800-04532c6068d0.png" width="400" alt="Kaser and New Square">](https://zelonewolf.github.io/openstreetmap-americana/#map=12/41.13986/-74.0432&language=en)

<table>
<thead>
<tr>
<th>Change</th><th>Style JSON size (characters)</th>
</tr>
</thead>
<tbody>
<tr>
<td>replacer</td><td align="right">954,393</td>
</tr>
<tr>
<td>− replacer + scanner</td><td align="right">−22,050</td>
</tr>
<tr>
<td>+ deduplication</td><td align="right">+11,416</td>
</tr>
<tr>
<td>+ town glosses</td><td align="right">+8,986</td>
</tr>
</tbody>
<tfoot>
<tr>
<th scope="row">Net change</th><td align="right">−1,648</td>
</tfoot>
</table>

/ref https://github.com/ZeLonewolf/openstreetmap-americana/pull/592#discussion_r1035284310 https://github.com/ZeLonewolf/openstreetmap-americana/pull/666#issuecomment-1372443684

[^size]: `JSON.stringify(map.getStyle()).length`