### PR TITLE
Support for highway=track

### DIFF
--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -223,6 +223,13 @@
       "doc_url": "https://openmaptiles.org/schema/#transportation"
     },
     {
+      "key": "highway",
+      "value": "track",
+      "object_types": ["way"],
+      "description": "Track roads have a two-track dashed line pattern.",
+      "doc_url": "https://openmaptiles.org/schema/#transportation"
+    },
+    {
       "key": "railway",
       "value": "rail",
       "object_types": ["way"],

--- a/src/js/legend_config.js
+++ b/src/js/legend_config.js
@@ -4,6 +4,7 @@ import * as PlaceLayers from "../layer/place.js";
 import * as LanduseLayers from "../layer/landuse.js";
 import * as BoundaryLayers from "../layer/boundary.js";
 import * as RoadLayers from "../layer/road.js";
+import * as TrackLayers from "../layer/track.js";
 import * as ConstructionLayers from "../layer/construction.js";
 import * as HighwayExitLayers from "../layer/highway_exit.js";
 import * as RailLayers from "../layer/rail.js";
@@ -27,6 +28,7 @@ export const sections = [
     name: "Roads",
     entries: [
       ...RoadLayers.legendEntries,
+      ...TrackLayers.legendEntries,
       ...ConstructionLayers.legendEntries,
       ...HighwayExitLayers.legendEntries,
     ],

--- a/src/layer/index.js
+++ b/src/layer/index.js
@@ -14,6 +14,7 @@ import * as lyrPlace from "./place.js";
 import * as lyrPoi from "./poi.js";
 import * as lyrRail from "./rail.js";
 import * as lyrRoad from "./road.js";
+import * as lyrTrack from "./track.js";
 import * as lyrTransportationLabel from "./transportation_label.js";
 import * as lyrWater from "./water.js";
 import * as lyrBuilding from "./building.js";
@@ -85,6 +86,8 @@ export function build(locales) {
     lyrAeroway.runwayArea,
     lyrAeroway.taxiway,
     lyrAeroway.taxiwayArea,
+
+    lyrTrack.track,
 
     lyrRoad.motorwayLink.casing(),
     lyrRoad.trunkLink.casing(),

--- a/src/layer/track.js
+++ b/src/layer/track.js
@@ -1,0 +1,46 @@
+"use strict";
+
+import * as Color from "../constants/color.js";
+
+const trackSelect = ["match", ["get", "class"], ["track"]];
+
+export const track = {
+  id: "highway-track",
+  type: "line",
+  source: "openmaptiles",
+  "source-layer": "transportation",
+  filter: ["in", ["get", "class"], ["literal", ["track"]]],
+  minzoom: 9,
+  paint: {
+    "line-color": "tan",
+    "line-opacity": [
+      "interpolate",
+      ["exponential", 1.2],
+      ["zoom"],
+      13,
+      0,
+      15,
+      1,
+    ],
+    "line-blur": 0.75,
+    "line-width": 0.5,
+    "line-dasharray": [7, 5],
+    "line-offset": 0,
+    "line-gap-width": [
+      "interpolate",
+      ["exponential", 1.2],
+      ["zoom"],
+      13,
+      1.5,
+      20,
+      4,
+    ],
+  },
+};
+
+export const legendEntries = [
+  {
+    description: "Land access track",
+    layers: [track.id],
+  },
+];


### PR DESCRIPTION
As part of #216, this PR adds support for tracks, rendering them as double-tracked dashed lines.

- [ ] Basic rendering
- [ ] Bridges
- [ ] Tunnels
- [ ] Fords
- [ ] Vary dash pattern based on grade, surface, smoothness, etc. 
       Note that this will require separate layers with different `line-dasharray` values until maplibre/maplibre-gl-js#1235 is fixed similar to #526.
       Right now only `surface` is exposed in OpenMapTiles.
- [ ] Smoothly fade in tracks at z12 where available. 
      As mentioned in openmaptiles/openmaptiles#1334, some tracks should be showing up at z12, but I have yet to find examples. It would be great to fade them in smoothly based on their `route_rank`, but the `route_rank` isn't exposed in OMT, so tracks are just present or not at different zooms.