### PR TITLE
Fix error resolving Kurdish country codes

### DIFF
--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -127,7 +127,7 @@ export function localizeLayers(layers, locales) {
         // Neither the upcase expression operator nor the text-transform layout property is locale-aware, so uppercase the name upfront.
         ?.toLocaleUpperCase(locales)
         // Word boundaries are less discernible in uppercase text, so pad each word by an additional space.
-        .replaceAll(" ", "  "),
+        .replaceAll(" ", "  ") ?? null,
     ])
   );
   Object.assign(countryNamesByCode, localizedCountryNamesByCode);


### PR DESCRIPTION
When the user preferred labels in Kurdish (`ku`), without any fallbacks, the code generating the boundary edge label layers threw an uncaught error, preventing from the map from showing up at all. This is because the ISO&nbsp;3166-1 alpha-3 to alpha-2 lookup table inserted an `undefined` value for any country code that the browser didn’t have a translation for in the preferred language. JSON has no representation of `undefined`, so GL JS barfed on the inclusion of this lookup table in the style. The layer generation code already tries to account for `null` by falling back to the country code in parentheses, so we just need to coalesce the translations with `null`.

/ref #753