### PR TITLE
Fix local config path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ rebusurance.zip
 config.js
 .parcel-cache
 dist/
-src/local.config.js
+local.config.js


### PR DESCRIPTION
The project checks for `local.config.js` in the project root, not in `src/`. Re #736 