### PR TITLE
Add school icons

### DIFF
--- a/icons/poi_school.svg
+++ b/icons/poi_school.svg
@@ -1,6 +1,5 @@
 <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
- <g style="display:inline">
-  <path style="display:inline;fill:#f9f5f0;fill-opacity:1;stroke:#fff;stroke-width:0;stroke-linecap:round;paint-order:stroke markers fill" d="M 9,0 A 2.0002,2.0002 0 0 0 8.2304688,0.15429688 l -6,2.50000002 a 2.0002,2.0002 0 0 0 0,3.6914062 L 6.1992188,8 H 6 a 2.0002,2.0002 0 0 0 -2,2 v 8 a 2.0002,2.0002 0 0 0 2,2 h 8 a 2.0002,2.0002 0 0 0 2,-2 V 10 A 2.0002,2.0002 0 0 0 14,8 H 13 V 2 A 2.0002,2.0002 0 0 0 11,0 Z"/>
-  <path style="display:inline;fill:#003f87;fill-opacity:1;stroke:#fff;stroke-width:0;stroke-linecap:round;paint-order:stroke markers fill" d="M 9.0000001,1.9999999 3,4.5 9.0000001,6.9999993 Z M 6,10 v 8 h 8 V 10 Z M 9,2 v 8 h 2 V 2 Z"/>
+ <g style="display:inline;stroke:#000;stroke-opacity:0">
+  <path style="display:inline;fill:#003f87;fill-opacity:1;stroke:#f9f5f0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill" d="M 11,1 3,4 9,6 Z M 5,9 V 19 H 15 V 9 Z M 9,6 v 3 h 2 V 1 Z"/>
  </g>
 </svg>

--- a/icons/poi_school.svg
+++ b/icons/poi_school.svg
@@ -1,57 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="20"
-   height="20"
-   version="1.1"
-   id="svg4"
-   sodipodi:docname="poi_school.svg"
-   inkscape:version="1.2 (dc2aeda, 2022-05-15)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs8" />
-  <sodipodi:namedview
-     id="namedview6"
-     pagecolor="#505050"
-     bordercolor="#eeeeee"
-     borderopacity="1"
-     inkscape:showpageshadow="0"
-     inkscape:pageopacity="0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#505050"
-     showgrid="true"
-     inkscape:zoom="18.847001"
-     inkscape:cx="7.587414"
-     inkscape:cy="8.7812379"
-     inkscape:window-width="1309"
-     inkscape:window-height="713"
-     inkscape:window-x="0"
-     inkscape:window-y="23"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="g706">
-    <inkscape:grid
-       type="xygrid"
-       id="grid632"
-       originx="0"
-       originy="0" />
-  </sodipodi:namedview>
-  <g
-     id="g706"
-     style="display:inline">
-    <path
-       id="path941"
-       style="display:inline;fill:#f9f5f0;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-linecap:round;paint-order:stroke markers fill"
-       sodipodi:type="inkscape:offset"
-       inkscape:radius="2"
-       inkscape:original="M 9 2 L 3 4.5 L 9 7 L 9 10 L 6 10 L 6 18 L 14 18 L 14 10 L 11 10 L 11 2 L 9 2 z "
-       d="M 9,0 A 2.0002,2.0002 0 0 0 8.2304688,0.15429688 l -6,2.50000002 a 2.0002,2.0002 0 0 0 0,3.6914062 L 6.1992188,8 H 6 a 2.0002,2.0002 0 0 0 -2,2 v 8 a 2.0002,2.0002 0 0 0 2,2 h 8 a 2.0002,2.0002 0 0 0 2,-2 V 10 A 2.0002,2.0002 0 0 0 14,8 H 13 V 2 A 2.0002,2.0002 0 0 0 11,0 Z"
-       inkscape:label="path941" />
-    <path
-       id="path6157"
-       style="display:inline;fill:#003f87;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-linecap:round;paint-order:stroke markers fill"
-       d="M 9.0000001,1.9999999 3,4.5 9.0000001,6.9999993 Z M 6,10 v 8 h 8 V 10 Z M 9,2 v 8 h 2 V 2 Z"
-       sodipodi:nodetypes="cccccccccccccc" />
-  </g>
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+ <g style="display:inline">
+  <path style="display:inline;fill:#f9f5f0;fill-opacity:1;stroke:#fff;stroke-width:0;stroke-linecap:round;paint-order:stroke markers fill" d="M 9,0 A 2.0002,2.0002 0 0 0 8.2304688,0.15429688 l -6,2.50000002 a 2.0002,2.0002 0 0 0 0,3.6914062 L 6.1992188,8 H 6 a 2.0002,2.0002 0 0 0 -2,2 v 8 a 2.0002,2.0002 0 0 0 2,2 h 8 a 2.0002,2.0002 0 0 0 2,-2 V 10 A 2.0002,2.0002 0 0 0 14,8 H 13 V 2 A 2.0002,2.0002 0 0 0 11,0 Z"/>
+  <path style="display:inline;fill:#003f87;fill-opacity:1;stroke:#fff;stroke-width:0;stroke-linecap:round;paint-order:stroke markers fill" d="M 9.0000001,1.9999999 3,4.5 9.0000001,6.9999993 Z M 6,10 v 8 h 8 V 10 Z M 9,2 v 8 h 2 V 2 Z"/>
+ </g>
 </svg>

