### PR TITLE
Refactor utility functions out of shield definitions

### DIFF
--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -74,6 +74,19 @@ export function isValidRef(ref) {
 }
 
 /**
+ * Get the number of banner placards associated with this shield
+ *
+ * @param {*} shield - Shield definition
+ * @returns the number of banner placards that need to be drawn
+ */
+export function getBannerCount(shield) {
+  if (shield == null || typeof shield.modifiers == "undefined") {
+    return 0; //Unadorned shield
+  }
+  return shield.modifiers.length;
+}
+
+/**
  * Retrieve the shield blank that goes with a particular route.  If there are
  * multiple shields for a route (different widths), it picks the best shield.
  *
@@ -128,7 +141,7 @@ function textColor(shieldDef) {
  * @returns a blank graphics context
  */
 function generateBlankGraphicsContext(shieldDef, routeDef) {
-  var bannerCount = ShieldDef.getBannerCount(shieldDef);
+  var bannerCount = getBannerCount(shieldDef);
   var shieldArtwork = getRasterShieldBlank(shieldDef, routeDef);
   var compoundBounds = null;
 
@@ -148,7 +161,7 @@ function generateBlankGraphicsContext(shieldDef, routeDef) {
 }
 
 function drawShield(ctx, shieldDef, routeDef) {
-  var bannerCount = ShieldDef.getBannerCount(shieldDef);
+  var bannerCount = getBannerCount(shieldDef);
 
   var shieldArtwork = getRasterShieldBlank(shieldDef, routeDef);
 
@@ -172,7 +185,7 @@ function drawShield(ctx, shieldDef, routeDef) {
 }
 
 function drawShieldText(ctx, shieldDef, routeDef) {
-  var bannerCount = ShieldDef.getBannerCount(shieldDef);
+  var bannerCount = getBannerCount(shieldDef);
   var shieldBounds = null;
 
   var shieldArtwork = getRasterShieldBlank(shieldDef, routeDef);

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -4222,29 +4222,3 @@ export function loadShields(shieldImages) {
 
   return shields;
 }
-
-/**
- * Determines whether there is a raster shield background for a particular network
- *
- * @param {*} network - Route network
- * @returns true if a raster shield is available
- */
-export function hasShieldArtwork(network) {
-  return (
-    shields[network] != null &&
-    typeof shields[network].backgroundImage !== "undefined"
-  );
-}
-
-/**
- * Get the number of banner placards associated with this shield
- *
- * @param {*} shield - Shield definition
- * @returns the number of banner placards that need to be drawn
- */
-export function getBannerCount(shield) {
-  if (shield == null || typeof shield.modifiers == "undefined") {
-    return 0; //Unadorned shield
-  }
-  return shield.modifiers.length;
-}


### PR DESCRIPTION
While attempting #699, the refactor quickly got out of control.  However, I identified a few no-brainer refactors that helps us get towards the goal of modularizing the shield definitions and better separates definitions from code.

This PR moves `getBannerCount` out of the shield definition file, and removes `hasShieldArtwork`, which was unused.