### PR TITLE
Update Holmes County shield

### DIFF
--- a/icons/shield_us_oh_hol.svg
+++ b/icons/shield_us_oh_hol.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="20" viewBox="0 0 7.937 5.292" xmlns="http://www.w3.org/2000/svg">
+ <path d="M 7.8052081,0.13229166 V 1.0583333 H 7.2760415 V 5.1593749 H 0.92604164 V 2.1166666 L 0.13229166,2.3812499 V 0.13229166 Z" style="fill:#006747;stroke:#fff;stroke-width:.264583;stroke-dasharray:none;stroke-opacity:1"/>
+</svg>

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2491,6 +2491,12 @@ export function loadShields() {
     "WYA",
     "COS:Jackson",
     "FAI:Greenfield",
+    "HOL:Berlin",
+    "HOL:Clark",
+    "HOL:Knox",
+    "HOL:Monroe", // No black border in reality, but a border is needed for contrast.
+    "HOL:Paint",
+    "HOL:Salt_Creek",
     "JEF:Knox",
     "LOG:Bokescreek",
     "LOG:Pleasant",

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2453,7 +2453,6 @@ export function loadShields() {
     "GAL",
     "HAS",
     "HOC",
-    "HOL",
     "KNO",
     "LAW",
     "LIC",
@@ -2535,6 +2534,16 @@ export function loadShields() {
       bottom: 7,
     },
   };
+  shields["US:OH:HOL"] = {
+    spriteBlank: ["shield_us_oh_hol"],
+    textColor: Color.shields.white,
+    padding: {
+      left: 4,
+      right: 3,
+      top: 2,
+      bottom: 2,
+    },
+  };
   shields["US:OH:SCI"] = {
     spriteBlank: ["shield_us_oh_sci_2", "shield_us_oh_sci_3"],
     textColor: Color.shields.black,
@@ -2572,12 +2581,6 @@ export function loadShields() {
     ["ASD", "TWP"],
     ["ATH", "Trimble"],
     ["FAI", "Violet"],
-    ["HOL", "Berlin"],
-    ["HOL", "Clark"],
-    ["HOL", "Knox"],
-    ["HOL", "Monroe"], // No black border in reality, but a border is needed for contrast.
-    ["HOL", "Paint"],
-    ["HOL", "Salt_Creek"],
     ["KNO", "Liberty"],
     ["KNO", "Milford"],
     ["LIC", "Jersey"],


### PR DESCRIPTION
Replaced the generic white shield in Holmes County, Ohio, with a shape of the county in green, simplified slightly:

[<img src="https://user-images.githubusercontent.com/1231218/227446825-f4d43e28-26e7-4016-8403-012cadafd2a6.png" width="400" alt="Berlin">](https://zelonewolf.github.io/openstreetmap-americana/#map=12/40.56352/-81.79596)

Fixes #810.