### PR TITLE
Group shields in legend by highway system

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -122,7 +122,7 @@
       <details class="legend-section" open>
         <summary></summary>
         <table>
-          <tbody></tbody>
+          <tbody class="legend-row-container"></tbody>
           <tfoot>
             <tr>
               <td class="legend-source" colspan="3"></td>

--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -479,6 +479,7 @@ export default class LegendControl {
     // Gets all the relevant images, sorted from generic to specialized.
     let getSortedImages = (network) => {
       let images = imagesByNetwork[network];
+      if (!images) return [];
       return [
         images.noRef,
         images.ref,

--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -632,8 +632,7 @@ export default class LegendControl {
           type: "language",
         });
         languageTag.textContent = languageNames.of(locale);
-        descriptionCell.appendChild(document.createTextNode(" "));
-        descriptionCell.appendChild(languageTag);
+        descriptionCell.append(" ", languageTag);
       }
     } else {
       descriptionCell.querySelector("code").replaceChildren(link);


### PR DESCRIPTION
The legend now incorporates Wikidata labels into its “Route markers” section while generating the section, instead of patching in the labels afterwards. If the Wikidata Query Service response hasn’t come back by the time the section is generated, the legend blows away the section and regenerates it once it receives the response.

When generating the section, entries are now combined with other entries that correspond to the same highway system item in Wikidata. This improves the display of highway systems that haven’t been modeled in as much detail in Wikidata. More detailed highway systems continue to get separate rows with separate labels.

[<img src="https://user-images.githubusercontent.com/1231218/217413611-804fe0b3-857d-470b-8053-25cf997bb855.png" width="314" alt="Murfreesboro">](https://zelonewolf.github.io/openstreetmap-americana/#map=12/35.86777/-86.37516&language=en) [<img src="https://user-images.githubusercontent.com/1231218/217414817-a689e71b-6163-4d74-845c-0d6825e887c5.png" width="299" alt="Guayama">](https://zelonewolf.github.io/openstreetmap-americana/#map=15/17.97549/-66.10174&language=es)

Fixes #771.