### PR TITLE
All routes for the UK and Ireland

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3753,17 +3753,6 @@ export function loadShields(shieldImages) {
     Color.shields.white
   );
 
-  // Great Britain
-  shields["omt-gb-motorway"] = roundedRectShield(
-    Color.shields.blue,
-    Color.shields.white
-  );
-
-  shields["omt-gb-trunk"] = roundedRectShield(
-    Color.shields.green,
-    Color.shields.yellow
-  );
-
   // Greece
   shields["GR:motorway"] = hexagonVerticalShield(
     3,
@@ -3797,6 +3786,22 @@ export function loadShields(shieldImages) {
     Color.shields.black,
     Color.shields.black,
     34
+  );
+
+  // Ireland
+  shields["omt-ie-motorway"] = roundedRectShield(
+    Color.shields.blue,
+    Color.shields.white
+  );
+
+  shields["omt-ie-national"] = roundedRectShield(
+    Color.shields.green,
+    Color.shields.yellow
+  );
+
+  shields["omt-ie-regional"] = roundedRectShield(
+    Color.shields.white,
+    Color.shields.black
   );
 
   // Italy
@@ -4024,6 +4029,22 @@ export function loadShields(shieldImages) {
   shields["ua:international"] = roundedRectShield(
     Color.shields.blue,
     Color.shields.white
+  );
+
+  // United Kingdom
+  shields["omt-gb-motorway"] = roundedRectShield(
+    Color.shields.blue,
+    Color.shields.white
+  );
+
+  shields["omt-gb-trunk"] = roundedRectShield(
+    Color.shields.green,
+    Color.shields.yellow
+  );
+
+  shields["omt-gb-primary"] = roundedRectShield(
+    Color.shields.white,
+    Color.shields.black
   );
 
   // OCEANIA


### PR DESCRIPTION
This PR implements pseudo-shields representing the three road categories in the United Kingdom and the Republic of Ireland. Support for the UK third-level route networks was added in openmaptiles/openmaptiles#1465, and new support for Irish routes was added in openmaptiles/openmaptiles#1466.

Since these route networks are new to OpenMapTiles, they are not currently being rendered in planetiler builds. Therefore, I've rendered an extract of the UK and Ireland down to zoom 14 to test this build. Please use the following tileserver to test this build, and bear in mind that the default Americana map view is centered and zoomed on the US -- so you'll have to zoom out a few stops in order to navigate to the test area.

```
https://6ug7hetxl9.execute-api.us-east-2.amazonaws.com/data/uk-ireland.json
```

Additionally, I re-alphabetized the country list in shield defs, renaming "Great Britain" to "[United Kingdom](https://www.youtube.com/watch?v=rNu8XDBSn10)", since the UK route networks also cover Northern Ireland.

UK: 
![image](https://user-images.githubusercontent.com/3254090/212566377-acde0883-c2ef-4bc6-bf29-d30276c952e1.png)

Ireland:
![image](https://user-images.githubusercontent.com/3254090/212566388-1cfdbfbf-556e-4ea9-84ba-b1abeafbbc0c.png)
