### PR TITLE
Remove unused imports

### DIFF
--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -4,7 +4,6 @@ import * as ShieldDraw from "./shield_canvas_draw.js";
 import * as Label from "../constants/label.js";
 import * as ShieldDef from "./shield_defs.js";
 
-import * as LegendConfig from "./legend_config.js";
 import * as HighwayShieldLayers from "../layer/highway_shield.js";
 
 import * as maplibregl from "maplibre-gl";

--- a/test/spec/highway_shield.js
+++ b/test/spec/highway_shield.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import chai, { expect } from "chai";
+import { expect } from "chai";
 import * as HighwayShieldLayers from "../../src/layer/highway_shield.js";
 import { expression } from "@maplibre/maplibre-gl-style-spec";
 

--- a/test/spec/label.js
+++ b/test/spec/label.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import chai, { expect } from "chai";
+import { expect } from "chai";
 import * as Label from "../../src/constants/label.js";
 import { expression } from "@maplibre/maplibre-gl-style-spec";
 


### PR DESCRIPTION
PR removes three unused imports that I found.  Would be nice if this kind of thing could be more automated.