### PR TITLE
Flip school icon

### DIFF
--- a/icons/poi_school.svg
+++ b/icons/poi_school.svg
@@ -1,5 +1,5 @@
 <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
  <g style="display:inline;stroke:#000;stroke-opacity:0">
-  <path style="display:inline;fill:#000;fill-opacity:1;stroke:#fff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill" d="m 11,1 -6.999801,3 6,2 z M 5,9 V 19 H 15 V 9 Z m 5.000199,-3 0,3 H 11 V 1 Z" transform="matrix(-1 0 0 1 20 0)"/>
+  <path style="display:inline;fill:#000;fill-opacity:1;stroke:#fff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill" d="m 11,1 -7,3 6,2 z m -5.5,9 v 9 h 9 V 10 Z M 10,6 v 4 h 1 V 1 Z" transform="matrix(-1 0 0 1 20 0)"/>
  </g>
 </svg>

--- a/icons/poi_school.svg
+++ b/icons/poi_school.svg
@@ -1,5 +1,5 @@
 <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
  <g style="display:inline;stroke:#000;stroke-opacity:0">
-  <path style="display:inline;fill:#000;fill-opacity:1;stroke:#fff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill" d="M 11,1 3,4 9,6 Z M 5,9 V 19 H 15 V 9 Z M 9,6 v 3 h 2 V 1 Z"/>
+  <path style="display:inline;fill:#000;fill-opacity:1;stroke:#fff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill" d="m 11,1 -6.999801,3 6,2 z M 5,9 V 19 H 15 V 9 Z m 5.000199,-3 0,3 H 11 V 1 Z" transform="matrix(-1 0 0 1 20 0)"/>
  </g>
 </svg>


### PR DESCRIPTION
Following discussion in #807, this PR flips the flag in the school icon so that it blows left to right, matching the newly rendered city hall icon.

I also reduced width of flagpole to 1 px and slightly changed the flag dimensions.

<img width="341" alt="Screen Shot 2023-04-09 at 9 18 30 PM" src="https://user-images.githubusercontent.com/58491489/230825472-c9a57839-f757-43c3-be18-0b8c4b4666bb.png">
<img width="205" alt="Screen Shot 2023-04-09 at 9 19 09 PM" src="https://user-images.githubusercontent.com/58491489/230825477-e8d4c563-0a4f-4319-8685-ea054a4413dc.png">
