### PR TITLE
Fix error when opening legend

### DIFF
--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -704,8 +704,9 @@ export default class LegendControl {
     if (!networkMetadata) return;
 
     let section = document.getElementById("legend-section-shields");
-    let rowContainer = section.querySelector(".legend-row-container");
-    let pendingRows = rowContainer.querySelectorAll('[data-pending="true"]');
+    let rowContainer = section?.querySelector(".legend-row-container");
+    let pendingRows =
+      rowContainer?.querySelectorAll('[data-pending="true"]') ?? [];
     if (pendingRows.length === 0) return;
 
     // If any synthesized British networks are visible, also query Wikidata for


### PR DESCRIPTION
This PR fixes a regression from #773 that produces an error when opening the legend: https://github.com/ZeLonewolf/openstreetmap-americana/pull/774#issuecomment-1424847267. If there’s no “Route markers” section because no route markers are visible in the current viewport, then there are no pending rows and no need to regenerate them with Wikidata labels.