### PR TITLE
Validate the output style json

### DIFF
--- a/scripts/generate_style.js
+++ b/scripts/generate_style.js
@@ -1,7 +1,10 @@
+import * as fs from "node:fs";
+
+import { Command } from "commander";
+import { validate } from "@maplibre/maplibre-gl-style-spec";
+
 import * as Style from "../src/js/style.js";
 import config from "../src/config.js";
-import * as fs from "fs";
-import { Command } from "commander";
 
 /**
  * Requires mapbox-gl-rtl-text:
@@ -21,6 +24,12 @@ let style = Style.build(
   "https://zelonewolf.github.io/openstreetmap-americana/sprites/sprite",
   opts.locales
 );
+
+const errors = validate(style);
+if (errors.length) {
+  console.error(errors.map((e) => e.message).join("\n"));
+  process.exit(1);
+}
 
 if (opts.outfile == "-") {
   console.log("%j", style);


### PR DESCRIPTION
The map will refuse to start with errors anyway, but this will cause them to show up in the checks.