### PR TITLE
Split localized name on semicolons before gloss

### DIFF
--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -437,7 +437,7 @@ export const localizedNameWithLocalGloss = [
     // localized name.
     [
       "format",
-      ["var", "localizedName"],
+      listValuesExpression(["var", "localizedName"], "\n"),
       "\n",
       "(\u200B",
       { "font-scale": 0.8 },

--- a/test/spec/label.js
+++ b/test/spec/label.js
@@ -302,6 +302,16 @@ describe("label", function () {
       expect(evaluated.sections.length).to.be.eql(1);
       expect(evaluated.sections[0].text).to.be.eql("Null Island");
     });
+    it("spreads multiple unlocalized names across multiple lines", function () {
+      let evaluated = evaluatedExpression(["en"], {
+        name: "Null Island;Insula Nullius",
+      });
+
+      expect(evaluated.sections.length).to.be.eql(1);
+      expect(evaluated.sections[0].text).to.be.eql(
+        "Null Island\nInsula Nullius"
+      );
+    });
     it("glosses an anglicized name with the local name", function () {
       let evaluated = evaluatedExpression(["en"], {
         "name:en": "Null Island",
@@ -361,6 +371,45 @@ describe("label", function () {
       expectGloss("es", "Quebec", "Québec", "Quebec", "Québec");
       expectGloss("pl", "Ryga", "Rīga", "Ryga", "Rīga");
       expectGloss("pl", "Jurmała", "Jūrmala", "Jurmała", "Jūrmala");
+    });
+    it("glosses multiple local names", function () {
+      expectGloss(
+        "en",
+        "Null Island",
+        "Terra Nullius;空虛島",
+        "Null Island",
+        "Terra Nullius • 空虛島"
+      );
+    });
+    it("deduplicates anglicized name and one of the local names", function () {
+      expectGloss(
+        "en",
+        "Null Island",
+        "Null Island;Terra Nullius;空虛島",
+        "Null Island",
+        "Terra Nullius • 空虛島"
+      );
+      expectGloss(
+        "en",
+        "Null Island",
+        "Terra Nullius;Null Island;空虛島",
+        "Null Island",
+        "Terra Nullius • 空虛島"
+      );
+      expectGloss(
+        "en",
+        "Null Island",
+        "Terra Nullius;空虛島;Null Island",
+        "Null Island",
+        "Terra Nullius • 空虛島"
+      );
+      expectGloss(
+        "en",
+        "Null Island",
+        "Null Island;Null Island;Null Island",
+        "Null Island",
+        ""
+      );
     });
   });
 


### PR DESCRIPTION
The semicolon-related changes in #666 left out one part of the massive `text-field` expression that inserts the localized name before the local-language gloss. Now non-native `name:*` tags that contain semicolons will also benefit from semicolon splitting.

[<img src="https://user-images.githubusercontent.com/1231218/211177220-badf6c18-ba09-4e52-9812-3f9dc16be7a6.png" width="400" alt="San Francisco">](https://zelonewolf.github.io/openstreetmap-americana/#map=10/37.8435/-122.3284&language=zh)