### PR TITLE
Use "NSP" as the ref for Niagara Scenic Parkway.

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -4285,6 +4285,7 @@ export function loadShields() {
     "Hutchinson River Parkway": "HRP",
     "Korean War Veterans Parkway": "KWVP",
     "Mosholu Parkway": "MP",
+    "Niagara Scenic Parkway": "NSP",
     "Pelham Parkway": "PP",
     "Saw Mill River Parkway": "SMP",
     "Sprain Brook Parkway": "SBP",


### PR DESCRIPTION
Currently, the road is tagged as being part of the `US:NY:Parkway` network, due to the similarity between its shield and other green parkway shields. While there still are differences, including the first letter of each word not being emphasized, the shield should still probably be rendered the same way as others in the network.

Should the road be retagged under its own network, this should be changed.

![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/3254090/b51433d8-2183-48b3-9b7f-62604470070e)
