### PR TITLE
Use map.style.getImage() instead of internal maplibre variables

### DIFF
--- a/scripts/taginfo.js
+++ b/scripts/taginfo.js
@@ -67,7 +67,7 @@ function addNetworkTags(project) {
 
       if (icon == undefined && shieldDef.canvasDrawnBlank !== undefined) {
         //Generate empty canvas sized to the graphic
-        let shieldGfx = Gfx.getGfxContext(Shields.getDrawnShieldBounds(id));
+        let shieldGfx = Gfx.getGfxContext(Shields.getDrawnShieldBounds(shieldDef, " "));
 
         //Draw shield to the canvas
         Shields.drawShield(shieldGfx, shieldDef, routeDef);

--- a/scripts/taginfo.js
+++ b/scripts/taginfo.js
@@ -67,7 +67,9 @@ function addNetworkTags(project) {
 
       if (icon == undefined && shieldDef.canvasDrawnBlank !== undefined) {
         //Generate empty canvas sized to the graphic
-        let shieldGfx = Gfx.getGfxContext(Shields.getDrawnShieldBounds(shieldDef, " "));
+        let shieldGfx = Gfx.getGfxContext(
+          Shields.getDrawnShieldBounds(shieldDef, " ")
+        );
 
         //Draw shield to the canvas
         Shields.drawShield(shieldGfx, shieldDef, routeDef);

--- a/scripts/taginfo.js
+++ b/scripts/taginfo.js
@@ -59,8 +59,19 @@ function addNetworkTags(project) {
 
       let icon_url;
 
-      if (icon == undefined) {
-        let shieldGfx = Shields.generateSpriteCtx({}, `shield\n${network}= `);
+      //Shield ID with ref as a single space character
+      let id = `shield\n${network}= `;
+
+      let routeDef = Shields.getRouteDef(id);
+      let shieldDef = Shields.getShieldDef(routeDef);
+
+      if (icon == undefined && shieldDef.canvasDrawnBlank !== undefined) {
+        //Generate empty canvas sized to the graphic
+        let shieldGfx = Gfx.getGfxContext(Shields.getDrawnShieldBounds(id));
+
+        //Draw shield to the canvas
+        Shields.drawShield(shieldGfx, shieldDef, routeDef);
+
         delete shields[network].modifiers;
         let def = JSON.stringify(shields[network]);
 

--- a/src/americana.js
+++ b/src/americana.js
@@ -12,7 +12,7 @@ import * as CustomShields from "./js/custom_shields.js";
 import * as languageLabel from "./js/language_label.js";
 
 import * as maplibregl from "maplibre-gl";
-//import "maplibre-gl/dist/maplibre-gl.css";
+import "maplibre-gl/dist/maplibre-gl.css";
 import * as search from "./search.js";
 
 import LegendControl from "./js/legend_control.js";

--- a/src/americana.js
+++ b/src/americana.js
@@ -12,7 +12,7 @@ import * as CustomShields from "./js/custom_shields.js";
 import * as languageLabel from "./js/language_label.js";
 
 import * as maplibregl from "maplibre-gl";
-import "maplibre-gl/dist/maplibre-gl.css";
+//import "maplibre-gl/dist/maplibre-gl.css";
 import * as search from "./search.js";
 
 import LegendControl from "./js/legend_control.js";

--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -377,15 +377,12 @@ export function romanizeRef(ref) {
   return roman + ref.slice(number.toString().length);
 }
 
-export function getDrawnShieldBounds(id) {
-  let routeDef = getRouteDef(id);
-  let shieldDef = getShieldDef(routeDef);
-
+export function getDrawnShieldBounds(shieldDef, ref) {
   let width = Math.max(
     ShieldDraw.CS,
     ShieldDraw.computeWidth(
       shieldDef.canvasDrawnBlank.params,
-      routeDef.ref,
+      ref,
       shieldDef.canvasDrawnBlank.drawFunc
     )
   );
@@ -416,7 +413,7 @@ export function generateShieldCtx(map, id) {
 
   if (shieldArtwork == null) {
     if (typeof shieldDef.canvasDrawnBlank != "undefined") {
-      let bounds = getDrawnShieldBounds(id);
+      let bounds = getDrawnShieldBounds(shieldDef, routeDef.ref);
       width = bounds.width;
       height = bounds.height;
     }

--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -172,7 +172,7 @@ function getDrawFunc(shieldDef) {
   return ShieldDraw.blank;
 }
 
-function drawShield(ctx, shieldDef, routeDef) {
+export function drawShield(ctx, shieldDef, routeDef) {
   let bannerCount = getBannerCount(shieldDef);
   let yOffset = bannerCount * ShieldDef.bannerSizeH + ShieldDef.topPadding;
 
@@ -296,7 +296,7 @@ export function missingIconLoader(map, e) {
   );
 }
 
-function getShieldDef(routeDef) {
+export function getShieldDef(routeDef) {
   if (routeDef == null) {
     return null;
   }
@@ -331,7 +331,7 @@ function getShieldDef(routeDef) {
   return shieldDef;
 }
 
-function getRouteDef(id) {
+export function getRouteDef(id) {
   if (id == "shield_") {
     return null;
   }
@@ -377,6 +377,22 @@ export function romanizeRef(ref) {
   return roman + ref.slice(number.toString().length);
 }
 
+export function getDrawnShieldBounds(id) {
+  let routeDef = getRouteDef(id);
+  let shieldDef = getShieldDef(routeDef);
+
+  let width = Math.max(
+    ShieldDraw.CS,
+    ShieldDraw.computeWidth(
+      shieldDef.canvasDrawnBlank.params,
+      routeDef.ref,
+      shieldDef.canvasDrawnBlank.drawFunc
+    )
+  );
+  let height = ShieldDraw.shapeHeight(shieldDef.canvasDrawnBlank.drawFunc);
+  return { width, height };
+}
+
 export function generateShieldCtx(map, id) {
   let routeDef = getRouteDef(id);
   let shieldDef = getShieldDef(routeDef);
@@ -400,15 +416,9 @@ export function generateShieldCtx(map, id) {
 
   if (shieldArtwork == null) {
     if (typeof shieldDef.canvasDrawnBlank != "undefined") {
-      width = Math.max(
-        ShieldDraw.CS,
-        ShieldDraw.computeWidth(
-          shieldDef.canvasDrawnBlank.params,
-          routeDef.ref,
-          shieldDef.canvasDrawnBlank.drawFunc
-        )
-      );
-      height = ShieldDraw.shapeHeight(shieldDef.canvasDrawnBlank.drawFunc);
+      let bounds = getDrawnShieldBounds(id);
+      width = bounds.width;
+      height = bounds.height;
     }
   } else {
     width = shieldArtwork.data.width;

--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -114,12 +114,12 @@ export function getBannerCount(shield) {
  * Retrieve the shield blank that goes with a particular route.  If there are
  * multiple shields for a route (different widths), it picks the best shield.
  *
- * @param {*} sprites - sprite sheet
+ * @param {*} map - maplibre Map
  * @param {*} shieldDef - shield definition for this route
  * @param {*} routeDef - route tagging from OSM
  * @returns shield blank or null if no shield exists
  */
-function getRasterShieldBlank(sprites, shieldDef, routeDef) {
+function getRasterShieldBlank(map, shieldDef, routeDef) {
   var shieldArtwork = null;
   var textLayout;
   var bannerCount = 0;
@@ -128,12 +128,12 @@ function getRasterShieldBlank(sprites, shieldDef, routeDef) {
   //Special case where there's a defined fallback shield when no ref is tagged
   //Example: PA Turnpike
   if (!isValidRef(routeDef.ref) && "norefImage" in shieldDef) {
-    return sprites[shieldDef.norefImage];
+    return map.style.getImage(shieldDef.norefImage);
   }
 
   if (Array.isArray(shieldDef.spriteBlank)) {
     for (var i = 0; i < shieldDef.spriteBlank.length; i++) {
-      shieldArtwork = sprites[shieldDef.spriteBlank[i]];
+      shieldArtwork = map.style.getImage(shieldDef.spriteBlank[i]);
 
       bounds = compoundShieldSize(shieldArtwork.data, bannerCount);
       textLayout = ShieldText.layoutShieldTextFromDef(
@@ -146,7 +146,7 @@ function getRasterShieldBlank(sprites, shieldDef, routeDef) {
       }
     }
   } else {
-    shieldArtwork = sprites[shieldDef.spriteBlank];
+    shieldArtwork = map.style.getImage(shieldDef.spriteBlank);
   }
 
   return shieldArtwork;
@@ -191,11 +191,11 @@ function getDrawHeight(shieldDef) {
   return ShieldDraw.CS;
 }
 
-function drawShieldText(ctx, sprites, shieldDef, routeDef) {
+function drawShieldText(ctx, map, shieldDef, routeDef) {
   var bannerCount = getBannerCount(shieldDef);
   var shieldBounds = null;
 
-  var shieldArtwork = getRasterShieldBlank(sprites, shieldDef, routeDef);
+  var shieldArtwork = getRasterShieldBlank(map, shieldDef, routeDef);
   let yOffset = bannerCount * ShieldDef.bannerSizeH + ShieldDef.topPadding;
 
   if (shieldArtwork == null) {
@@ -378,10 +378,6 @@ export function romanizeRef(ref) {
 }
 
 export function generateShieldCtx(map, id) {
-  return generateSpriteCtx(map.style.imageManager.images, id);
-}
-
-export function generateSpriteCtx(sprites, id) {
   let routeDef = getRouteDef(id);
   let shieldDef = getShieldDef(routeDef);
 
@@ -397,7 +393,7 @@ export function generateSpriteCtx(sprites, id) {
   //Determine overall shield+banner dimensions
   let bannerCount = getBannerCount(shieldDef);
 
-  let shieldArtwork = getRasterShieldBlank(sprites, shieldDef, routeDef);
+  let shieldArtwork = getRasterShieldBlank(map, shieldDef, routeDef);
 
   let width = ShieldDraw.CS;
   let height = ShieldDraw.CS;
@@ -447,7 +443,7 @@ export function generateSpriteCtx(sprites, id) {
   }
 
   // Draw the shield text
-  drawShieldText(ctx, sprites, shieldDef, routeDef);
+  drawShieldText(ctx, map, shieldDef, routeDef);
 
   // Add modifier plaque text
   drawBannerPart(ctx, routeDef.network, ShieldText.drawBannerText);


### PR DESCRIPTION
Based on initial discussions in maplibre/maplibre-gl-js#2159, this PR changes the sprite sheet access from the internal variable map.style.imageManager.images[id] to map.style.getImage(id). There is no map.getImage(id) function at the top level, so this is the most top-level function we can call to extract images.
