### PR TITLE
add Swiss national route shields

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -147,6 +147,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .be,
 .bg,
 .by,
+.ch,
 .cz,
 .ee,
 .es,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3803,6 +3803,12 @@ export function loadShields() {
     Color.shields.white
   );
 
+  // Switzerland
+  shields["ch:national"] = roundedRectShield(
+    Color.shields.blue,
+    Color.shields.white
+  );
+
   // Czechia
   shields["CZ:national"] = roundedRectShield(
     Color.shields.red,


### PR DESCRIPTION
Related to #391. Some national routes have been tagged with `network=ch:national`, though motorways still have `network=motorway` which we are hesitant to implement without a country code.

[![Screenshot from 2023-04-08 16-01-15](https://user-images.githubusercontent.com/1732117/230740520-018c482e-428b-445c-b01e-2ac1818c806a.png)](http://localhost:1776/#map=12.23/46.49841/7.27952)