### PR TITLE
Add style.json to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           npm ci --include=dev
           cp src/configs/config.aws.js src/config.js
-          npm run build
+          npm run build style
       - name: Upload 🏗
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,8 @@ jobs:
         run: |
           npm ci --include=dev
           cp src/configs/config.aws.js src/config.js
-          npm run build style
+          npm run build
+          npm run style
       - name: Upload 🏗
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -17,9 +17,8 @@ jobs:
       - name: Install and Build 🔧
         run: |
           npm ci --include=dev
-          sed 's/<your MapTiler key>/53iZvB2drcamS0Ge0xiD/g' src/configs/config.maptiler.js > src/config.js
-          npm run build
-        # MapTiler key 53iZvB2drcamS0Ge0xiD only allows requests from zelonewolf.github.io
+          cp src/configs/config.aws.js src/config.js
+          npm run build style
       - name: Test 🧪
         run: |
           npm test

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Install and Build 🔧
         run: |
           npm ci --include=dev
-          cp src/configs/config.aws.js src/config.js
           npm run build
           npm run style
       - name: Test 🧪

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -18,7 +18,8 @@ jobs:
         run: |
           npm ci --include=dev
           cp src/configs/config.aws.js src/config.js
-          npm run build style
+          npm run build
+          npm run style
       - name: Test 🧪
         run: |
           npm test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ rebusurance.zip
 config.js
 .parcel-cache
 dist/
+src/local.config.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,9 @@ and re-running `npm install`.
 Environment specific settings go in the untracked file `config.js`. Copy from one of
 the templates in the configs/ folder `config.*.js` and rename it `config.js` in
 the src/ root. The variables in this file can then be changed without the risk of
-accidentally comitting to the main repo.
+accidentally comitting to the main repo. By default, the repository `config.js` points
+to a development tile server operated by the project maintainers. It is free to use
+for development purposes but service is not garaunteed.
 
 You can create a new copy of the config file by running `npm run config`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,9 +104,9 @@ and re-running `npm install`.
 Environment specific settings go in the untracked file `config.js`. Copy from one of
 the templates in the configs/ folder `config.*.js` and rename it `config.js` in
 the src/ root. The variables in this file can then be changed without the risk of
-accidentally comitting to the main repo. By default, the repository `config.js` points
+accidentally committing to the main repo. By default, the repository `config.js` points
 to a development tile server operated by the project maintainers. It is free to use
-for development purposes but service is not garaunteed.
+for development purposes but service is not guaranteed.
 
 You can create a new copy of the config file by running `npm run config`
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,19 +5,19 @@ import esbuild from "esbuild";
 
 const maybeLocalConfig = async (name = "local.config.js") => {
   let exists = await stat(name)
-    .then(st => st.isFile())
-    .catch(err => {
+    .then((st) => st.isFile())
+    .catch((err) => {
       if (err.code !== "ENOENT") throw err;
     });
   if (exists) {
     console.log("Local config in use: %o", name);
     return {
       define: {
-        "CONFIG_PATH": JSON.stringify("../" + name),
+        CONFIG_PATH: JSON.stringify("../" + name),
       },
-    }
+    };
   }
-}
+};
 
 const buildWith = async (key, buildOptions) => {
   await mkdir("dist", { recursive: true });
@@ -44,17 +44,18 @@ const buildWith = async (key, buildOptions) => {
       ...buildOptions?.define,
     },
   };
-  return esbuild[key](options)
-    // esbuild will pretty-print its own error messages;
-    // suppress node.js from printing the exception.
-    .catch(() => process.exit(1));
+  return (
+    esbuild[key](options)
+      // esbuild will pretty-print its own error messages;
+      // suppress node.js from printing the exception.
+      .catch(() => process.exit(1))
+  );
 };
 
 export const buildContext = (buildOptions = {}) =>
   buildWith("context", buildOptions);
 
-export const build = (buildOptions = {}) =>
-  buildWith("build", buildOptions);
+export const build = (buildOptions = {}) => buildWith("build", buildOptions);
 
 const mainModule = pathToFileURL(process.argv[1]).toString();
 const isMain = import.meta.url === mainModule;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,23 @@
-import { copyFile, mkdir } from "node:fs/promises";
+import { stat, copyFile, mkdir } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
 import esbuild from "esbuild";
+
+const maybeLocalConfig = async (name = "local.config.js") => {
+  let exists = await stat(name)
+    .then(st => st.isFile())
+    .catch(err => {
+      if (err.code !== "ENOENT") throw err;
+    });
+  if (exists) {
+    console.log("Local config in use: %o", name);
+    return {
+      define: {
+        "CONFIG_PATH": JSON.stringify("../" + name),
+      },
+    }
+  }
+}
 
 const buildWith = async (key, buildOptions) => {
   await mkdir("dist", { recursive: true });
@@ -10,7 +26,10 @@ const buildWith = async (key, buildOptions) => {
       copyFile(`src/${f}`, `dist/${f}`)
     )
   );
-  return esbuild[key]({
+
+  const localConfig = await maybeLocalConfig();
+
+  const options = {
     entryPoints: ["src/americana.js", "src/shieldtest.js"],
     format: "esm",
     bundle: true,
@@ -18,18 +37,24 @@ const buildWith = async (key, buildOptions) => {
     sourcemap: true,
     outdir: "dist",
     logLevel: "info",
+    ...localConfig,
     ...buildOptions,
-  });
+    define: {
+      ...localConfig?.define,
+      ...buildOptions?.define,
+    },
+  };
+  return esbuild[key](options)
+    // esbuild will pretty-print its own error messages;
+    // suppress node.js from printing the exception.
+    .catch(() => process.exit(1));
 };
 
 export const buildContext = (buildOptions = {}) =>
   buildWith("context", buildOptions);
 
 export const build = (buildOptions = {}) =>
-  buildWith("build", buildOptions)
-    // esbuild will pretty-print its own error messages;
-    // suppress node.js from printing the exception.
-    .catch(() => process.exit(1));
+  buildWith("build", buildOptions);
 
 const mainModule = pathToFileURL(process.argv[1]).toString();
 const isMain = import.meta.url === mainModule;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export { default } from "./configs/config.aws.js";

--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,14 @@
-export { default } from "./configs/config.aws.js";
+// The build script injects this global variable if "local.config.js"
+// exists in the project root (alongside package.json). That file is in
+// gitignore and so can be modified without making changes to this file.
+
+const importConfig = () => {
+  if (typeof CONFIG_PATH !== "undefined") {
+    return import(CONFIG_PATH);
+  } else {
+    return import("./configs/config.aws.js");
+  }
+};
+
+const { default: config } = await importConfig();
+export { config as default };


### PR DESCRIPTION
Fixes #68 

This PR generates the style.json and hosts it on GitHub pages.  This artifact is provided for development and experimentation purposes; however, I envision it will eventually be part of an end-user deployable style in the spirit of #70.

I also removed the old code that was copying a maptiler key into the old maptiler config.