### PR TITLE
Add layer sorting for roads within a common layer

### DIFF
--- a/src/layer/road.js
+++ b/src/layer/road.js
@@ -32,6 +32,7 @@ const tunDashArray = [
 const getBrunnel = ["get", "brunnel"];
 const getClass = ["get", "class"];
 const getExpressway = ["coalesce", ["get", "expressway"], 0];
+const getLayer = ["coalesce", ["get", "layer"], 0];
 const getRamp = ["coalesce", ["get", "ramp"], 0];
 const getToll = ["coalesce", ["get", "toll"], 0];
 
@@ -93,24 +94,25 @@ const opacity = [
 
 const layerSortKey = [
   "+",
-  ["*", -28, getRamp],
+  getLayer,
+  ["*", -0.28, getRamp],
   [
     "*",
-    4,
+    0.04,
     [
       ...classSelector,
       "motorway",
-      6,
+      0.06,
       "trunk",
-      5,
+      0.05,
       "primary",
-      4,
+      0.04,
       "secondary",
-      3,
+      0.03,
       "tertiary",
-      2,
+      0.02,
       "minor",
-      1,
+      0.01,
       0,
     ],
   ],


### PR DESCRIPTION
This is a partial fix for #27.

This PR sorts features in the vertical direction by `layer`, _when they are in the same style layer_. This resolves a handful of layer corner cases not currently supported, however this is not a general solution for layered roads, which needs a solution to maplibre/maplibre-gl-js#2108. However, all `motorway` are now in the same layer, so in the case of overlapping motorway features, they will now sort correctly. This includes overlapping bridge/tunnel motorway and motorway_link features to any layer level. However, this does not address overlaps between motorways and other highway classes such as trunk/primary/etc.

In the screenshots below, in Boston, there is a `layer=-2` tunnel _underneath_ a `layer=-1` tunnel.

Before:
[![image](https://user-images.githubusercontent.com/3254090/217709119-8aad54ca-711b-418e-b123-8b9d426ae2b3.png)](https://zelonewolf.github.io/openstreetmap-americana/#map=18/42.364902/-71.05877)

After:
[![image](https://user-images.githubusercontent.com/3254090/217709189-7b73e37e-ad17-4954-a2bb-196dc475a197.png)](http://localhost:1776/#map=18/42.364902/-71.05877)

Because `line-sort-key` takes a number, I changed the existing class deconfliction selector to use fractional values and add in the `layer` value, which is always a whole number.

This takes the total style size from `944,239` to `954,931`.

I suspect that some of the code in `layerSortKey` is actually unnecessary since we use separate layers, however I'd like to leave that investigation for a separate PR.