### PR TITLE
add missing combining characters and punctuation to font stack

### DIFF
--- a/scripts/fonts.json
+++ b/scripts/fonts.json
@@ -23,6 +23,7 @@
     "Noto Sans Myanmar": ["regular", "700"],
     "Noto Sans Oriya": ["regular", "700"],
     "Noto Sans Sinhala": ["regular", "700"],
+    "Noto Sans Symbols": ["regular", "700"],
     "Noto Sans Tamil": ["regular", "700"],
     "Noto Sans Thaana": ["regular", "700"],
     "Noto Serif Tibetan": ["regular", "700"],
@@ -127,7 +128,7 @@
       [33, 879],
       [7424, 7615],
       [7680, 7935],
-      [8192, 8703],
+      [8192, 8591],
       [11360, 11391],
       [42784, 43007],
       [43824, 43887],
@@ -140,6 +141,7 @@
     "oriya": [[2816, 2943]],
     "sinhala": [[3456, 3583]],
     "space": [[32, 32]],
+    "symbols": [[8592, 8703]],
     "tamil": [[2944, 3071]],
     "telugu": [[3072, 3199]],
     "thaana": [[1920, 1983]],
@@ -228,6 +230,10 @@
       {
         "file": "NotoSansSinhala-regular",
         "ranges": ["sinhala"]
+      },
+      {
+        "file": "NotoSansSymbols-regular",
+        "ranges": ["symbols"]
       },
       {
         "file": "NotoSansTamil-regular",
@@ -340,6 +346,10 @@
         "ranges": ["sinhala"]
       },
       {
+        "file": "NotoSansSymbols-700",
+        "ranges": ["symbols"]
+      },
+      {
         "file": "NotoSansTamil-700",
         "ranges": ["tamil"]
       },
@@ -450,6 +460,10 @@
         "ranges": ["sinhala"]
       },
       {
+        "file": "NotoSansSymbols-regular",
+        "ranges": ["symbols"]
+      },
+      {
         "file": "NotoSansTamil-regular",
         "ranges": ["tamil"]
       },
@@ -558,6 +572,10 @@
       {
         "file": "NotoSansSinhala-700",
         "ranges": ["sinhala"]
+      },
+      {
+        "file": "NotoSansSymbols-700",
+        "ranges": ["symbols"]
       },
       {
         "file": "NotoSansTamil-700",

--- a/scripts/fonts.json
+++ b/scripts/fonts.json
@@ -50,7 +50,10 @@
       [126208, 126287],
       [126464, 126719]
     ],
-    "armenian": [[1328, 1423]],
+    "armenian": [
+      [1328, 1423],
+      [64272, 64279]
+    ],
     "bengali": [[2432, 2559]],
     "bopomofo": [
       [12544, 12591],
@@ -80,6 +83,7 @@
       [11648, 11743],
       [43776, 43823]
     ],
+    "fullwidth": [[65280, 65519]],
     "greek": [
       [880, 1023],
       [7936, 8191],
@@ -108,7 +112,7 @@
     ],
     "hebrew": [
       [1424, 1535],
-      [64285, 64331]
+      [64280, 64335]
     ],
     "hiragana": [[12352, 12447]],
     "kanbun": [[12688, 12703]],
@@ -120,15 +124,14 @@
     ],
     "khmer": [[6016, 6911]],
     "latin": [
-      [33, 767],
+      [33, 879],
       [7424, 7615],
       [7680, 7935],
-      [8304, 8591],
+      [8192, 8703],
       [11360, 11391],
       [42784, 43007],
       [43824, 43887],
-      [64256, 64335],
-      [65280, 65519],
+      [64256, 64271],
       [67456, 67519],
       [122624, 122879]
     ],
@@ -152,7 +155,7 @@
       },
       {
         "file": "MPlusRounded1C-regular",
-        "ranges": ["hiragana", "kanbun", "katakana"]
+        "ranges": ["fullwidth", "hiragana", "kanbun", "katakana"]
       },
       {
         "file": "NotoSansArabic-regular",
@@ -262,7 +265,7 @@
       },
       {
         "file": "MPlusRounded1C-700",
-        "ranges": ["hiragana", "kanbun", "katakana"]
+        "ranges": ["fullwidth", "hiragana", "kanbun", "katakana"]
       },
       {
         "file": "NotoSansArabic-700",
@@ -372,7 +375,7 @@
       },
       {
         "file": "MPlusRounded1C-regular",
-        "ranges": ["hiragana", "kanbun", "katakana"]
+        "ranges": ["fullwidth", "hiragana", "kanbun", "katakana"]
       },
       {
         "file": "NotoSansArabic-regular",
@@ -482,7 +485,7 @@
       },
       {
         "file": "MPlusRounded1C-700",
-        "ranges": ["hiragana", "kanbun", "katakana"]
+        "ranges": ["fullwidth", "hiragana", "kanbun", "katakana"]
       },
       {
         "file": "NotoSansArabic-700",


### PR DESCRIPTION
Fixes #850 

[![Screenshot from 2023-04-11 20-32-01](https://user-images.githubusercontent.com/1732117/231317177-f93dcd31-406b-41ac-8094-6fc1f2661a74.png)](http://localhost:1776/#map=15.06/39.2577/-84.27606)

[![Screenshot from 2023-04-11 20-32-36](https://user-images.githubusercontent.com/1732117/231317234-8b12b472-dfda-4ef2-ac36-7ce556ddc9b1.png)](http://localhost:1776/#map=17/39.267085/-84.259346)

[![Screenshot from 2023-04-11 20-33-05](https://user-images.githubusercontent.com/1732117/231317304-3b64c4dd-7510-4804-99ec-42541503d0f0.png)](http://localhost:1776/#map=19/51.02108/6.9075)

[![Screenshot from 2023-04-11 20-28-24](https://user-images.githubusercontent.com/1732117/231316779-fc8e28c9-6425-4a3b-8bde-499fadf8391a.png)](http://localhost:1776/#map=13.86/41.43675/-85.72496)

[![Screenshot from 2023-04-11 20-29-18](https://user-images.githubusercontent.com/1732117/231316877-174fb2bd-b2c6-4eed-8664-5c098b93b450.png)](http://localhost:1776/#map=14.85/49.02422/-123.10267)

[![Screenshot from 2023-04-11 20-56-14](https://user-images.githubusercontent.com/1732117/231319886-0cb25357-4ed2-4219-bb80-83fda649f61c.png)](http://localhost:1776/#map=15.34/-16.497549/-68.162391)