### PR TITLE
Refactor remaining shape draw functions to JSON

### DIFF
--- a/src/americana.js
+++ b/src/americana.js
@@ -7,6 +7,7 @@ import * as Style from "./js/style.js";
 
 import * as Shield from "./js/shield.js";
 import * as ShieldDef from "./js/shield_defs.js";
+import * as CustomShields from "./js/custom_shields.js";
 
 import * as languageLabel from "./js/language_label.js";
 
@@ -54,6 +55,8 @@ export const map = (window.map = new maplibregl.Map({
   zoom: 4, // starting zoom
   attributionControl: false,
 }));
+
+CustomShields.loadCustomShields();
 
 map.on("styledata", function (event) {
   ShieldDef.loadShields(map.style.imageManager.images);

--- a/src/js/custom_shields.js
+++ b/src/js/custom_shields.js
@@ -1,0 +1,73 @@
+"use strict";
+
+import * as Color from "../constants/color.js";
+import * as ShieldDraw from "./shield_canvas_draw.js";
+
+// Special case for Allegheny, PA Belt System, documented in CONTRIBUTE.md
+export function paBelt(params) {
+  let ctx = ShieldDraw.roundedRectangle({
+    fillColor: Color.shields.white,
+    strokeColor: Color.shields.black,
+    outlineWidth: 1,
+    radius: 2,
+    rectWidth: 20,
+  });
+
+  let fillColor = params.fillColor;
+
+  let lineWidth = 0.5 * ShieldDraw.PXR;
+  let diameter = ShieldDraw.CS / 3 - lineWidth;
+  ctx.beginPath();
+  ctx.arc(
+    ShieldDraw.CS / 2,
+    ShieldDraw.CS / 2,
+    diameter,
+    0,
+    2 * Math.PI,
+    false
+  );
+
+  ctx.fillStyle = fillColor;
+  ctx.strokeStyle = Color.shields.black;
+  ctx.fill();
+
+  ctx.lineWidth = lineWidth;
+  ctx.stroke();
+  return ctx;
+}
+
+// Special case for Branson color-coded routes, documented in CONTRIBUTE.md
+export function bransonRoute(params) {
+  var ctx = ShieldDraw.roundedRectangle({
+    fillColor: Color.shields.green,
+    strokeColor: Color.shields.white,
+    outlineWidth: 1,
+    radius: 2,
+    rectWidth: 20,
+  });
+
+  let fillColor = params.fillColor;
+
+  let lineWidth = 0.5 * ShieldDraw.PXR;
+  let x = 0.15 * ShieldDraw.CS + lineWidth;
+  let width = 0.7 * ShieldDraw.CS - 2 * lineWidth;
+
+  let y = 0.4 * ShieldDraw.CS + lineWidth;
+  let height = 0.45 * ShieldDraw.CS - 2 * lineWidth;
+
+  ctx.beginPath();
+  ctx.rect(x, y, width, height);
+
+  ctx.fillStyle = fillColor;
+  ctx.strokeStyle = Color.shields.white;
+  ctx.fill();
+
+  ctx.lineWidth = lineWidth;
+  ctx.stroke();
+  return ctx;
+}
+
+export function loadCustomShields() {
+  ShieldDraw.registerDrawFunction("branson", bransonRoute);
+  ShieldDraw.registerDrawFunction("paBelt", paBelt);
+}

--- a/src/js/custom_shields.js
+++ b/src/js/custom_shields.js
@@ -28,7 +28,7 @@ export function paBelt(params) {
   );
 
   ctx.fillStyle = fillColor;
-  ctx.strokeStyle = Color.shields.black;
+  ctx.strokeStyle = params.strokeColor;
   ctx.fill();
 
   ctx.lineWidth = lineWidth;
@@ -59,7 +59,7 @@ export function bransonRoute(params) {
   ctx.rect(x, y, width, height);
 
   ctx.fillStyle = fillColor;
-  ctx.strokeStyle = Color.shields.white;
+  ctx.strokeStyle = params.strokeColor;
   ctx.fill();
 
   ctx.lineWidth = lineWidth;

--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -144,13 +144,7 @@ function getDrawFunc(shieldDef) {
         ref
       );
   }
-
-  //TODO: eliminate backgroundDraw
-  if (typeof shieldDef.backgroundDraw == "undefined") {
-    return ShieldDraw.blank;
-  }
-
-  return shieldDef.backgroundDraw;
+  return ShieldDraw.blank;
 }
 
 /**

--- a/src/js/shield_canvas_draw.js
+++ b/src/js/shield_canvas_draw.js
@@ -661,7 +661,7 @@ registerDrawFunction("ellipse", ellipse);
 registerDrawFunction("escutcheon", escutcheon);
 registerDrawFunction("hexagonVertical", hexagonVertical);
 registerDrawFunction("hexagonHorizontal", hexagonHorizontal);
-registerDrawFunction("octagonVertical", hexagonVertical);
+registerDrawFunction("octagonVertical", octagonVertical);
 registerDrawFunction("pentagon", pentagon);
 registerDrawFunction("roundedRectangle", roundedRectangle);
 registerDrawFunction("trapezoid", trapezoid);

--- a/src/js/shield_canvas_draw.js
+++ b/src/js/shield_canvas_draw.js
@@ -327,7 +327,7 @@ function diamond(params, ref) {
 }
 
 function pentagon(params, ref) {
-  let pointUp = params.pointUp == undefined ? false : params.pointUp;
+  let pointUp = params.pointUp == undefined ? true : params.pointUp;
   let offset = params.offset == undefined ? 0 : params.offset;
   let angle = params.angle == undefined ? 0 : params.angle;
   let fill = params.fillColor == undefined ? "white" : params.fillColor;

--- a/src/js/shield_canvas_draw.js
+++ b/src/js/shield_canvas_draw.js
@@ -4,71 +4,17 @@
  * Shield blanks which are drawn rather built from raster shield blanks
  */
 
-import * as Color from "../constants/color.js";
 import * as Gfx from "./screen_gfx.js";
 import * as ShieldText from "./shield_text.js";
 
 export const PXR = Gfx.getPixelRatio();
 
 // Canvas size in pixels. Length of smallest dimension (typically height)
-const CS = 20 * PXR;
+export const CS = 20 * PXR;
 
 const minGenericShieldWidth = 20 * PXR;
 const maxGenericShieldWidth = 34 * PXR;
 const genericShieldFontSize = 18 * PXR;
-
-// Special case for Allegheny, PA Belt System, documented in CONTRIBUTE.md
-export function paBelt(fillColor, strokeColor) {
-  let ctx = roundedRectangle({
-    fillColor: Color.shields.white,
-    strokeColor: Color.shields.black,
-    outlineWidth: 1,
-    radius: 2,
-    rectWidth: 20,
-  });
-
-  let lineWidth = 0.5 * PXR;
-  let diameter = CS / 3 - lineWidth;
-  ctx.beginPath();
-  ctx.arc(CS / 2, CS / 2, diameter, 0, 2 * Math.PI, false);
-
-  ctx.fillStyle = fillColor;
-  ctx.strokeStyle = strokeColor;
-  ctx.fill();
-
-  ctx.lineWidth = lineWidth;
-  ctx.stroke();
-  return ctx;
-}
-
-// Special case for Branson color-coded routes, documented in CONTRIBUTE.md
-export function bransonRoute(fillColor, strokeColor) {
-  var ctx = roundedRectangle({
-    fillColor: Color.shields.green,
-    strokeColor: Color.shields.white,
-    outlineWidth: 1,
-    radius: 2,
-    rectWidth: 20,
-  });
-
-  let lineWidth = 0.5 * PXR;
-  let x = 0.15 * CS + lineWidth;
-  let width = 0.7 * CS - 2 * lineWidth;
-
-  let y = 0.4 * CS + lineWidth;
-  let height = 0.45 * CS - 2 * lineWidth;
-
-  ctx.beginPath();
-  ctx.rect(x, y, width, height);
-
-  ctx.fillStyle = fillColor;
-  ctx.strokeStyle = strokeColor;
-  ctx.fill();
-
-  ctx.lineWidth = lineWidth;
-  ctx.stroke();
-  return ctx;
-}
 
 function ellipse(params, ref) {
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
@@ -120,7 +66,7 @@ export function blank(ref) {
   return Gfx.getGfxContext({ width: width, height: CS });
 }
 
-function roundedRectangle(params, ref) {
+export function roundedRectangle(params, ref) {
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
   let radius = params.radius == undefined ? 0 : params.radius;

--- a/src/js/shield_canvas_draw.js
+++ b/src/js/shield_canvas_draw.js
@@ -174,15 +174,14 @@ function roundedRectangle(params, ref) {
   return ctx;
 }
 
-export function escutcheon(
-  offset,
-  fill,
-  outline,
-  ref,
-  radius,
-  outlineWidth,
-  rectWidth
-) {
+function escutcheon(params, ref) {
+  let offset = params.offset == undefined ? 0 : params.offset;
+  let fill = params.fillColor == undefined ? "white" : params.fillColor;
+  let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
+  let radius = params.radius == undefined ? 0 : params.radius;
+  let outlineWidth = params.outlineWidth == undefined ? 1 : params.outlineWidth;
+  let rectWidth = params.rectWidth == undefined ? null : params.rectWidth;
+
   if (rectWidth == null) {
     var shieldWidth =
       ShieldText.calculateTextWidth(ref, genericShieldFontSize) + 2 * PXR;
@@ -239,17 +238,17 @@ export function escutcheon(
   return ctx;
 }
 
-export function trapezoid(
-  shortSideUp,
-  angle,
-  fill,
-  outline,
-  ref,
-  radius,
-  outlineWidth,
-  rectWidth
-) {
+function trapezoid(params, ref) {
+  let shortSideUp =
+    params.shortSideUp == undefined ? false : params.shortSideUp;
+  let angle = params.angle == undefined ? 0 : params.angle;
+  let fill = params.fillColor == undefined ? "white" : params.fillColor;
+  let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
+  let radius = params.radius == undefined ? 0 : params.radius;
+  let outlineWidth = params.outlineWidth == undefined ? 1 : params.outlineWidth;
+  let rectWidth = params.rectWidth == undefined ? null : params.rectWidth;
   let angleSign = shortSideUp ? -1 : 1;
+
   let sine = Math.sin(angle);
   let cosine = Math.cos(angle);
   let tangent = Math.tan(angle);
@@ -310,7 +309,13 @@ export function trapezoid(
   return ctx;
 }
 
-export function diamond(fill, outline, ref, radius, outlineWidth, rectWidth) {
+function diamond(params, ref) {
+  let fill = params.fillColor == undefined ? "white" : params.fillColor;
+  let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
+  let radius = params.radius == undefined ? 0 : params.radius;
+  let outlineWidth = params.outlineWidth == undefined ? 1 : params.outlineWidth;
+  let rectWidth = params.rectWidth == undefined ? null : params.rectWidth;
+
   let extraSpace = 4 * PXR;
   let height = CS + extraSpace;
 
@@ -375,18 +380,17 @@ export function diamond(fill, outline, ref, radius, outlineWidth, rectWidth) {
   return ctx;
 }
 
-export function pentagon(
-  pointUp,
-  offset,
-  angle,
-  fill,
-  outline,
-  ref,
-  radius1,
-  radius2,
-  outlineWidth,
-  rectWidth
-) {
+function pentagon(params, ref) {
+  let pointUp = params.pointUp == undefined ? false : params.pointUp;
+  let offset = params.offset == undefined ? 0 : params.offset;
+  let angle = params.angle == undefined ? 0 : params.angle;
+  let fill = params.fillColor == undefined ? "white" : params.fillColor;
+  let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
+  let radius1 = params.radius1 == undefined ? 0 : params.radius1;
+  let radius2 = params.radius2 == undefined ? 0 : params.radius2;
+  let outlineWidth = params.outlineWidth == undefined ? 1 : params.outlineWidth;
+  let rectWidth = params.rectWidth == undefined ? null : params.rectWidth;
+
   let angleSign = pointUp ? -1 : 1;
   let sine = Math.sin(angle);
   let cosine = Math.cos(angle);
@@ -425,8 +429,6 @@ export function pentagon(
   let x6 = x8 - angleSign * (y2 - y0) * tangent;
 
   let offsetAngle = Math.atan(drawOffset / (x4 - x0));
-  let offsetSine = Math.sin(offsetAngle);
-  let offsetCosine = Math.cos(offsetAngle);
 
   let halfComplementAngle1 = (Math.PI / 2 - offsetAngle + angle) / 2;
   let halfComplementTangent1 = Math.tan(halfComplementAngle1);
@@ -461,15 +463,14 @@ export function pentagon(
   return ctx;
 }
 
-export function hexagonVertical(
-  offset,
-  fill,
-  outline,
-  ref,
-  radius,
-  outlineWidth,
-  rectWidth
-) {
+function hexagonVertical(params, ref) {
+  let offset = params.offset == undefined ? 0 : params.offset;
+  let fill = params.fillColor == undefined ? "white" : params.fillColor;
+  let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
+  let radius = params.radius == undefined ? 0 : params.radius;
+  let outlineWidth = params.outlineWidth == undefined ? 1 : params.outlineWidth;
+  let rectWidth = params.rectWidth == undefined ? null : params.rectWidth;
+
   if (rectWidth == null) {
     var shieldWidth =
       ShieldText.calculateTextWidth(ref, genericShieldFontSize) + 2 * PXR;
@@ -524,15 +525,14 @@ export function hexagonVertical(
   return ctx;
 }
 
-export function hexagonHorizontal(
-  angle,
-  fill,
-  outline,
-  ref,
-  radius,
-  outlineWidth,
-  rectWidth
-) {
+function hexagonHorizontal(params, ref) {
+  let angle = params.angle == undefined ? 0 : params.angle;
+  let fill = params.fillColor == undefined ? "white" : params.fillColor;
+  let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
+  let radius = params.radius == undefined ? 0 : params.radius;
+  let outlineWidth = params.outlineWidth == undefined ? 1 : params.outlineWidth;
+  let rectWidth = params.rectWidth == undefined ? null : params.rectWidth;
+
   let sine = Math.sin(angle);
   let cosine = Math.cos(angle);
   let tangent = Math.tan(angle);
@@ -599,16 +599,15 @@ export function hexagonHorizontal(
   return ctx;
 }
 
-export function octagonVertical(
-  offset,
-  angle,
-  fill,
-  outline,
-  ref,
-  radius,
-  outlineWidth,
-  rectWidth
-) {
+function octagonVertical(params, ref) {
+  let offset = params.offset == undefined ? 0 : params.offset;
+  let angle = params.angle == undefined ? 0 : params.angle;
+  let fill = params.fillColor == undefined ? "white" : params.fillColor;
+  let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
+  let radius = params.radius == undefined ? 0 : params.radius;
+  let outlineWidth = params.outlineWidth == undefined ? 1 : params.outlineWidth;
+  let rectWidth = params.rectWidth == undefined ? null : params.rectWidth;
+
   let sine = Math.sin(angle);
   let cosine = Math.cos(angle);
   let tangent = Math.tan(angle);
@@ -711,5 +710,12 @@ export function registerDrawFunction(name, fxn) {
 }
 
 //Built-in draw functions (standard shapes)
-registerDrawFunction("roundedRectangle", roundedRectangle);
+registerDrawFunction("diamond", diamond);
 registerDrawFunction("ellipse", ellipse);
+registerDrawFunction("escutcheon", escutcheon);
+registerDrawFunction("hexagonVertical", hexagonVertical);
+registerDrawFunction("hexagonHorizontal", hexagonHorizontal);
+registerDrawFunction("octagonVertical", hexagonVertical);
+registerDrawFunction("pentagon", pentagon);
+registerDrawFunction("roundedRectangle", roundedRectangle);
+registerDrawFunction("trapezoid", trapezoid);

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -540,15 +540,17 @@ function pillShield(fillColor, strokeColor, textColor, rectWidth) {
  * Draws a circle icon inside a black-outlined white square shield
  *
  * @param {*} fillColor - Color of circle icon background fill
+ * @param {*} strokeColor - Color of circle icon outline
  * @returns a shield definition object
  */
-function paBeltShield(fillColor) {
+function paBeltShield(fillColor, strokeColor) {
   return {
     notext: true,
     canvasDrawnBlank: {
       drawFunc: "paBelt",
       params: {
         fillColor: fillColor,
+        strokeColor: strokeColor,
       },
     },
   };
@@ -558,15 +560,17 @@ function paBeltShield(fillColor) {
  * Draws a rectangle icon inside a white-outlined green square shield
  *
  * @param {*} fillColor - Color of rectangle icon background fill
+ * @param {*} strokeColor - Color of rectangle icon outline
  * @returns a shield definition object
  */
-function bransonRouteShield(fillColor) {
+function bransonRouteShield(fillColor, strokeColor) {
   return {
     notext: true,
     canvasDrawnBlank: {
       drawFunc: "branson",
       params: {
         fillColor: fillColor,
+        strokeColor: strokeColor,
       },
     },
   };

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -551,13 +551,17 @@ function pillShield(fillColor, strokeColor, textColor, rectWidth) {
  * Draws a circle icon inside a black-outlined white square shield
  *
  * @param {*} fillColor - Color of circle icon background fill
- * @param {*} strokeColor - Color of circle icon outline stroke
  * @returns a shield definition object
  */
-function paBeltShield(fillColor, strokeColor) {
+function paBeltShield(fillColor) {
   return {
     notext: true,
-    backgroundDraw: (ref) => ShieldDraw.paBelt(fillColor, strokeColor),
+    canvasDrawnBlank: {
+      drawFunc: "paBelt",
+      params: {
+        fillColor: fillColor,
+      },
+    },
   };
 }
 
@@ -565,13 +569,17 @@ function paBeltShield(fillColor, strokeColor) {
  * Draws a rectangle icon inside a white-outlined green square shield
  *
  * @param {*} fillColor - Color of rectangle icon background fill
- * @param {*} strokeColor - Color of rectangle icon outline stroke
  * @returns a shield definition object
  */
-function bransonRouteShield(fillColor, strokeColor) {
+function bransonRouteShield(fillColor) {
   return {
     notext: true,
-    backgroundDraw: (ref) => ShieldDraw.bransonRoute(fillColor, strokeColor),
+    canvasDrawnBlank: {
+      drawFunc: "branson",
+      params: {
+        fillColor: fillColor,
+      },
+    },
   };
 }
 

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -118,16 +118,17 @@ function escutcheonDownShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 0;
   return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.escutcheon(
-        offset,
-        fillColor,
-        strokeColor,
-        ref,
-        radius,
-        1,
-        rectWidth
-      ),
+    canvasDrawnBlank: {
+      drawFunc: "escutcheon",
+      params: {
+        offset: offset,
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        rectWidth: rectWidth,
+        radius: radius,
+        outlineWidth: 1,
+      },
+    },
     textLayoutConstraint: (spaceBounds, textBounds) =>
       ShieldText.roundedRectTextConstraint(spaceBounds, textBounds, radius),
     padding: {
@@ -162,18 +163,18 @@ function trapezoidDownShield(
   let angleInRadians = (angle * Math.PI) / 180;
   textColor = textColor ?? strokeColor;
   radius = radius ?? 0;
+
   return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.trapezoid(
-        false,
-        angleInRadians,
-        fillColor,
-        strokeColor,
-        ref,
-        radius,
-        1,
-        rectWidth
-      ),
+    canvasDrawnBlank: {
+      drawFunc: "trapezoid",
+      params: {
+        angle: angleInRadians,
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        rectWidth: rectWidth,
+        radius: radius,
+      },
+    },
     textLayoutConstraint: (spaceBounds, textBounds) =>
       ShieldText.roundedRectTextConstraint(spaceBounds, textBounds, radius),
     padding: {
@@ -209,17 +210,16 @@ function trapezoidUpShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 0;
   return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.trapezoid(
-        true,
-        angleInRadians,
-        fillColor,
-        strokeColor,
-        ref,
-        radius,
-        1,
-        rectWidth
-      ),
+    canvasDrawnBlank: {
+      drawFunc: "trapezoid",
+      params: {
+        angle: angleInRadians,
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        rectWidth: rectWidth,
+        radius: radius,
+      },
+    },
     textLayoutConstraint: (spaceBounds, textBounds) =>
       ShieldText.roundedRectTextConstraint(spaceBounds, textBounds, radius),
     padding: {
@@ -246,6 +246,15 @@ function diamondShield(fillColor, strokeColor, textColor, radius, rectWidth) {
   textColor = textColor ?? strokeColor;
   radius = radius ?? 2;
   return {
+    canvasDrawnBlank: {
+      drawFunc: "diamond",
+      params: {
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        radius: radius,
+        rectWidth: rectWidth,
+      },
+    },
     backgroundDraw: (ref) =>
       ShieldDraw.diamond(fillColor, strokeColor, ref, radius, 1, rectWidth),
     textLayoutConstraint: ShieldText.ellipseTextConstraint,
@@ -254,59 +263,6 @@ function diamondShield(fillColor, strokeColor, textColor, radius, rectWidth) {
       right: 4.5,
       top: 5,
       bottom: 5,
-    },
-    textColor: textColor,
-  };
-}
-
-/**
- * Draws a shield with a pentagon background, pointed downward
- *
- * @param {*} offset - Height of diagonal edges
- * @param {*} angle - Angle (in degrees) at which sides deviate from vertical
- * @param {*} fillColor - Color of pentagon background fill
- * @param {*} strokeColor - Color of pentagon outline stroke
- * @param {*} textColor - Color of text (defaults to strokeColor)
- * @param {*} radius1 - Corner radius of pointed side of pentagon (defaults to 2)
- * @param {*} radius2 - Corner radius of flat side of pentagon (defaults to 0)
- * @param {*} rectWidth - Width of pentagon (defaults to variable-width)
- * @returns a shield definition object
- */
-function pentagonDownShield(
-  offset,
-  angle,
-  fillColor,
-  strokeColor,
-  textColor,
-  radius1,
-  radius2,
-  rectWidth
-) {
-  let angleInRadians = (angle * Math.PI) / 180;
-  textColor = textColor ?? strokeColor;
-  radius1 = radius1 ?? 2;
-  radius2 = radius2 ?? 0;
-  return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.pentagon(
-        false,
-        offset,
-        angleInRadians,
-        fillColor,
-        strokeColor,
-        ref,
-        radius1,
-        radius2,
-        1,
-        rectWidth
-      ),
-    textLayoutConstraint: (spaceBounds, textBounds) =>
-      ShieldText.roundedRectTextConstraint(spaceBounds, textBounds, radius2),
-    padding: {
-      left: 2 + 10 * Math.tan(angleInRadians),
-      right: 2 + 10 * Math.tan(angleInRadians),
-      top: 3,
-      bottom: 2 + offset / 2,
     },
     textColor: textColor,
   };
@@ -340,19 +296,18 @@ function pentagonUpShield(
   radius1 = radius1 ?? 2;
   radius2 = radius2 ?? 0;
   return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.pentagon(
-        true,
-        offset,
-        angleInRadians,
-        fillColor,
-        strokeColor,
-        ref,
-        radius1,
-        radius2,
-        1,
-        rectWidth
-      ),
+    canvasDrawnBlank: {
+      drawFunc: "pentagon",
+      params: {
+        offset: offset,
+        angle: angleInRadians,
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        radius1: radius1,
+        radius2: radius2,
+        rectWidth: rectWidth,
+      },
+    },
     textLayoutConstraint: (spaceBounds, textBounds) =>
       ShieldText.roundedRectTextConstraint(spaceBounds, textBounds, radius2),
     padding: {
@@ -390,19 +345,19 @@ function homePlateDownShield(
   radius1 = radius1 ?? 2;
   radius2 = radius2 ?? 2;
   return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.pentagon(
-        false,
-        offset,
-        0,
-        fillColor,
-        strokeColor,
-        ref,
-        radius1,
-        radius2,
-        1,
-        rectWidth
-      ),
+    canvasDrawnBlank: {
+      drawFunc: "pentagon",
+      params: {
+        pointUp: false,
+        offset: offset,
+        angle: 0,
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        radius1: radius1,
+        radius2: radius2,
+        rectWidth: rectWidth,
+      },
+    },
     textLayoutConstraint: (spaceBounds, textBounds) =>
       ShieldText.roundedRectTextConstraint(spaceBounds, textBounds, radius2),
     padding: {
@@ -410,56 +365,6 @@ function homePlateDownShield(
       right: 2,
       top: 2,
       bottom: 1 + offset,
-    },
-    textColor: textColor,
-  };
-}
-
-/**
- * Draws a shield with a home plate background, pointed upward
- *
- * @param {*} offset - Height of diagonal edges
- * @param {*} fillColor - Color of home plate background fill
- * @param {*} strokeColor - Color of home plate outline stroke
- * @param {*} textColor - Color of text (defaults to strokeColor)
- * @param {*} radius1 - Corner radius of pointed side of home plate (defaults to 2)
- * @param {*} radius2 - Corner radius of flat side of home plate (defaults to 2)
- * @param {*} rectWidth - Width of home plate (defaults to variable-width)
- * @returns a shield definition object
- */
-function homePlateUpShield(
-  offset,
-  fillColor,
-  strokeColor,
-  textColor,
-  radius1,
-  radius2,
-  rectWidth
-) {
-  textColor = textColor ?? strokeColor;
-  radius1 = radius1 ?? 2;
-  radius2 = radius2 ?? 2;
-  return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.pentagon(
-        true,
-        offset,
-        0,
-        fillColor,
-        strokeColor,
-        ref,
-        radius1,
-        radius2,
-        1,
-        rectWidth
-      ),
-    textLayoutConstraint: (spaceBounds, textBounds) =>
-      ShieldText.roundedRectTextConstraint(spaceBounds, textBounds, radius2),
-    padding: {
-      left: 2,
-      right: 2,
-      top: 1 + offset,
-      bottom: 2,
     },
     textColor: textColor,
   };
@@ -487,6 +392,16 @@ function hexagonVerticalShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 2;
   return {
+    canvasDrawnBlank: {
+      drawFunc: "hexagonVertical",
+      params: {
+        offset: offset,
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        radius: radius,
+        rectWidth: rectWidth,
+      },
+    },
     backgroundDraw: (ref) =>
       ShieldDraw.hexagonVertical(
         offset,
@@ -532,16 +447,16 @@ function hexagonHorizontalShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 2;
   return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.hexagonHorizontal(
-        angleInRadians,
-        fillColor,
-        strokeColor,
-        ref,
-        radius,
-        1,
-        rectWidth
-      ),
+    canvasDrawnBlank: {
+      drawFunc: "hexagonHorizontal",
+      params: {
+        angle: angleInRadians,
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        radius: radius,
+        rectWidth: rectWidth,
+      },
+    },
     textLayoutConstraint: ShieldText.ellipseTextConstraint,
     padding: {
       left: 3,
@@ -578,17 +493,17 @@ function octagonVerticalShield(
   textColor = textColor ?? strokeColor;
   radius = radius ?? 2;
   return {
-    backgroundDraw: (ref) =>
-      ShieldDraw.octagonVertical(
-        offset,
-        angleInRadians,
-        fillColor,
-        strokeColor,
-        ref,
-        radius,
-        1,
-        rectWidth
-      ),
+    canvasDrawnBlank: {
+      drawFunc: "octagonVertical",
+      params: {
+        offset: offset,
+        angle: 0,
+        fillColor: fillColor,
+        strokeColor: strokeColor,
+        radius: radius,
+        rectWidth: rectWidth,
+      },
+    },
     textLayoutConstraint: ShieldText.ellipseTextConstraint,
     padding: {
       left: 2,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -213,6 +213,7 @@ function trapezoidUpShield(
     canvasDrawnBlank: {
       drawFunc: "trapezoid",
       params: {
+        shortSideUp: true,
         angle: angleInRadians,
         fillColor: fillColor,
         strokeColor: strokeColor,
@@ -255,8 +256,6 @@ function diamondShield(fillColor, strokeColor, textColor, radius, rectWidth) {
         rectWidth: rectWidth,
       },
     },
-    backgroundDraw: (ref) =>
-      ShieldDraw.diamond(fillColor, strokeColor, ref, radius, 1, rectWidth),
     textLayoutConstraint: ShieldText.ellipseTextConstraint,
     padding: {
       left: 4.5,
@@ -402,16 +401,6 @@ function hexagonVerticalShield(
         rectWidth: rectWidth,
       },
     },
-    backgroundDraw: (ref) =>
-      ShieldDraw.hexagonVertical(
-        offset,
-        fillColor,
-        strokeColor,
-        ref,
-        radius,
-        1,
-        rectWidth
-      ),
     textLayoutConstraint: (spaceBounds, textBounds) =>
       ShieldText.roundedRectTextConstraint(spaceBounds, textBounds, radius),
     padding: {
@@ -497,7 +486,7 @@ function octagonVerticalShield(
       drawFunc: "octagonVertical",
       params: {
         offset: offset,
-        angle: 0,
+        angle: angleInRadians,
         fillColor: fillColor,
         strokeColor: strokeColor,
         radius: radius,
@@ -592,8 +581,8 @@ function bransonRouteShield(fillColor) {
  */
 function banneredShield(baseDef, modifiers) {
   return {
-    ...baseDef,
     modifiers: modifiers,
+    ...baseDef,
   };
 }
 


### PR DESCRIPTION
This continues the refactor started in #701 and #706 by converting the remaining draw functions to JSON.  Additionally, I moved the two custom drawing functions to their own file, which gives a nice demonstrator of how to add your own custom shields.  This removes the dependency of shield.js on color.js, which was the major blocker on #699.