### PR TITLE
Add aerialway station icon

### DIFF
--- a/icons/poi_aerialway_circle.svg
+++ b/icons/poi_aerialway_circle.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+ <circle cx="10" cy="10" fill="#fff" stroke="#000" r="9.5"/>
+ <path style="fill:none;stroke:#000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M10.5 2.5c-.471404 0-1 .5285955-1 1v2c0 .4714045.528596 1 1 1M1.2 6.5 15.2 2"/>
+ <path style="color:#000;fill:#000;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none" d="M 5,7 A 0.50005,0.50005 0 0 0 4.5351562,7.3144531 c -1.0512252,2.6280631 -1.0512252,5.7430309 0,8.3710939 A 0.50005,0.50005 0 0 0 5,16 h 10 a 0.50005,0.50005 0 0 0 0.464844,-0.314453 c 1.051225,-2.628063 1.051225,-5.7430308 0,-8.3710939 A 0.50005,0.50005 0 0 0 15,7 h -5 z"/>
+ <path style="color:#000;fill:#fff;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none" d="M 5.40625 8 C 4.9512475 9.2608747 4.7569735 10.63881 4.8203125 12 L 15.179688 12 C 15.243026 10.63881 15.048752 9.2608747 14.59375 8 L 10 8 L 5.40625 8 z"/>
+</svg>

--- a/src/layer/poi.js
+++ b/src/layer/poi.js
@@ -2,6 +2,14 @@ import * as label from "../constants/label.js";
 import * as Color from "../constants/color.js";
 
 var iconDefs = {
+  aerialway_station: {
+    classes: {
+      aerialway: ["station"],
+    },
+    sprite: "poi_aerialway_circle",
+    color: Color.poi.transport,
+    description: "Aerial lift station",
+  },
   bar: {
     classes: {
       bar: ["bar"],


### PR DESCRIPTION
Is it an enclosed gondola? Is it a chair lift? No, it's a delightfully ambiguous aerial tramway car!

Note that drag lifts also get this icon, as OpenMapTiles only differentiates aerialway subclasses on lines, not stations.

[![Screenshot from 2023-04-10 11-02-55](https://user-images.githubusercontent.com/1732117/230928180-aed8ca42-21f5-4efd-b592-4dac6ffc7fb7.png)](http://localhost:1776/#map=14.23/39.48126/-106.05888)
[![Screenshot from 2023-04-10 11-06-05](https://user-images.githubusercontent.com/1732117/230928779-b1ceb3b7-2696-4af4-a684-55617e345ce1.png)](http://localhost:1776/#map=17.17/19.345307/-99.06362)
[![Screenshot from 2023-04-10 11-11-35](https://user-images.githubusercontent.com/1732117/230929850-2a11ebc5-18ea-43dc-a967-86dc64d035e3.png)](http://localhost:1776/#map=15.66/-16.490002/-68.141044)
[![Screenshot from 2023-04-10 11-12-59](https://user-images.githubusercontent.com/1732117/230930083-f03859a8-277f-4488-b4a9-35e8034448dd.png)](http://localhost:1776/#map=15.15/47.150657/10.582845)