### PR TITLE
Fix conversion from `fill-opacity` to CSS

### DIFF
--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -340,15 +340,14 @@ export default class LegendControl {
     let fillColor =
       fill?.layer.paint["fill-color"] ||
       fill?.layer.paint["fill-extrusion-color"];
-    if (fillColor) {
-      let opacity =
-        fill?.layer.paint["fill-opacity"] ??
-        fill?.layer.paint["fill-extrusion-opacity"] ??
-        fillColor.a ??
-        1;
-      fillColor = `rgba(${fillColor.r * 255}, ${fillColor.g * 255}, ${
-        fillColor.b * 255
-      }, ${opacity})`;
+    let fillOpacity =
+      fill?.layer.paint["fill-opacity"] ??
+      fill?.layer.paint["fill-extrusion-opacity"];
+    if (fillColor && fillOpacity) {
+      let opacity = fillOpacity ?? fillColor.a ?? 1;
+      fillColor = `rgba(${(fillColor.r * 255) / opacity}, ${
+        (fillColor.g * 255) / opacity
+      }, ${(fillColor.b * 255) / opacity}, ${opacity})`;
     }
     let borderStyle = "solid";
     if (stroke?.layer.paint["line-dasharray"]) {

--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -340,9 +340,7 @@ export default class LegendControl {
     let fillColor =
       fill?.layer.paint["fill-color"] ||
       fill?.layer.paint["fill-extrusion-color"];
-    let fillOpacity =
-      fill?.layer.paint["fill-opacity"] ??
-      fill?.layer.paint["fill-extrusion-opacity"];
+    let fillOpacity = fill?.layer.paint["fill-opacity"];
     if (fillColor && fillOpacity) {
       let opacity = fillOpacity ?? fillColor.a ?? 1;
       fillColor = `rgba(${(fillColor.r * 255) / opacity}, ${
@@ -364,6 +362,7 @@ export default class LegendControl {
         stroke?.layer.paint["line-color"] || fillColor || "transparent",
       borderStyle: borderStyle,
       borderWidth: `${stroke?.layer.paint["line-width"] ?? 1}px`,
+      opacity: fill?.layer.paint["fill-extrusion-opacity"] ?? 1,
     };
   }
 


### PR DESCRIPTION
Unmultiply RGB components by the alpha component. If `fill-opacity` is unspecified, use `fill-color` directly in CSS. Apply `fill-extrusion-opacity` to the whole feature, not just its fill.

[<img src="https://user-images.githubusercontent.com/1231218/211167412-9e2ba533-77ee-4227-839f-2eb986a8ee53.png" width="700" alt="Tucson">](https://zelonewolf.github.io/openstreetmap-americana/#map=14/32.11553/-110.83281)

Fixes #664.