### PR TITLE
Add Ireland to shield status map

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -155,6 +155,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .de,
 .gr,
 .is,
+.ie,
 .it,
 .xk,
 .lt,
@@ -170,11 +171,11 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .si,
 .sk,
 .ua,
+.gb,
 .au,
 .nz,
 .cw,
-.ust,
-.gb { fill: #8250df; }
+.ust { fill: #8250df; }
 
 /* Color individual borders
 For example, to color the border between Angola and Namibia in green, add this line in the space below:

--- a/scripts/status_map.js
+++ b/scripts/status_map.js
@@ -13,8 +13,6 @@ function fillPaths(svg, codes) {
     // Routes in United States insular areas use US prefix with the U.S.
     selectors.add(".ust");
   }
-  // Great Britain uses OpenMapTiles special processing
-  selectors.add(".gb");
   return svg.replace(".supported", new Array(...selectors).join(",\n"));
 }
 
@@ -27,9 +25,9 @@ let worldSVG = fs.readFileSync(`${process.cwd()}/scripts/blank_map_world.svg`, {
 worldSVG = fillPaths(
   worldSVG,
   Object.keys(shields)
-    .map((network) => network.match(/^(\w\w)(?::|$)/))
+    .map((network) => network.match(/^(\w\w)(?::|$)|^omt-(\w\w)-/))
     .filter((m) => m)
-    .map((m) => m[1])
+    .map((m) => m[1] || m[2])
 );
 worldSVG = worldSVG.replace(
   /<title>.+?<\/title>/,


### PR DESCRIPTION
#696 added support for route networks in Ireland that don’t exist in OSM but are instead synthesized by OpenMapTiles using a different `network` syntax. This PR generalizes the script that generates the shield status map to handle all such networks, not just Great Britain’s.