### PR TITLE
Add config variable to outline shield text padding

### DIFF
--- a/src/configs/config.aws.js
+++ b/src/configs/config.aws.js
@@ -7,12 +7,15 @@ const OPENMAPTILES_URL =
   "https://6ug7hetxl9.execute-api.us-east-2.amazonaws.com/data/v3.json";
 
 /*
-Uncomment this variable to override the shield text halo color. Useful while testing shield design changes.
-Accepts an HTML color name, hex code, or other CSS color value.
+The following two variables override the color of the bounding box and halo of
+shield text, respectively. Useful while testing shield design changes.
+Both accept an HTML color name, hex code, or other CSS color value.
 */
+const SHIELD_TEXT_BBOX_COLOR = null;
 const SHIELD_TEXT_HALO_COLOR_OVERRIDE = null;
 
 export default {
   OPENMAPTILES_URL,
+  SHIELD_TEXT_BBOX_COLOR,
   SHIELD_TEXT_HALO_COLOR_OVERRIDE,
 };

--- a/src/configs/config.localhost.js
+++ b/src/configs/config.localhost.js
@@ -6,12 +6,15 @@
 const OPENMAPTILES_URL = "http://localhost:8080/data/v3.json";
 
 /*
-Uncomment this variable to override the shield text halo color. Useful while testing shield design changes.
-Accepts an HTML color name, hex code, or other CSS color value.
+The following two variables override the color of the bounding box and halo of
+shield text, respectively. Useful while testing shield design changes.
+Both accept an HTML color name, hex code, or other CSS color value.
 */
+const SHIELD_TEXT_BBOX_COLOR = null;
 const SHIELD_TEXT_HALO_COLOR_OVERRIDE = null;
 
 export default {
   OPENMAPTILES_URL,
+  SHIELD_TEXT_BBOX_COLOR,
   SHIELD_TEXT_HALO_COLOR_OVERRIDE,
 };

--- a/src/configs/config.maptiler.js
+++ b/src/configs/config.maptiler.js
@@ -20,14 +20,17 @@ const ATTRIBUTION_TEXT =
   '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a>';
 
 /*
-Uncomment this variable to override the shield text halo color. Useful while testing shield design changes.
-Accepts an HTML color name, hex code, or other CSS color value.
+The following two variables override the color of the bounding box and halo of
+shield text, respectively. Useful while testing shield design changes.
+Both accept an HTML color name, hex code, or other CSS color value.
 */
+const SHIELD_TEXT_BBOX_COLOR = null;
 const SHIELD_TEXT_HALO_COLOR_OVERRIDE = null;
 
 export default {
   OPENMAPTILES_URL,
   ATTRIBUTION_LOGO,
   ATTRIBUTION_TEXT,
+  SHIELD_TEXT_BBOX_COLOR,
   SHIELD_TEXT_HALO_COLOR_OVERRIDE,
 };

--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -245,6 +245,21 @@ function drawShieldText(ctx, shieldDef, routeDef) {
   ctx.fillStyle = textColor(shieldDef);
   ShieldText.drawShieldText(ctx, routeDef.ref, textLayout);
 
+  if (config.SHIELD_TEXT_BBOX_COLOR) {
+    ctx.strokeStyle = config.SHIELD_TEXT_BBOX_COLOR;
+    ctx.lineWidth = ShieldDraw.PXR;
+    ctx.strokeRect(
+      (shieldDef.padding.left - 0.5) * ShieldDraw.PXR,
+      bannerCount * ShieldDef.bannerSizeH +
+        ShieldDef.topPadding +
+        (shieldDef.padding.top - 0.5) * ShieldDraw.PXR,
+      shieldBounds.width -
+        (shieldDef.padding.left + shieldDef.padding.right - 1) * ShieldDraw.PXR,
+      shieldBounds.height -
+        (shieldDef.padding.top + shieldDef.padding.bottom - 1) * ShieldDraw.PXR
+    );
+  }
+
   return ctx;
 }
 


### PR DESCRIPTION
Adds a debug variable in `config.js` to display a rectangle on shields representing the padding values passed from the shield definition.

![Screenshot from 2023-01-24 13-30-41](https://user-images.githubusercontent.com/1732117/214378584-6d7d89b6-6cae-4e0c-aba4-1ef6709a94cc.png)