### PR TITLE
change Michigan State Trunkline Highway shield to variable-width

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1812,13 +1812,7 @@ export function loadShields() {
   };
 
   // Michigan
-  shields["US:MI"] = diamondShield(
-    Color.shields.white,
-    Color.shields.black,
-    Color.shields.black,
-    2,
-    24
-  );
+  shields["US:MI"] = diamondShield(Color.shields.white, Color.shields.black);
   ["CR", "Benzie", "Gogebic", "Kalkaska", "Montcalm", "Roscommon"].forEach(
     (county) =>
       (shields[`US:MI:${county}`] = pentagonUpShield(


### PR DESCRIPTION
This route network was originally assigned a fixed-width diamond, but 3-digit routes often have a wide diamond on guide signs:

[![Screenshot from 2023-03-24 14-41-21](https://user-images.githubusercontent.com/1732117/227612236-f195be05-9877-4bbd-a8a5-7fc774007c0c.png)](https://www.mapillary.com/app/?lat=41.769916125918&lng=-86.736845754794&z=17&pKey=1382573692123857&focus=photo&x=0.5414097848513808&y=0.48797943444094155&zoom=0)

Before/after:

[<img width=400 alt="Screenshot from 2023-03-24 14-48-40" src="https://user-images.githubusercontent.com/1732117/227613746-76327322-91b2-4cea-8f24-9aee168703ff.png" /> <img width=400 alt="Screenshot from 2023-03-24 14-45-42" src="https://user-images.githubusercontent.com/1732117/227613199-f476bde4-611f-4b79-9106-f1c7dd40dccc.png" />](http://localhost:1776/#map=12.1/42.2983/-85.57446)