### PR TITLE
Make font path absolute

### DIFF
--- a/src/js/style.js
+++ b/src/js/style.js
@@ -4,7 +4,8 @@ import * as Layers from "../layer/index.js";
 export function build(tileURL, spriteURL, locales) {
   return {
     name: "Americana",
-    glyphs: "fonts/{fontstack}/{range}.pbf",
+    glyphs:
+      "https://zelonewolf.github.io/openstreetmap-americana/fonts/{fontstack}/{range}.pbf",
     layers: Layers.build(locales),
     sources: {
       openmaptiles: {


### PR DESCRIPTION
2nd attempt to fix the broken font link - just force a relative URL.

We can come up with a scheme to make this properly relative later, but the immediate priority is to have a working map.