### PR TITLE
Force shield canvas to cpu.

### DIFF
--- a/src/js/screen_gfx.js
+++ b/src/js/screen_gfx.js
@@ -5,7 +5,9 @@ export const shieldFont = (size) => `bold ${size}px ${fontFamily}`;
 export const fontSizeThreshold = 12;
 
 export function getGfxContext(bounds) {
-  var ctx = document.createElement("canvas").getContext("2d");
+  var ctx = document
+    .createElement("canvas")
+    .getContext("2d", { willReadFrequently: true });
   ctx.imageSmoothingQuality = "high";
   ctx.textAlign = "center";
   ctx.textBaseline = "top";


### PR DESCRIPTION
Enable `willReadFrequently` on the shield drawing canvas, which (is a hint to) move rendering from the GPU to CPU.

Doesn't make a noticeable difference on many systems, but my chromebook is showing a consistent 4x speedup, from 8 ms to 2 ms, by avoiding the overhead of going to the GPU.