### PR TITLE
add Noto Sans Cherokee to font stack

### DIFF
--- a/scripts/fonts.json
+++ b/scripts/fonts.json
@@ -8,6 +8,7 @@
     "Noto Sans Armenian": ["regular", "700"],
     "Noto Sans Bengali": ["regular", "700"],
     "Noto Sans Canadian Aboriginal": ["regular", "700"],
+    "Noto Sans Cherokee": ["regular", "700"],
     "Noto Sans Devanagari": ["regular", "700"],
     "Noto Sans Ethiopic": ["regular", "600"],
     "Noto Sans Georgian": ["regular", "700"],
@@ -60,6 +61,10 @@
       [5120, 5487],
       [6928, 6975],
       [71216, 71231]
+    ],
+    "cherokee": [
+      [5024, 5119],
+      [43888, 43967]
     ],
     "cyrillic": [
       [1024, 1327],
@@ -164,6 +169,10 @@
       {
         "file": "NotoSansCanadianAboriginal-regular",
         "ranges": ["canadian_aboriginal"]
+      },
+      {
+        "file": "NotoSansCherokee-regular",
+        "ranges": ["cherokee"]
       },
       {
         "file": "NotoSansDevanagari-regular",
@@ -272,6 +281,10 @@
         "ranges": ["canadian_aboriginal"]
       },
       {
+        "file": "NotoSansCherokee-700",
+        "ranges": ["cherokee"]
+      },
+      {
         "file": "NotoSansDevanagari-700",
         "ranges": ["devanagari"]
       },
@@ -378,6 +391,10 @@
         "ranges": ["canadian_aboriginal"]
       },
       {
+        "file": "NotoSansCherokee-regular",
+        "ranges": ["cherokee"]
+      },
+      {
         "file": "NotoSansDevanagari-regular",
         "ranges": ["devanagari"]
       },
@@ -482,6 +499,10 @@
       {
         "file": "NotoSansCanadianAboriginal-700",
         "ranges": ["canadian_aboriginal"]
+      },
+      {
+        "file": "NotoSansCherokee-700",
+        "ranges": ["cherokee"]
       },
       {
         "file": "NotoSansDevanagari-700",


### PR DESCRIPTION
Adds support for Cherokee script.

[![Screenshot from 2023-03-26 19-40-53](https://user-images.githubusercontent.com/1732117/227812232-89b32bbb-40a2-452c-a40b-ea1455654b3b.png)](http://localhost:1776/#map=11.82/35.4714/-83.30396&language=chr%2Cen)

Note: lowercase Cherokee is included here, though technical limitations prevent Unicode characters beyond `U+FFFF` from being rendered. However, lowercase Cherokee is a relatively recent invention that hasn't seen widespread adoption yet, and nearly all Cherokee labels on OSM remain in all caps.