### PR TITLE
[Bugfix] Remove shield top padding

### DIFF
--- a/src/js/shield.js
+++ b/src/js/shield.js
@@ -24,10 +24,7 @@ function drawBannerPart(ctx, network, drawFunc) {
 function compoundShieldSize(dimension, bannerCount) {
   return {
     width: dimension.width,
-    height:
-      dimension.height +
-      bannerCount * ShieldDef.bannerSizeH +
-      ShieldDef.topPadding,
+    height: dimension.height + bannerCount * ShieldDef.bannerSizeH,
   };
 }
 
@@ -119,7 +116,7 @@ function getDrawFunc(shieldDef) {
 
 export function drawShield(ctx, shieldDef, routeDef) {
   let bannerCount = getBannerCount(shieldDef);
-  let yOffset = bannerCount * ShieldDef.bannerSizeH + ShieldDef.topPadding;
+  let yOffset = bannerCount * ShieldDef.bannerSizeH;
 
   //Shift canvas to draw shield below banner
   ctx.save();
@@ -141,7 +138,7 @@ function drawShieldText(ctx, map, shieldDef, routeDef) {
   var shieldBounds = null;
 
   var shieldArtwork = getRasterShieldBlank(map, shieldDef, routeDef);
-  let yOffset = bannerCount * ShieldDef.bannerSizeH + ShieldDef.topPadding;
+  let yOffset = bannerCount * ShieldDef.bannerSizeH;
 
   if (shieldArtwork == null) {
     ctx.translate(0, yOffset);
@@ -180,8 +177,7 @@ function drawShieldText(ctx, map, shieldDef, routeDef) {
     shieldBounds
   );
 
-  textLayout.yBaseline +=
-    bannerCount * ShieldDef.bannerSizeH + ShieldDef.topPadding;
+  textLayout.yBaseline += bannerCount * ShieldDef.bannerSizeH;
 
   if (config.SHIELD_TEXT_HALO_COLOR_OVERRIDE) {
     ctx.strokeStyle = config.SHIELD_TEXT_HALO_COLOR_OVERRIDE;
@@ -200,7 +196,6 @@ function drawShieldText(ctx, map, shieldDef, routeDef) {
     ctx.strokeRect(
       (shieldDef.padding.left - 0.5) * ShieldDraw.PXR,
       bannerCount * ShieldDef.bannerSizeH +
-        ShieldDef.topPadding +
         (shieldDef.padding.top - 0.5) * ShieldDraw.PXR,
       shieldBounds.width -
         (shieldDef.padding.left + shieldDef.padding.right - 1) * ShieldDraw.PXR,
@@ -385,7 +380,7 @@ export function generateShieldCtx(map, id) {
     height = sourceSprite.data.height;
   }
 
-  let bannerHeight = bannerCount * ShieldDef.bannerSizeH + ShieldDef.topPadding;
+  let bannerHeight = bannerCount * ShieldDef.bannerSizeH;
   height += bannerHeight;
 
   //Generate empty canvas sized to the graphic

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -6,7 +6,6 @@ import * as Gfx from "./screen_gfx.js";
 //Height of modifier banners
 export const bannerSizeH = 9 * Gfx.getPixelRatio();
 export const bannerPadding = 0.5 * Gfx.getPixelRatio();
-export const topPadding = 1 * Gfx.getPixelRatio();
 
 export const shields = {};
 

--- a/src/js/shield_text.js
+++ b/src/js/shield_text.js
@@ -251,8 +251,7 @@ export function drawBannerText(ctx, text, bannerIndex) {
     textLayout.xBaseline,
     textLayout.yBaseline +
       bannerIndex * ShieldDef.bannerSizeH -
-      ShieldDef.bannerPadding +
-      ShieldDef.topPadding
+      ShieldDef.bannerPadding
   );
 }
 
@@ -281,8 +280,7 @@ export function drawBannerHaloText(ctx, text, bannerIndex) {
     textLayout.xBaseline,
     textLayout.yBaseline +
       bannerIndex * ShieldDef.bannerSizeH -
-      ShieldDef.bannerPadding +
-      ShieldDef.topPadding
+      ShieldDef.bannerPadding
   );
   ctx.shadowColor = null;
   ctx.shadowBlur = null;


### PR DESCRIPTION
I was troubleshooting why our taginfo shield graphics were shifted to the south by one pixel. I discovered that, inexplicably, we had a 1 pixel top padding specified for no obvious reason.

![image](https://user-images.githubusercontent.com/3254090/220815794-aa63c8a1-0f30-415c-98ef-5817fd1ff846.png)

This PR removes that padding.
