### PR TITLE
Switch tile server domain

### DIFF
--- a/src/configs/config.aws.js
+++ b/src/configs/config.aws.js
@@ -4,7 +4,7 @@
 Planetiler tile server, hosted at AWS
 */
 const OPENMAPTILES_URL =
-  "https://6ug7hetxl9.execute-api.us-east-2.amazonaws.com/data/v3.json";
+  "https://tile.ourmap.us/data/v3.json";
 
 /*
 The following two variables override the color of the bounding box and halo of

--- a/src/configs/config.aws.js
+++ b/src/configs/config.aws.js
@@ -3,8 +3,7 @@
 /*
 Planetiler tile server, hosted at AWS
 */
-const OPENMAPTILES_URL =
-  "https://tile.ourmap.us/data/v3.json";
+const OPENMAPTILES_URL = "https://tile.ourmap.us/data/v3.json";
 
 /*
 The following two variables override the color of the bounding box and halo of


### PR DESCRIPTION
To reduce hosting costs, this PR switches the Americana tile server to https://tile.ourmap.us/

This is the same tile server. I've just installed an SSL certificate on it and pointed the ourmap.us domain there. This allows me to stop using the AWS "API Gateway" service.