--- a/icons/poi_school.svg
+++ b/icons/poi_school.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="20"
+   height="20"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="poi_school.svg"
+   inkscape:version="1.2 (dc2aeda, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="true"
+     inkscape:zoom="18.847001"
+     inkscape:cx="7.587414"
+     inkscape:cy="8.7812379"
+     inkscape:window-width="1309"
+     inkscape:window-height="713"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g706">
+    <inkscape:grid
+       type="xygrid"
+       id="grid632"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <g
+     id="g706"
+     style="display:inline">
+    <path
+       id="path941"
+       style="display:inline;fill:#f9f5f0;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-linecap:round;paint-order:stroke markers fill"
+       sodipodi:type="inkscape:offset"
+       inkscape:radius="2"
+       inkscape:original="M 9 2 L 3 4.5 L 9 7 L 9 10 L 6 10 L 6 18 L 14 18 L 14 10 L 11 10 L 11 2 L 9 2 z "
+       d="M 9,0 A 2.0002,2.0002 0 0 0 8.2304688,0.15429688 l -6,2.50000002 a 2.0002,2.0002 0 0 0 0,3.6914062 L 6.1992188,8 H 6 a 2.0002,2.0002 0 0 0 -2,2 v 8 a 2.0002,2.0002 0 0 0 2,2 h 8 a 2.0002,2.0002 0 0 0 2,-2 V 10 A 2.0002,2.0002 0 0 0 14,8 H 13 V 2 A 2.0002,2.0002 0 0 0 11,0 Z"
+       inkscape:label="path941" />
+    <path
+       id="path6157"
+       style="display:inline;fill:#003f87;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-linecap:round;paint-order:stroke markers fill"
+       d="M 9.0000001,1.9999999 3,4.5 9.0000001,6.9999993 Z M 6,10 v 8 h 8 V 10 Z M 9,2 v 8 h 2 V 2 Z"
+       sodipodi:nodetypes="cccccccccccccc" />
+  </g>
+</svg>

--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -326,6 +326,34 @@
       "object_types": ["area"],
       "description": "Intermittent lakes are translucent with a dashed line representing the lakeshore.",
       "doc_url": "https://openmaptiles.org/schema/#water"
+    },
+    {
+      "key": "amenity",
+      "value": "school",
+      "object_types": ["node", "area"],
+      "description": "Schools are represented by an icon.",
+      "doc_url": "https://openmaptiles.org/schema/#poi"
+    },
+    {
+      "key": "amenity",
+      "value": "kindergarten",
+      "object_types": ["node", "area"],
+      "description": "Schools are represented by an icon.",
+      "doc_url": "https://openmaptiles.org/schema/#poi"
+    },
+    {
+      "key": "amenity",
+      "value": "college",
+      "object_types": ["node", "area"],
+      "description": "Schools are represented by an icon.",
+      "doc_url": "https://openmaptiles.org/schema/#poi"
+    },
+    {
+      "key": "amenity",
+      "value": "university",
+      "object_types": ["node", "area"],
+      "description": "Schools are represented by an icon.",
+      "doc_url": "https://openmaptiles.org/schema/#poi"
     }
   ]
 }

