### PR TITLE
add bannered Michigan shields

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1862,6 +1862,8 @@ export function loadShields() {
 
   // Michigan
   shields["US:MI"] = diamondShield(Color.shields.white, Color.shields.black);
+  shields["US:MI:Business"] = banneredShield(shields["US:MI"], ["BUS"]);
+  shields["US:MI:Connector"] = banneredShield(shields["US:MI"], ["CONN"]);
   ["CR", "Benzie", "Gogebic", "Kalkaska", "Montcalm", "Roscommon"].forEach(
     (county) =>
       (shields[`US:MI:${county}`] = pentagonUpShield(


### PR DESCRIPTION
Adds support for Business and Connector Michigan State Trunkline Highways.

These were recently retagged (example [1](https://www.openstreetmap.org/relation/13588729), [2](https://www.openstreetmap.org/relation/2535244)); waiting on a tile update.