### PR TITLE
Convert roundedRectangle to JSON definition

### DIFF
--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -134,6 +134,21 @@ function textColor(shieldDef) {
   return "black";
 }
 
+//Temporary fix until we can remove backgroundDraw
+function getDrawFunc(shieldDef) {
+  if (typeof shieldDef.draw != "undefined") {
+    return (ref) =>
+      ShieldDraw.draw(shieldDef.draw.drawFunc, ref, shieldDef.draw.params);
+  }
+
+  //TODO: eliminate backgroundDraw
+  if (typeof shieldDef.backgroundDraw == "undefined") {
+    return ShieldDraw.blank;
+  }
+
+  return shieldDef.backgroundDraw;
+}
+
 /**
  * Creates a graphics context of the correct size to hold the shield and banner.
  * @param {*} shieldDef shield definition
@@ -146,12 +161,8 @@ function generateBlankGraphicsContext(shieldDef, routeDef) {
   var compoundBounds = null;
 
   if (shieldArtwork == null) {
-    if (typeof shieldDef.backgroundDraw == "undefined") {
-      shieldDef.backgroundDraw = ShieldDraw.blank;
-    }
-
-    //Do a test background draw to determine drawn size
-    let drawnShieldCtx = shieldDef.backgroundDraw(routeDef.ref);
+    let drawFunc = getDrawFunc(shieldDef);
+    let drawnShieldCtx = drawFunc(routeDef.ref);
     compoundBounds = compoundShieldSize(drawnShieldCtx.canvas, bannerCount);
   } else {
     compoundBounds = compoundShieldSize(shieldArtwork.data, bannerCount);
@@ -166,11 +177,8 @@ function drawShield(ctx, shieldDef, routeDef) {
   var shieldArtwork = getRasterShieldBlank(shieldDef, routeDef);
 
   if (shieldArtwork == null) {
-    if (typeof shieldDef.backgroundDraw == "undefined") {
-      shieldDef.backgroundDraw = ShieldDraw.blank;
-    }
-
-    let drawnShieldCtx = shieldDef.backgroundDraw(routeDef.ref);
+    let drawFunc = getDrawFunc(shieldDef);
+    let drawnShieldCtx = drawFunc(routeDef.ref);
 
     ctx.drawImage(
       drawnShieldCtx.canvas,
@@ -191,11 +199,8 @@ function drawShieldText(ctx, shieldDef, routeDef) {
   var shieldArtwork = getRasterShieldBlank(shieldDef, routeDef);
 
   if (shieldArtwork == null) {
-    if (typeof shieldDef.backgroundDraw == "undefined") {
-      shieldDef.backgroundDraw = ShieldDraw.blank;
-    }
-
-    let drawnShieldCtx = shieldDef.backgroundDraw(routeDef.ref);
+    let drawFunc = getDrawFunc(shieldDef);
+    let drawnShieldCtx = drawFunc(routeDef.ref);
 
     shieldBounds = {
       width: drawnShieldCtx.canvas.width,

--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -138,7 +138,7 @@ function textColor(shieldDef) {
 function getDrawFunc(shieldDef) {
   if (typeof shieldDef.draw != "undefined") {
     return (ref) =>
-      ShieldDraw.draw(shieldDef.draw.drawFunc, ref, shieldDef.draw.params);
+      ShieldDraw.draw(shieldDef.draw.drawFunc, shieldDef.draw.params, ref);
   }
 
   //TODO: eliminate backgroundDraw

--- a/src/js/shield_canvas_draw.js
+++ b/src/js/shield_canvas_draw.js
@@ -125,14 +125,13 @@ export function blank(ref) {
   return Gfx.getGfxContext({ width: width, height: CS });
 }
 
-export function roundedRectangle(
-  fill,
-  outline,
-  ref,
-  radius,
-  outlineWidth,
-  rectWidth
-) {
+function roundedRectangle(ref, params) {
+  let fill = params.fillColor == undefined ? "white" : params.fillColor;
+  let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
+  let radius = params.radius == undefined ? 1 : params.radius;
+  let outlineWidth = params.outlineWidth == undefined ? 1 : params.outlineWidth;
+  let rectWidth = params.rectWidth == undefined ? null : params.rectWidth;
+
   if (rectWidth == null) {
     var shieldWidth =
       ShieldText.calculateTextWidth(ref, genericShieldFontSize) + 2 * PXR;
@@ -698,3 +697,23 @@ export function octagonVertical(
 
   return ctx;
 }
+
+export function draw(name, ref, options) {
+  return drawFunctions[name](ref, options);
+}
+
+//Register draw functions
+const drawFunctions = {};
+
+/**
+ * Invoked by a style to implement a custom draw function
+ *
+ * @param {*} name name of the function as referenced by the shield definition
+ * @param {*} fxn callback to the implementing function. Takes two parameters, ref and options
+ */
+export function registerDrawFunction(name, fxn) {
+  drawFunctions[name] = fxn;
+}
+
+//Built-in draw functions (standard shapes)
+registerDrawFunction("roundedRectangle", roundedRectangle);

