### PR TITLE
Update transport POI color to mauve

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,5 +377,6 @@ For consistency, POI icons use the following color palette:
 | Consumer               | UTexas Orange   | <img src="doc-img/texas_orange.svg" height=18 width=50 /> Orange            | 191 87 0    | #bf5700     |
 | Outdoor                |                 | TBD (green?)                                                                |             |             |
 | Attraction             |                 | TBD (brown?)                                                                |             |             |
-| Transport              | Medium Purple C | <img src="doc-img/pantone_medium_purple_c.svg" height=18 width=50 /> Purple | 78 0 142    | #4e008e     |
+| Airport                | Medium Purple C | <img src="doc-img/pantone_medium_purple_c.svg" height=18 width=50 /> Purple | 78 0 142    | #4e008e     |
+| Transport              | Pantone 234 C   | <img src="doc-img/pantone_234_c.svg" height=18 width=50 /> Mauve            | 162 0 103   | #a20067     |
 | Knockout               |                 | <img src="doc-img/background.svg" height=18 width=50 /> Lt Grayish Orange   | 249 245 240 | #f9f5f0     |

--- a/doc-img/pantone_234_c.svg
+++ b/doc-img/pantone_234_c.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="1"
+   height="1"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="pantone_234_c.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="256"
+     inkscape:cx="0.49804688"
+     inkscape:cy="0.49804688"
+     inkscape:window-width="2256"
+     inkscape:window-height="1440"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <rect
+     width="1"
+     height="1"
+     rx="0"
+     ry="0"
+     fill="#6d2077"
+     style="paint-order:fill markers stroke;fill:#a20067;fill-opacity:1"
+     id="rect2" />
+</svg>

--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -34,6 +34,7 @@ export const palette = {
   blue: "#003f87", // Pantone 294
   brown: "#693f23", // Pantone 469
   green: "#006747", // Pantone 342
+  mauve: "#a20067", // Pantone 234 C
   orange: "#f38f00", // Pantone 152
   texas_orange: "#bf5700", // UTexas Orange
   pink: "#df4661", // Pantone 198
@@ -72,7 +73,7 @@ export const hue = {
   tollRoad: 48,
   park: 136,
   water: 211,
-  transport: 273,
+  airport: 273,
   borderCasing: 281,
 };
 
@@ -81,5 +82,6 @@ export const poi = {
   consumer: palette.texas_orange,
   //outdoor:
   //attraction:
-  transport: `hsl(${hue.transport}, 100%, 28%)`,
+  airport: `hsl(${hue.airport}, 100%, 28%)`,
+  transport: palette.mauve,
 };

--- a/src/layer/aeroway.js
+++ b/src/layer/aeroway.js
@@ -15,8 +15,8 @@ const iconLayout = {
     "match",
     ["get", "class"],
     "military",
-    "poi\nsprite=poi_military_plane\ncolor=" + Color.poi.transport,
-    "poi\nsprite=poi_plane\ncolor=" + Color.poi.transport,
+    "poi\nsprite=poi_military_plane\ncolor=" + Color.poi.airport,
+    "poi\nsprite=poi_plane\ncolor=" + Color.poi.airport,
   ],
   "text-anchor": "bottom",
   "text-variable-anchor": [


### PR DESCRIPTION
> >The intent was for aerialway magenta to be used for public transit features. Airports are not necessarily passenger facilities, but aerial lifts almost always are.
>
> @claysmalley do you think you could add the shade you used to the [Contributing Guidelines](https://github.com/ZeLonewolf/openstreetmap-americana/blob/main/CONTRIBUTING.md#color-scheme-1)? Maybe the purple should be in a new "Air" category, with magenta replacing it for "Transport"

_Originally posted by @wmisener in https://github.com/ZeLonewolf/openstreetmap-americana/issues/790#issuecomment-1476999639_
            