### PR TITLE
change Mackinac Island shield to fixed-width

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -4080,7 +4080,13 @@ export function loadShields(shieldImages) {
   };
 
   shields["US:MI"].overrideByRef = {
-    185: diamondShield(Color.shields.brown, Color.shields.white),
+    185: diamondShield(
+      Color.shields.brown,
+      Color.shields.white,
+      Color.shields.white,
+      0,
+      24
+    ),
   };
 
   shields["US:MO:Taney:Branson"].overrideByRef = {


### PR DESCRIPTION
Michigan State Trunkline Highway 185 is the ring road of Mackinac Island, on which motorized vehicles are banned (except for a handful of emergency vehicles). It has a unique shield due to its non-motorized status. In #593 the SVG icon was replaced by a draw function, but erroneously set the shield to variable-width. This changes it back to fixed-width, and also removes the rounded corners to match the real-life shield.

before/after:
![Screenshot from 2023-01-21 14-28-29](https://user-images.githubusercontent.com/1732117/213883876-53904159-c48f-4dba-8eff-809527066eed.png)
![Screenshot from 2023-01-21 14-31-08](https://user-images.githubusercontent.com/1732117/213883968-dc040ad8-dac1-41f8-b210-90a9e4e2581a.png)
