### PR TITLE
Railway halts should be styled like stations

### DIFF
--- a/src/layer/poi.js
+++ b/src/layer/poi.js
@@ -62,7 +62,7 @@ var iconDefs = {
   },
   railway_station: {
     classes: {
-      railway: ["station", "subway"],
+      railway: ["station", "halt", "subway"],
     },
     sprite: "poi_rail_circle",
     color: Color.poi.transport,
@@ -70,11 +70,11 @@ var iconDefs = {
   },
   railway_stop: {
     classes: {
-      railway: ["halt", "tram_stop"],
+      railway: ["tram_stop"],
     },
     sprite: "poi_rail",
     color: Color.poi.transport,
-    description: "Tram stop or train halt",
+    description: "Tram stop",
   },
   school: {
     classes: {
@@ -163,13 +163,12 @@ export const poi = {
     [
       "match",
       ["get", "subclass"],
-      ["station"],
+      ["station", "halt"],
       12,
       ["bus_station", "subway"],
       14,
       [
         "bus_stop",
-        "halt",
         "hospital",
         "tram_stop",
         ...getSubclasses(iconDefs.school),


### PR DESCRIPTION
I overlooked this when reviewing #790, but `railway=halt` is a type of station, not a type of stop. In the US, the _de facto_ accepted practice is to use `railway=halt` for stations with flag-stop service. Other countries use different criteria to distinguish `railway=halt` from `railway=station`, but regardless, either can have one or many `railway=stop` (not rendered) associated with them.

Before/after:

[<img width=400 alt="Screenshot from 2023-04-10 15-31-44" src="https://user-images.githubusercontent.com/1732117/230981847-639b49a5-10cd-4e3e-a147-8d91c96dfe1d.png" /> <img width=400 alt="Screenshot from 2023-04-10 15-30-39" src="https://user-images.githubusercontent.com/1732117/230981670-19add7f8-cac1-4663-8132-2dbafd5b98ad.png" />](http://localhost:1776/#map=12.19/41.73421/-87.60683)

[<img width=400 alt="Screenshot from 2023-04-10 15-41-20" src="https://user-images.githubusercontent.com/1732117/230983617-fc2250bb-bf0d-4358-bc0c-c8891997e0db.png" /> <img width=400 alt="Screenshot from 2023-04-10 15-41-49" src="https://user-images.githubusercontent.com/1732117/230983620-ad11d98e-ab48-4278-95f0-bccb82b20034.png" />](http://localhost:1776/#map=15.2/41.740686/-87.600464)