### PR TITLE
Change Latvia regional shield to blue

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3847,11 +3847,15 @@ export function loadShields(shieldImages) {
   // Latvia
   shields["lv:national"] = roundedRectShield(
     Color.shields.red,
-    Color.shields.white
+    Color.shields.white,
+    Color.shields.white,
+    34
   );
   shields["lv:regional"] = roundedRectShield(
-    Color.shields.red,
-    Color.shields.white
+    Color.shields.blue,
+    Color.shields.white,
+    Color.shields.white,
+    34
   );
 
   // Moldova


### PR DESCRIPTION
Fixes #655

Also changes all Latvian shields to fixed-width, as photographs indicate.

![Screenshot from 2023-01-16 15-59-18](https://user-images.githubusercontent.com/1732117/212764948-4d933302-9b4c-4b70-b852-2b615e4e1f90.png)
