### PR TITLE
Distinguish Ohio Turnpike from Ohio state routes

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2356,7 +2356,6 @@ export function loadShields(shieldImages) {
   // Ohio
   shields["US:OH"] = {
     backgroundImage: [shieldImages.shield_us_oh_2, shieldImages.shield_us_oh_3],
-    norefImage: shieldImages.shield_us_oh_turnpike,
     textColor: Color.shields.black,
     padding: {
       left: 3,
@@ -2367,6 +2366,10 @@ export function loadShields(shieldImages) {
   };
   shields["US:OH:Bypass"] = banneredShield(shields["US:OH"], ["BYP"]);
   shields["US:OH:Business"] = banneredShield(shields["US:OH"], ["BUS"]);
+  shields["US:OH:Turnpike"] = {
+    backgroundImage: shieldImages.shield_us_oh_turnpike,
+    notext: true,
+  };
 
   // Ohio county and township roads
 


### PR DESCRIPTION
Restored the Ohio Turnpike shield, now associated with `network=US:OH:Turnpike` instead of `network=US:OH`. This allows the legend to distinguish the Ohio Turnpike from ordinary state routes:

<img src="https://user-images.githubusercontent.com/1231218/214903676-3089c612-8771-48f1-84aa-f4b38adc2f30.png" width="282" alt="legend">

Fixes #718.