--- a/src/js/shield_canvas_draw.js
+++ b/src/js/shield_canvas_draw.js
@@ -37,13 +37,13 @@ export function paBelt(fillColor, strokeColor) {
 
 // Special case for Branson color-coded routes, documented in CONTRIBUTE.md
 export function bransonRoute(fillColor, strokeColor) {
-  var ctx = roundedRectangle(
-    Color.shields.green,
-    Color.shields.white,
-    "",
-    2,
-    1
-  );
+  var ctx = roundedRectangle({
+    fillColor: Color.shields.green,
+    strokeColor: Color.shields.white,
+    outlineWidth: 1,
+    radius: 2,
+    rectWidth: 20,
+  });
 
   let lineWidth = 0.5 * PXR;
   let x = 0.15 * CS + lineWidth;
@@ -125,7 +125,7 @@ export function blank(ref) {
   return Gfx.getGfxContext({ width: width, height: CS });
 }
 
-function roundedRectangle(ref, params) {
+function roundedRectangle(params, ref) {
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
   let radius = params.radius == undefined ? 1 : params.radius;
@@ -698,8 +698,8 @@ export function octagonVertical(
   return ctx;
 }
 
-export function draw(name, ref, options) {
-  return drawFunctions[name](ref, options);
+export function draw(name, options, ref) {
+  return drawFunctions[name](options, ref);
 }
 
 //Register draw functions

--- a/src/js/shield_canvas_draw.js
+++ b/src/js/shield_canvas_draw.js
@@ -19,7 +19,13 @@ const genericShieldFontSize = 18 * PXR;
 
 // Special case for Allegheny, PA Belt System, documented in CONTRIBUTE.md
 export function paBelt(fillColor, strokeColor) {
-  var ctx = square();
+  let ctx = roundedRectangle({
+    fillColor: Color.shields.white,
+    strokeColor: Color.shields.black,
+    outlineWidth: 1,
+    radius: 2,
+    rectWidth: 20,
+  });
 
   let lineWidth = 0.5 * PXR;
   let diameter = CS / 3 - lineWidth;
@@ -98,21 +104,6 @@ export function ellipse(fill, outline, ref, rectWidth) {
   ctx.strokeStyle = outline;
   ctx.stroke();
   return ctx;
-}
-
-function square() {
-  return rectangle("");
-}
-
-export function rectangle(ref) {
-  return roundedRectangle(
-    Color.shields.white,
-    Color.shields.black,
-    ref,
-    2,
-    1,
-    null
-  );
 }
 
 export function blank(ref) {

--- a/src/js/shield_canvas_draw.js
+++ b/src/js/shield_canvas_draw.js
@@ -120,7 +120,7 @@ function roundedRectangle(params, ref) {
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
   let radius = params.radius == undefined ? 1 : params.radius;
-  let outlineWidth = params.outlineWidth == undefined ? 1 : params.outlineWidth;
+  let outlineWidth = params.outlineWidth == undefined ? 0 : params.outlineWidth;
   let rectWidth = params.rectWidth == undefined ? null : params.rectWidth;
 
   if (rectWidth == null) {

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -69,15 +69,15 @@ function roundedRectShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 2;
   return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.roundedRectangle(
-        fillColor,
-        strokeColor,
-        ref,
-        radius,
-        1,
-        rectWidth
-      ),
+    draw: {
+      drawFunc: "roundedRectangle",
+      params: {
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        textColor: textColor,
+        rectWidth: rectWidth,
+      },
+    },
     textLayoutConstraint: (spaceBounds, textBounds) =>
       ShieldText.roundedRectTextConstraint(spaceBounds, textBounds, radius),
     padding: {
@@ -606,15 +606,15 @@ function octagonVerticalShield(
 function pillShield(fillColor, strokeColor, textColor, rectWidth) {
   textColor = textColor ?? strokeColor;
   return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.roundedRectangle(
-        fillColor,
-        strokeColor,
-        ref,
-        10,
-        1,
-        rectWidth
-      ),
+    draw: {
+      drawFunc: "roundedRectangle",
+      params: {
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        rectWidth: rectWidth,
+        radius: 10,
+      },
+    },
     textLayoutConstraint: ShieldText.ellipseTextConstraint,
     padding: {
       left: 2,


### PR DESCRIPTION
Unblocks #699 

This PR implements an incremental step towards #118 by converting the `roundedRectangle()` function into a JSON definition.  This still leaves in place the existing function pointers for other draw functions so that the conversion can be done incrementally and in stages.  Ultimately the goal is that the shield definitions can be entirely implemented as a JSON, which allows for the possibility of a shield generator that can work on native as well as the existing one for the web.

Instead, the shield definitions would implement something that looks like this:
```
draw: {
      drawFunc: "roundedRectangle",
      params: {
        fillColor: "white",
        strokeColor: "black",
        textColor: "black",
        rectWidth: 20,
      },
    },
```

This would then get extended to other drawing functions. Additionally, I added:

```
export function registerDrawFunction(name, fxn) {
  drawFunctions[name] = fxn;
}
```

This function would allow some other implementer the ability to define their own custom shield drawing functions (in addition to the built-in ones that will also call this function internally).

This approach will require standardizing all the draw functions to take in a `ref` and `options` object, where the `options` contains any color/style variations that need to be passed in.

CC/#577 

If the team is satisfied with this general approach, my intent is to apply this to the other drawing functions, and then move on to the text layout functions.  That will remove the major blockers to having a pure-JSON shield definition.