### PR TITLE
Remove unneeded sort attributes

### DIFF
--- a/src/layer/road.js
+++ b/src/layer/road.js
@@ -92,32 +92,21 @@ const opacity = [
   1,
 ];
 
-const layerSortKey = [
+const motorwaySortKey = [
   "+",
   getLayer,
-  ["*", -0.28, getRamp],
-  [
-    "*",
-    0.04,
-    [
-      ...classSelector,
-      "motorway",
-      0.06,
-      "trunk",
-      0.05,
-      "primary",
-      0.04,
-      "secondary",
-      0.03,
-      "tertiary",
-      0.02,
-      "minor",
-      0.01,
-      0,
-    ],
-  ],
-  ["*", 2, getExpressway],
-  getToll,
+  0.1,
+  ["*", -0.1, getRamp],
+  ["*", 0.2, getToll],
+];
+
+const expresswaySortKey = [
+  "+",
+  getLayer,
+  0.1,
+  ["*", -0.1, getRamp],
+  ["*", 0.2, getToll],
+  ["*", 0.4, getExpressway],
 ];
 
 //Helper function to create a "filter" block for a particular road class.
@@ -408,6 +397,7 @@ class Road {
     this.minZoomCasing = 4;
     this.casingColor = roadCasingColor;
     this.fillColor = highwayFillColor;
+    this.sortKey = expresswaySortKey;
   }
   fill = function () {
     var layer = baseRoadLayer(
@@ -421,7 +411,7 @@ class Road {
       "line-cap": "round",
       "line-join": "round",
       visibility: "visible",
-      "line-sort-key": layerSortKey,
+      "line-sort-key": this.sortKey,
     };
     layer.paint = {
       "line-opacity": opacity,
@@ -448,7 +438,7 @@ class Road {
       "line-cap": this.brunnel === "bridge" ? "butt" : "round",
       "line-join": this.brunnel === "bridge" ? "bevel" : "round",
       visibility: "visible",
-      "line-sort-key": layerSortKey,
+      "line-sort-key": this.sortKey,
     };
     layer.paint = {
       "line-opacity": opacity,
@@ -480,7 +470,7 @@ class Road {
       "line-cap": "butt",
       "line-join": "round",
       visibility: "visible",
-      "line-sort-key": layerSortKey,
+      "line-sort-key": this.sortKey,
     };
     layer.paint = {
       "line-opacity": opacity,
@@ -595,7 +585,7 @@ class Motorway extends Road {
   constructor() {
     super();
     this.constraints = ["all", ["==", getClass, "motorway"], isNotLink];
-
+    this.sortKey = motorwaySortKey;
     this.minZoomFill = minZoomAllRoads;
     this.minZoomCasing = minZoomAllRoads;
 


### PR DESCRIPTION
This PR simplifies the sort key used in various road classes.  The sort key is used to determine what in order to draw features _within a single style layer_. In general, the only key that makes sense to sort is `layer`, as this has a clear definition of ordering in OSM. Sorting comes into play at certain zooms where the thickness of road lines may cause overlaps.

For motorways, the only attributes that make sense for sorting are ramps, and toll roads, with toll roads on top, then non-toll roads, and then ramps.

For lower classifications, the only attribute that we need to consider sorting on is to have expressways appear above other classes of road.

It's pointless to sort by highway classification because these are already filtered into separate layers.

This change saves 23Kb of style JSON.

This change should result in no difference in rendering. Tested in Boston, NYC, and the Sam Houston Tollway.

Before:
```
Total layer size 954,931 bytes
road(201)........................753,810 bytes
```
After:
```
Total layer size 931,071 bytes
road(201)........................729,950 bytes
```
