### PR TITLE
Add low-zoom tileserver source

### DIFF
--- a/src/configs/config.aws-low-zoom.js
+++ b/src/configs/config.aws-low-zoom.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/*
+Planetiler tile server, hosted at AWS
+*/
+const OPENMAPTILES_URL =
+  "https://6ug7hetxl9.execute-api.us-east-2.amazonaws.com/data/planet-low-zoom.json";
+
+/*
+Uncomment this variable to override the shield text halo color. Useful while testing shield design changes.
+Accepts an HTML color name, hex code, or other CSS color value.
+*/
+const SHIELD_TEXT_HALO_COLOR_OVERRIDE = null;
+
+export default {
+  OPENMAPTILES_URL,
+  SHIELD_TEXT_HALO_COLOR_OVERRIDE,
+};


### PR DESCRIPTION
This PR adds a low-zoom tileserver source.

I've added a second .mbtiles source to the [AWS tileserver](https://6ug7hetxl9.execute-api.us-east-2.amazonaws.com/) which is rendered using openmaptiles-tools from a bleeding-edge openmaptiles schema.  This mechanism allows us to test out the style against new features which have been added to openmaptiles but aren't yet available in planetiler.

This specific source (low-zoom) is filtered to show administrative boundaries, water features, and some place labels.  Because of the time/resources needed for openmaptiles-tools rendering, it's necessary to be selective in what we render. My motivation for this particular extract was to test out the rendering of large water-body labels.  There's a few glitches in the tile data, such as some missing boundaries, which seems to be an artifact of osmium tags-filter.  I described this process in a recent OpenStreetMap [diary entry](https://www.openstreetmap.org/user/ZeLonewolf/diary).

![image](https://user-images.githubusercontent.com/3254090/212490846-c8f65a02-4d99-4583-909c-2d867c31f0a2.png)

If there is other "in openmaptiles but not yet released" functionality that anyone would like me to add, please make a request by all means.  If we need to test unreleased high-zoom functionality, we can do that by means of a geographic filter (for example, choosing one country or state to render to full zoom).