### PR TITLE
Filter out more transparent road, rail features from legend

### DIFF
--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -164,6 +164,14 @@ export default class LegendControl {
     let mainFeature = features[0];
     if (!mainFeature) return;
 
+    // No point in illustrating an invisible line.
+    if (
+      mainFeature.layer.type === "line" &&
+      mainFeature.layer.paint?.["line-opacity"] === 0
+    ) {
+      return;
+    }
+
     // Copy the entry, adding the first match, which is from the topmost layer.
     let matchedEntry = { feature: mainFeature };
     Object.assign(matchedEntry, entry);

--- a/src/layer/rail.js
+++ b/src/layer/rail.js
@@ -490,7 +490,6 @@ const isNarrowGauge = ["==", ["get", "subclass"], "narrow_gauge"];
 const isSubway = ["==", ["get", "subclass"], "subway"];
 const isLightRail = ["==", ["get", "subclass"], "light_rail"];
 const isTram = ["==", ["get", "subclass"], "tram"];
-const isNotTransparent = [">", opacity, 0];
 
 export const legendEntries = [
   {
@@ -516,12 +515,12 @@ export const legendEntries = [
   {
     description: "Subway line",
     layers: [railwayTunnel.fill().id, railway.fill().id],
-    filter: ["all", isSubway, isNotService, isNotCrossover, isNotTransparent],
+    filter: ["all", isSubway, isNotService, isNotCrossover],
   },
   {
     description: "Subway siding or yard track",
     layers: [railwayTunnel.fill().id, railway.fill().id],
-    filter: ["all", isSubway, isService, isNotTransparent],
+    filter: ["all", isSubway, isService],
   },
   {
     description: "Monorail line",
@@ -534,38 +533,31 @@ export const legendEntries = [
       ["==", ["get", "subclass"], "monorail"],
       isNotService,
       isNotCrossover,
-      isNotTransparent,
     ],
   },
   {
     description: "Light rail line",
     layers: [lightRailTram.dashes().id, railway.fill().id],
-    filter: [
-      "all",
-      isLightRail,
-      isNotService,
-      isNotCrossover,
-      isNotTransparent,
-    ],
+    filter: ["all", isLightRail, isNotService, isNotCrossover],
   },
   {
     description: "Light rail siding or yard track",
     layers: [lightRailTramService.dashes().id, railway.fill().id],
-    filter: ["all", isLightRail, isService, isNotTransparent],
+    filter: ["all", isLightRail, isService],
   },
   {
     description: "Streetcar line",
     layers: [lightRailTram.dashes().id, railway.fill().id],
-    filter: ["all", isTram, isNotService, isNotCrossover, isNotTransparent],
+    filter: ["all", isTram, isNotService, isNotCrossover],
   },
   {
     description: "Streetcar siding or yard track",
     layers: [lightRailTramService.dashes().id, railway.fill().id],
-    filter: ["all", isTram, isService, isNotTransparent],
+    filter: ["all", isTram, isService],
   },
   {
     description: "Funicular or inclined elevator",
     layers: [funicular.dashes().id, railway.fill().id],
-    filter: ["all", ["==", ["get", "subclass"], "funicular"], isNotTransparent],
+    filter: ["==", ["get", "subclass"], "funicular"],
   },
 ];

--- a/src/layer/rail.js
+++ b/src/layer/rail.js
@@ -490,6 +490,7 @@ const isNarrowGauge = ["==", ["get", "subclass"], "narrow_gauge"];
 const isSubway = ["==", ["get", "subclass"], "subway"];
 const isLightRail = ["==", ["get", "subclass"], "light_rail"];
 const isTram = ["==", ["get", "subclass"], "tram"];
+const isNotTransparent = [">", opacity, 0];
 
 export const legendEntries = [
   {
@@ -515,12 +516,12 @@ export const legendEntries = [
   {
     description: "Subway line",
     layers: [railwayTunnel.fill().id, railway.fill().id],
-    filter: ["all", isSubway, isNotService, isNotCrossover],
+    filter: ["all", isSubway, isNotService, isNotCrossover, isNotTransparent],
   },
   {
     description: "Subway siding or yard track",
     layers: [railwayTunnel.fill().id, railway.fill().id],
-    filter: ["all", isSubway, isService],
+    filter: ["all", isSubway, isService, isNotTransparent],
   },
   {
     description: "Monorail line",
@@ -533,31 +534,38 @@ export const legendEntries = [
       ["==", ["get", "subclass"], "monorail"],
       isNotService,
       isNotCrossover,
+      isNotTransparent,
     ],
   },
   {
     description: "Light rail line",
     layers: [lightRailTram.dashes().id, railway.fill().id],
-    filter: ["all", isLightRail, isNotService, isNotCrossover],
+    filter: [
+      "all",
+      isLightRail,
+      isNotService,
+      isNotCrossover,
+      isNotTransparent,
+    ],
   },
   {
     description: "Light rail siding or yard track",
     layers: [lightRailTramService.dashes().id, railway.fill().id],
-    filter: ["all", isLightRail, isService],
+    filter: ["all", isLightRail, isService, isNotTransparent],
   },
   {
     description: "Streetcar line",
     layers: [lightRailTram.dashes().id, railway.fill().id],
-    filter: ["all", isTram, isNotService, isNotCrossover],
+    filter: ["all", isTram, isNotService, isNotCrossover, isNotTransparent],
   },
   {
     description: "Streetcar siding or yard track",
     layers: [lightRailTramService.dashes().id, railway.fill().id],
-    filter: ["all", isTram, isService],
+    filter: ["all", isTram, isService, isNotTransparent],
   },
   {
     description: "Funicular or inclined elevator",
     layers: [funicular.dashes().id, railway.fill().id],
-    filter: ["==", ["get", "subclass"], "funicular"],
+    filter: ["all", ["==", ["get", "subclass"], "funicular"], isNotTransparent],
   },
 ];

--- a/src/layer/road.js
+++ b/src/layer/road.js
@@ -1196,6 +1196,7 @@ export const secondaryLinkTollBridge = new SecondaryLinkTollBridge();
 export const tertiaryLinkBridge = new TertiaryLinkBridge();
 export const tertiaryLinkTollBridge = new TertiaryLinkTollBridge();
 
+const isNotTransparent = [">", opacity, 0];
 const normalRoadLayers = [
   motorway.fill().id,
   motorway.casing().id,
@@ -1211,7 +1212,7 @@ export const legendEntries = [
   {
     description: "Freeway (controlled access, divided)",
     layers: [motorway.fill().id, motorway.casing().id],
-    filter: ["all", isNotToll, [">", opacity, 0]],
+    filter: ["all", isNotToll, isNotTransparent],
   },
   {
     description: "Expressway (limited access, divided)",
@@ -1257,6 +1258,7 @@ export const legendEntries = [
       "all",
       ["==", getClass, "service"],
       [...smallServiceSelector, true, false],
+      isNotTransparent,
     ],
   },
   {
@@ -1284,6 +1286,6 @@ export const legendEntries = [
       minor.fill().id,
       roadSimpleCasing.casing().id,
     ],
-    filter: isUnpaved,
+    filter: ["all", isUnpaved, isNotTransparent],
   },
 ];

--- a/src/layer/road.js
+++ b/src/layer/road.js
@@ -1196,7 +1196,6 @@ export const secondaryLinkTollBridge = new SecondaryLinkTollBridge();
 export const tertiaryLinkBridge = new TertiaryLinkBridge();
 export const tertiaryLinkTollBridge = new TertiaryLinkTollBridge();
 
-const isNotTransparent = [">", opacity, 0];
 const normalRoadLayers = [
   motorway.fill().id,
   motorway.casing().id,
@@ -1212,7 +1211,7 @@ export const legendEntries = [
   {
     description: "Freeway (controlled access, divided)",
     layers: [motorway.fill().id, motorway.casing().id],
-    filter: ["all", isNotToll, isNotTransparent],
+    filter: isNotToll,
   },
   {
     description: "Expressway (limited access, divided)",
@@ -1258,7 +1257,6 @@ export const legendEntries = [
       "all",
       ["==", getClass, "service"],
       [...smallServiceSelector, true, false],
-      isNotTransparent,
     ],
   },
   {
@@ -1286,6 +1284,6 @@ export const legendEntries = [
       minor.fill().id,
       roadSimpleCasing.casing().id,
     ],
-    filter: ["all", isUnpaved, isNotTransparent],
+    filter: isUnpaved,
   },
 ];


### PR DESCRIPTION
The legend should never show an entry based on a transparent feature. Unfortunately, some of the layers powering the road and rail entries set `line-opacity` to a `step` expression that can resolve to 0 at some zoom levels. This is normally an antipattern in that it forces the renderer to do more for no apparent reason, but it’s probably necessary for minimizing the number of layers. This PR just prevents the entries from showing up in the legend, causing confusion.

Fixes #682.