### PR TITLE
Fix relative font path

### DIFF
--- a/src/js/style.js
+++ b/src/js/style.js
@@ -4,7 +4,7 @@ import * as Layers from "../layer/index.js";
 export function build(tileURL, spriteURL, locales) {
   return {
     name: "Americana",
-    glyphs: "/fonts/{fontstack}/{range}.pbf",
+    glyphs: "fonts/{fontstack}/{range}.pbf",
     layers: Layers.build(locales),
     sources: {
       openmaptiles: {


### PR DESCRIPTION
Fixes an error introduced in #801 which referenced the font stack from root rather than relative URL path.  Hope this works. It runs locally but no real way to test on the CI...