--- a/src/layer/poi.js
+++ b/src/layer/poi.js
@@ -7,7 +7,7 @@ var iconDefs = {
   hospital: "hospital",
   medical: ["doctors", "clinic"],
   parking: "parking",
-  school: "school",
+  school: ["kindergarten", "school", "college", "university"],
 };
 
 export const poi = {

--- a/src/layer/poi.js
+++ b/src/layer/poi.js
@@ -114,6 +114,6 @@ export const legendEntries = [
   {
     description: "School",
     layers: [poi.id],
-    filter: ["==", ["get", "subclass"], iconDefs.school],
+    filter: ["in", ["get", "subclass"], ["literal", iconDefs.school]],
   },
 ];

--- a/src/layer/poi.js
+++ b/src/layer/poi.js
@@ -35,7 +35,7 @@ export const poi = {
     [
       "match",
       ["get", "subclass"],
-      ["hospital", "school"],
+      ["hospital", ...iconDefs.school],
       15,
       [...iconDefs.bar, ...iconDefs.coffee],
       16,

--- a/src/layer/poi.js
+++ b/src/layer/poi.js
@@ -7,6 +7,7 @@ var iconDefs = {
   hospital: "hospital",
   medical: ["doctors", "clinic"],
   parking: "parking",
+  school: "school",
 };
 
 export const poi = {
@@ -23,7 +24,7 @@ export const poi = {
       ["get", "subclass"],
       [...iconDefs.bar, ...iconDefs.coffee],
       Color.poi.consumer,
-      ["hospital", "parking"],
+      ["hospital", "parking", "school"],
       Color.poi.infrastructure,
       Color.poi.infrastructure,
     ],
@@ -34,7 +35,7 @@ export const poi = {
     [
       "match",
       ["get", "subclass"],
-      "hospital",
+      ["hospital", "school"],
       15,
       [...iconDefs.bar, ...iconDefs.coffee],
       16,
@@ -66,6 +67,8 @@ export const poi = {
       "poi_hospital",
       iconDefs.parking,
       "poi_p",
+      iconDefs.school,
+      "poi_school",
       "poi_square_dot", //icon for generic POI, not currently used
     ],
     "icon-size": 1.0,
@@ -107,5 +110,10 @@ export const legendEntries = [
     description: "Parking",
     layers: [poi.id],
     filter: ["==", ["get", "subclass"], iconDefs.parking],
+  },
+  {
+    description: "School",
+    layers: [poi.id],
+    filter: ["==", ["get", "subclass"], iconDefs.school],
   },
 ];


### PR DESCRIPTION
Adds school POI icons. Fixes #78, and makes progress on #435.

In #78, a wide variety of US road maps were shown, a sizeable proportion of which displayed schools as some variation of a flat-roofed building topped by a pennant-shaped flag and flagpole. The icon I propose adheres to this design, although there's room for stylistic choice regarding the location, size, and direction of the flag.
![poi_school](https://user-images.githubusercontent.com/58491489/212460618-75afe998-96d7-4490-b3b8-7ccdd4f2bc49.svg)

I colored the icon "infrastructure blue" to adhere to the [Contributing Guide](https://github.com/ZeLonewolf/openstreetmap-americana/blob/main/CONTRIBUTING.md#points-of-interest), with the specified 2px-wide knockout. In the future, a separate color could be considered, especially in conjunction with an area fill if one is desired.
Location: San Francisco, CA ([localhost link](http://localhost:1776/#map=16.2/37.777946/-122.489602))
<img width="342" alt="Screen Shot 2023-01-13 at 10 55 29 PM" src="https://user-images.githubusercontent.com/58491489/212460961-9064a6d5-3f49-46a0-960d-7bc9af92869a.png">

Right now I've selected it to appear at zoom 15, the same as hospitals. Browsing around, it may be better for both of these icons to appear even earlier, but a decision can wait until there are more POIs to compare to.
Location: Beverly Hills, CA ([localhost link](http://localhost:1776/#map=15.53/34.061426/-118.412763))
<img width="543" alt="Screen Shot 2023-01-13 at 10 53 48 PM" src="https://user-images.githubusercontent.com/58491489/212460988-1814cc07-bf51-4888-be2f-ccbed09fc919.png">

This PR does not render colleges/universities or preschools. It also does not differentiate between different grade levels, as proposed in #78. It's unclear if such differentiation is possible with current tagging practices, but if so, there's probably room in the "building" icon, or to the right of the flagpole, for a letter. There's also no distinction between public/private/religious, though that could also be added in the future, perhaps through inverting the fill or changing the flag to a different symbol.
Location: Salinas, CA ([localhost link](http://localhost:1776/#map=15/36.66654/-121.66473))
<img width="732" alt="Screen Shot 2023-01-13 at 10 54 16 PM" src="https://user-images.githubusercontent.com/58491489/212461030-0b858e36-bac6-4061-8d6c-9a27cb65ba49.png">

Also adds a legend entry, which is just "School".
Location: Kingman, AZ ([localhost link](http://localhost:1776/#map=15.01/35.19116/-114.06062))
<img width="742" alt="Screen Shot 2023-01-13 at 10 59 37 PM" src="https://user-images.githubusercontent.com/58491489/212461217-3778c8f3-ea08-4e3b-931c-4fc191f8ceee.png">

Interaction with other features:
Location: New York, NY ([localhost link](http://localhost:1776/#map=16.18/40.715686/-73.997471))
<img width="930" alt="Screen Shot 2023-01-14 at 12 16 08 AM" src="https://user-images.githubusercontent.com/58491489/212463078-71c9478e-7894-4cdb-9a0e-4574ad124e21.png">

This is my first PR, and I think the first PR for POIs after the original (#387), so I hope I haven't missed anything!