### PR TITLE
Add museum icon and brown "attraction" POI color

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,7 +376,7 @@ For consistency, POI icons use the following color palette:
 | Infrastructure         | Pantone 294     | <img src="doc-img/pantone_294.svg" height=18 width=50 /> Blue               | 0 63 135    | #003f87     |
 | Consumer               | UTexas Orange   | <img src="doc-img/texas_orange.svg" height=18 width=50 /> Orange            | 191 87 0    | #bf5700     |
 | Outdoor                |                 | TBD (green?)                                                                |             |             |
-| Attraction             |                 | TBD (brown?)                                                                |             |             |
+| Attraction             | Pantone 469     | <img src="doc-img/pantone_469.svg" height=18 width=50 /> Brown              | 105 63 35   | #693f23     |
 | Airport                | Medium Purple C | <img src="doc-img/pantone_medium_purple_c.svg" height=18 width=50 /> Purple | 78 0 142    | #4e008e     |
 | Transport              | Pantone 234 C   | <img src="doc-img/pantone_234_c.svg" height=18 width=50 /> Mauve            | 162 0 103   | #a20067     |
 | Knockout               |                 | <img src="doc-img/background.svg" height=18 width=50 /> Lt Grayish Orange   | 249 245 240 | #f9f5f0     |

--- a/icons/poi_museum.svg
+++ b/icons/poi_museum.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+ <path style="stroke:#f9f5f0;stroke-width:2;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers" d="m 1,5 v 1 h 2 v 9 l -2,1 v 1 H 19 V 16 L 17,15 V 6 h 2 V 5 L 10,3 Z m 4,2 h 2 v 8 H 5 Z m 4,0 h 2 v 8 H 9 Z m 4,0 h 2 v 8 h -2 z"/>
+</svg>

--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -464,6 +464,15 @@
       "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/icons/poi_town_hall.svg"
     },
     {
+      "key": "tourism",
+      "value": "museum",
+      "object_types": ["node", "area"],
+      "description": "Museums are marked by an icon representing a Classical columned building.",
+      "doc_url": "https://openmaptiles.org/schema/#poi",
+      "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/icons/poi_museum.svg"
+    },
+
+    {
       "key": "amenity",
       "value": "clinic",
       "object_types": ["node", "area"],

--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -81,7 +81,7 @@ export const poi = {
   infrastructure: palette.blue,
   consumer: palette.texas_orange,
   //outdoor:
-  //attraction:
+  attraction: palette.brown,
   airport: `hsl(${hue.airport}, 100%, 28%)`,
   transport: palette.mauve,
 };

--- a/src/layer/poi.js
+++ b/src/layer/poi.js
@@ -52,6 +52,14 @@ var iconDefs = {
     color: Color.poi.infrastructure,
     description: "Doctor's office or clinic",
   },
+  museum: {
+    classes: {
+      museum: ["museum"],
+    },
+    sprite: "poi_museum",
+    color: Color.poi.attraction,
+    description: "Museum",
+  },
   parking: {
     classes: {
       parking: ["parking"],
@@ -152,6 +160,8 @@ export const poi = {
         ...getSubclasses(iconDefs.railway_stop),
       ],
       Color.poi.transport,
+      ["museum"],
+      Color.poi.attraction,
       ["hospital", "parking", "school", "townhall"],
       Color.poi.infrastructure,
       Color.poi.infrastructure,
@@ -171,9 +181,10 @@ export const poi = {
         "bus_stop",
         "halt",
         "hospital",
-        "tram_stop",
+        "museum",
         ...getSubclasses(iconDefs.school),
         "townhall",
+        "tram_stop",
       ],
       15,
       [...getSubclasses(iconDefs.bar), ...getSubclasses(iconDefs.coffee)],


### PR DESCRIPTION
Fixes #820, and makes progress on #692 (well, actually museums aren't explicitly listed in #692, but they probably should be). I've used a modified version of the columned, neoclassical building I originally proposed for town halls in #794, but without the flag:

![poi_museum](https://user-images.githubusercontent.com/58491489/231208510-afbf46cc-a11c-453d-b6af-78955661e5cb.svg)

This icon specifically evokes the large, established institutions of big cities, but I think the symbol is recognizable enough to represent museums of diverse sizes and settings.

This is the first POI in the "attraction" category, so the PR also adds and documents a new POI color, "attraction brown". Brown was suggested in #128, and it seems reasonable for attractions based on American usage, such as MUTCD signage. As @1ec5 pointed out on Slack, care may be needed when indigenous land boundaries are added (#105) to make sure the colors in the style clearly communicate their intended meaning. I've reused the brown color defined for highways, hex #693F23, but would be amenable to alterations if someone has a strong opinion.

Samples:
National Mall ([localhost](http://localhost:1776/#map=15.41/38.88993/-77.025717)):
<img width="1182" alt="Screen Shot 2023-04-11 at 8 25 55 AM" src="https://user-images.githubusercontent.com/58491489/231212171-bee5021e-8e90-429d-b910-106030aef081.png">

Woods Hole, MA ([localhost](http://localhost:1776/#map=16.75/41.523511/-70.667962)):
<img width="744" alt="Screen Shot 2023-04-11 at 8 28 57 AM" src="https://user-images.githubusercontent.com/58491489/231213019-816d6b8a-641d-45d6-9164-8d9b278c4453.png">

San Francisco, CA ([localhost](http://localhost:1776/#map=16.36/37.779986/-122.417826)):
<img width="683" alt="Screen Shot 2023-04-11 at 8 31 16 AM" src="https://user-images.githubusercontent.com/58491489/231213878-f0cfab96-a6bc-4a95-9a64-84fc0b3e53c5.png">

Chicago, IL ([localhost](http://localhost:1776/#map=15.11/41.864862/-87.615266)):
<img width="720" alt="Screen Shot 2023-04-11 at 8 42 40 AM" src="https://user-images.githubusercontent.com/58491489/231216609-334bd7ef-7548-4fd8-8c9a-ac6611ac1a46.png">
Note that the [Field Museum](https://www.openstreetmap.org/way/24825537) (`tourism=museum`) is rendered in this PR, but the [Shedd Aquarium](https://www.openstreetmap.org/way/24825568) (`tourism=aquarium` OMT class=aquarium, subclass=aquarium) and the [Adler Planetarium](https://www.openstreetmap.org/way/24825591) (`amenity=planetarium`, which doesn't appear to be in OMT, although I think this might be a tagging error) are not.