### PR TITLE
Simulate `line-gap-width` in legend

### DIFF
--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -402,7 +402,7 @@ export default class LegendControl {
     let height = Math.max(...lineWidths);
 
     let svg = cell.querySelector("svg");
-    svg.style.height = `${Math.ceil(height)}px`;
+    svg.style.height = `${height}px`;
 
     for (let feature of lineFeatures) {
       let line = document.createElementNS("http://www.w3.org/2000/svg", "line");
@@ -424,8 +424,8 @@ export default class LegendControl {
         let points = [
           [0, -lineWidth / 2.0],
           [100, -lineWidth / 2.0],
-          [100, (-lineWidth + gapWidth) / 2.0],
-          [0, (-lineWidth + gapWidth) / 2.0],
+          [100, -gapWidth / 2.0],
+          [0, -gapWidth / 2.0],
           [0, gapWidth / 2.0],
           [100, gapWidth / 2.0],
           [100, lineWidth / 2.0],

--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -417,11 +417,29 @@ export default class LegendControl {
         (d) => d * simpleLineWidth
       );
 
+      let lineWidth = getLineWidth(feature);
+      let gapWidth = feature.layer.paint["line-gap-width"];
+      let clipPath;
+      if (gapWidth) {
+        let points = [
+          [0, -lineWidth / 2.0],
+          [100, -lineWidth / 2.0],
+          [100, (-lineWidth + gapWidth) / 2.0],
+          [0, (-lineWidth + gapWidth) / 2.0],
+          [0, gapWidth / 2.0],
+          [100, gapWidth / 2.0],
+          [100, lineWidth / 2.0],
+          [0, lineWidth / 2.0],
+        ].map((p) => `${p[0]}% ${p[1]}px`);
+        clipPath = `polygon(evenodd, ${points.join(", ")})`;
+      }
+
       Object.assign(line.style, {
         opacity: feature.layer.paint["line-opacity"] ?? 1,
         stroke: feature.layer.paint["line-color"] || fillColor,
         strokeDasharray: dashArray?.join(" "),
-        strokeWidth: getLineWidth(feature),
+        strokeWidth: lineWidth,
+        clipPath: clipPath,
       });
 
       svg.appendChild(line);


### PR DESCRIPTION
Line layers that specify the `line-gap-width` paint property now appear as a double line in the legend. The SVG line is now clipped to a `[`-shaped polygon.

[<img src="https://user-images.githubusercontent.com/1231218/217452393-ba912759-c142-49cc-9ffa-6b9a905ad9a8.png" width="211" alt="A-35">](https://zelonewolf.github.io/openstreetmap-americana/#map=22/45.09306201/-73.08378183&language=fr)

Fixes #770.