### PR TITLE
Specify favicon.ico location

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>OpenStreetMap Americana</title>
-    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <meta
       name="viewport"
       content="initial-scale=1,maximum-scale=1,user-scalable=no"

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>OpenStreetMap Americana</title>
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
     <meta
       name="viewport"
       content="initial-scale=1,maximum-scale=1,user-scalable=no"


### PR DESCRIPTION
Because the demo map is deployed to a non-root location `/openstreetmap-americana/index.html`, the `favicon.ico` has to be specified with a relative path.