### PR TITLE
Fix failing github pages and view PR previews

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,7 +30,7 @@ jobs:
           npm run style
           cp src/configs/config.aws.js src/config.js
       - name: Deploy via FTP
-        uses: genietim/ftp-action@releases/v4
+        uses: genietim/ftp-action@v4
         with:
           host: ${{ secrets.FTP_SERVER }}
           user: ${{ secrets.FTP_USERNAME }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -48,6 +48,7 @@ jobs:
             * [Map](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/)
             * [Shield Test](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/shieldtest.html)
             * [style.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/style.json)
+            * [shields.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/shields.json)
             * [taginfo.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/taginfo.json)
 
             Sprite Sheets:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -50,8 +50,8 @@ jobs:
             PR Preview:
             * [Map](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/)
             * [Shield Test](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/shieldtest.html)
-            * [Sprites 1x](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite.png)
-            * [Sprites 2x](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite@2x.png)
             * [style.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/style.json)
             * [taginfo.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/taginfo.json)
+            * ![Sprites 1x][https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite.png]
+            * ![Sprites 2x][https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite@2x.png]
           comment_tag: pr_preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -2,17 +2,19 @@ name: Deploy PR Preview
 on:
   pull_request:
     branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 permissions:
   contents: read
   pages: write
   pull-requests: write
 concurrency: preview-${{ github.ref }}
 jobs:
-  build-and-deploy:
+  deploy-preview:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
@@ -29,4 +31,4 @@ jobs:
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: dist
+          source-dir: ./dist/

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -28,13 +28,6 @@ jobs:
           npm run build
           npm run style
           cp src/configs/config.aws.js src/config.js
-      - name: Remove prior FTP preview
-        uses: StephanThierry/ftp-delete-action@v2.1
-        with:
-          host: ${{ secrets.FTP_SERVER }}
-          user: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          remoteDirectories: pr/${{ github.event.pull_request.number }}/
       - name: Deploy via FTP
         uses: SamKirkland/FTP-Deploy-Action@v4.3.4
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -36,4 +36,4 @@ jobs:
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
           local-dir: dist/
-          server-dir: pr/${{ steps.pr.outputs.pull_request_number }}/
+          server-dir: pr/${{ github.event.pull_request.number }}/

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,10 +1,7 @@
-# Taken from https://github.com/marketplace/actions/deploy-to-github-pages
-
-name: Build and Deploy
+name: Deploy PR Preview
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    branches: [main]
 permissions:
   contents: read
   pages: write
@@ -29,10 +26,7 @@ jobs:
           cp src/configs/config.aws.js src/config.js
           npm run build
           npm run style
-      - name: Upload 🏗
-        uses: actions/upload-pages-artifact@v1
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
         with:
-          path: ./dist
-      - name: Deploy 🚀
-        id: deployment
-        uses: actions/deploy-pages@v1
+          source-dir: ./dist

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -43,6 +43,7 @@ jobs:
           password: ${{ secrets.FTP_PASSWORD }}
           local-dir: dist/
           server-dir: pr/${{ github.event.pull_request.number }}/
+          dangerous-clean-slate: true
       - name: Comment Pull Request
         uses: thollander/actions-comment-pull-request@v2.3.1
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -28,15 +28,17 @@ jobs:
           npm run build
           npm run style
           cp src/configs/config.aws.js src/config.js
-      - name: Deploy via FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+      - name: Deploy via S3
+        uses: jakejarvis/s3-sync-action@master
         with:
-          server: ${{ secrets.FTP_SERVER }}
-          username: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          local-dir: dist/
-          server-dir: pr/${{ github.event.pull_request.number }}/
-          dangerous-clean-slate: true
+          args: --acl public-read --follow-symlinks --delete --exclude '.git/*' --exclude '.github/*'
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          SOURCE_DIR: "./dist"
+          DEST_DIR: pr/${{ github.event.pull_request.number }}/
       - name: Comment Pull Request
         uses: thollander/actions-comment-pull-request@v2.3.1
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,7 +6,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - closed
 permissions:
   contents: read
   pages: write
@@ -29,6 +28,13 @@ jobs:
           npm run build
           npm run style
           cp src/configs/config.aws.js src/config.js
+      - name: ftp-delete-action
+        uses: StephanThierry/ftp-delete-action@v2.1
+        with:
+          host: ${{ secrets.FTP_SERVER }}
+          user: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          remoteDirectories: pr/${{ github.event.pull_request.number }}/
       - name: Deploy via FTP
         uses: SamKirkland/FTP-Deploy-Action@v4.3.4
         with:
@@ -42,10 +48,10 @@ jobs:
         with:
           message: |
             PR Preview:
-            * [Map](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/)
-            * [Shield Test](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/shieldtest.html)
-            * [Sprites 1x](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite.png)
-            * [Sprites 2x](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite@2x.png)
-            * [style.json](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/style.json)
-            * [taginfo.json](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/taginfo.json)
+            * [Map](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/)
+            * [Shield Test](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/shieldtest.html)
+            * [Sprites 1x](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite.png)
+            * [Sprites 2x](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite@2x.png)
+            * [style.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/style.json)
+            * [taginfo.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/taginfo.json)
           comment_tag: pr_preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -37,3 +37,15 @@ jobs:
           password: ${{ secrets.FTP_PASSWORD }}
           local-dir: dist/
           server-dir: pr/${{ github.event.pull_request.number }}/
+      - name: Comment Pull Request
+        uses: thollander/actions-comment-pull-request@v2.3.1
+        with:
+          message: |
+            PR Preview:
+            * [Map](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/)
+            * [Shield Test](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/shieldtest.html)
+            * [Sprites 1x](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite.png)
+            * [Sprites 2x](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite@2x.png)
+            * [style.json](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/style.json)
+            * [taginfo.json](https://tile.ourmap.us/pr/${{ github.event.pull_request.number }}/taginfo.json)
+          comment_tag: pr_preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -5,7 +5,7 @@ on:
 permissions:
   contents: read
   pages: write
-  id-token: write
+  pull-requests: write
 concurrency: preview-${{ github.ref }}
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,10 +30,10 @@ jobs:
           npm run style
           cp src/configs/config.aws.js src/config.js
       - name: Deploy via FTP
-        uses: GenieTim/ftp-action@v4.0.1
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
         with:
-          host: ${{ secrets.FTP_SERVER }}
-          user: ${{ secrets.FTP_USERNAME }}
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
-          localDir: dist/
-          remoteDir: pr/${{ steps.pr.outputs.pull_request_number }}/
+          local-dir: dist/
+          server-dir: pr/${{ steps.pr.outputs.pull_request_number }}/

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,6 +11,7 @@ permissions:
   contents: read
   pages: write
   pull-requests: write
+  id-token: write
 concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:
@@ -28,7 +29,11 @@ jobs:
           npm run build
           npm run style
           cp src/configs/config.aws.js src/config.js
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+      - name: Deploy via FTP
+        uses: genietim/ftp-action@releases/v4
         with:
-          source-dir: ./dist/
+          host: ${{ secrets.FTP_SERVER }}
+          user: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          localDir: dist/
+          remoteDir: pr/${{ steps.pr.outputs.pull_request_number }}/

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -38,7 +38,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           SOURCE_DIR: "./dist"
-          DEST_DIR: pr/${{ github.event.pull_request.number }}/
+          DEST_DIR: pr/${{ github.event.pull_request.number }}
       - name: Comment Pull Request
         uses: thollander/actions-comment-pull-request@v2.3.1
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -28,7 +28,7 @@ jobs:
           npm run build
           npm run style
           cp src/configs/config.aws.js src/config.js
-      - name: ftp-delete-action
+      - name: Remove prior FTP preview
         uses: StephanThierry/ftp-delete-action@v2.1
         with:
           host: ${{ secrets.FTP_SERVER }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -53,6 +53,7 @@ jobs:
             * [Shield Test](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/shieldtest.html)
             * [style.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/style.json)
             * [taginfo.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/taginfo.json)
-            * ![Sprites 1x][https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite.png]
-            * ![Sprites 2x][https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite@2x.png]
+            Sprite Sheets:
+            ![Sprites 1x](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite.png)
+            ![Sprites 2x](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite@2x.png)
           comment_tag: pr_preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -27,6 +27,7 @@ jobs:
           npm ci --include=dev
           npm run build
           npm run style
+          npm run shields
           cp src/configs/config.aws.js src/config.js
       - name: Deploy via S3
         uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,7 +30,7 @@ jobs:
           npm run style
           cp src/configs/config.aws.js src/config.js
       - name: Deploy via FTP
-        uses: genietim/ftp-action@v4
+        uses: GenieTim/ftp-action@v4.0.1
         with:
           host: ${{ secrets.FTP_SERVER }}
           user: ${{ secrets.FTP_USERNAME }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Install and Build 🔧
         run: |
           npm ci --include=dev
-          cp src/configs/config.aws.js src/config.js
           npm run build
           npm run style
+          cp src/configs/config.aws.js src/config.js
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: ./dist
+          source-dir: dist

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -53,7 +53,9 @@ jobs:
             * [Shield Test](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/shieldtest.html)
             * [style.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/style.json)
             * [taginfo.json](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/taginfo.json)
+
             Sprite Sheets:
+
             ![Sprites 1x](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite.png)
             ![Sprites 2x](https://preview.ourmap.us/pr/${{ github.event.pull_request.number }}/sprites/sprite@2x.png)
           comment_tag: pr_preview

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           cp src/configs/config.aws.js src/config.js
           npm run build
           npm run style
+          npm run shields
       - name: Upload 🏗
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   pages: write
+  id-token: write  
 concurrency: preview-${{ github.ref }}
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,16 +11,7 @@ permissions:
   id-token: write
 concurrency: preview-${{ github.ref }}
 jobs:
-  cleanup-preview:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove prior FTP preview
-        uses: StephanThierry/ftp-delete-action@v2.1
-        with:
-          host: ${{ secrets.FTP_SERVER }}
-          user: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          remoteDirectories: pr/${{ github.event.pull_request.number }}/
+  # TODO remove old PRs from s3 bucket automatically
   build-and-deploy:
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   pages: write
-  id-token: write  
+  id-token: write
 concurrency: preview-${{ github.ref }}
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
     steps:
-      - name: ftp-delete-action
+      - name: Remove prior FTP preview
         uses: StephanThierry/ftp-delete-action@v2.1
         with:
           host: ${{ secrets.FTP_SERVER }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: read
   pages: write
-  id-token: write
 concurrency: preview-${{ github.ref }}
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,16 @@ permissions:
   id-token: write
 concurrency: preview-${{ github.ref }}
 jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ftp-delete-action
+        uses: StephanThierry/ftp-delete-action@v2.1
+        with:
+          host: ${{ secrets.FTP_SERVER }}
+          user: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          remoteDirectories: pr/${{ github.event.pull_request.number }}/
   build-and-deploy:
     runs-on: ubuntu-latest
     environment:

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -75,6 +75,10 @@ const buildWith = async (
   ]);
 };
 
+export const buildContext = (
+  buildOptions: BuildOptions = {}
+): Promise<BuildContext[]> => buildWith("context", buildOptions);
+
 export const build = (
   buildOptions: BuildOptions = {}
 ): Promise<BuildContext[]> => buildWith("build", buildOptions);

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -75,20 +75,8 @@ const buildWith = async (
   ]);
 };
 
-export const buildContext = (
-  buildOptions: BuildOptions = {}
-): Promise<BuildContext[]> => buildWith("context", buildOptions);
-
 export const build = (
   buildOptions: BuildOptions = {}
 ): Promise<BuildContext[]> => buildWith("build", buildOptions);
 
-const mainModule = pathToFileURL(process.argv[1]).toString();
-const isMain = import.meta.url === mainModule;
-
-if (isMain) {
-  await build({
-    // defaults to undefined, but force it to get optimized out
-    define: { "window.LIVE_RELOAD": "false" },
-  });
-}
+await build();

--- a/scripts/fonts.json
+++ b/scripts/fonts.json
@@ -31,13 +31,7 @@
     "Noto Sans Telugu": ["regular", "700"],
     "Noto Sans Thai": ["regular", "700"]
   },
-  "bundle-font-stacks": {
-    "Noto Sans HK": ["regular", "700"],
-    "Noto Sans JP": ["regular", "700"],
-    "Noto Sans KR": ["regular", "700"],
-    "Noto Sans SC": ["regular", "700"],
-    "Noto Sans TC": ["regular", "700"]
-  },
+  "bundle-font-stacks": {},
   "glyph-ranges": {
     "arabic": [
       [1536, 1791],

--- a/scripts/status_map.js
+++ b/scripts/status_map.js
@@ -24,7 +24,7 @@ let worldSVG = fs.readFileSync(`${process.cwd()}/scripts/blank_map_world.svg`, {
 });
 worldSVG = fillPaths(
   worldSVG,
-  Object.keys(shields)
+  Object.keys(shields.networks)
     .map((network) => network.match(/^(\w\w)(?::|$)|^omt-(\w\w)-/))
     .filter((m) => m)
     .map((m) => m[1] || m[2])

--- a/shieldlib/src/shield_renderer.ts
+++ b/shieldlib/src/shield_renderer.ts
@@ -61,6 +61,7 @@ class AbstractShieldRenderer {
   private _networkPredicate: StringPredicate = () => true;
   private _routeParser: RouteParser;
   private _renderContext: ShieldRenderingContext;
+  private _shieldDefCallbacks = [];
 
   constructor(routeParser: RouteParser) {
     this._routeParser = routeParser;
@@ -71,6 +72,13 @@ class AbstractShieldRenderer {
   protected setShields(shieldSpec: ShieldSpecification) {
     this._renderContext.options = shieldSpec.options;
     this._renderContext.shieldDef = shieldSpec.networks;
+    this._shieldDefCallbacks.forEach((callback) =>
+      callback(shieldSpec.networks)
+    );
+  }
+
+  public getShieldDefinitions(): ShieldDefinitions {
+    return this._renderContext.shieldDef;
   }
 
   public debugOptions(debugOptions: DebugOptions): AbstractShieldRenderer {
@@ -100,6 +108,17 @@ class AbstractShieldRenderer {
   public renderOnMaplibreGL(map: Map): AbstractShieldRenderer {
     this.renderOnRepository(new MaplibreGLSpriteRepository(map));
     map.on("styleimagemissing", this.getStyleImageMissingHandler());
+    return this;
+  }
+
+  public onShieldDefLoad(
+    callback: (shields: ShieldDefinitions) => void
+  ): AbstractShieldRenderer {
+    if (this._renderContext.shieldDef) {
+      callback(this._renderContext.shieldDef);
+    } else {
+      this._shieldDefCallbacks.push(callback);
+    }
     return this;
   }
 

--- a/src/americana.js
+++ b/src/americana.js
@@ -83,7 +83,6 @@ const shieldRenderer = new URLShieldRenderer("shields.json", routeParser)
   .onShieldDefLoad((shields) => shieldDefLoad(shields));
 
 function shieldDefLoad(shields) {
-
   legendControl = new LegendControl(shields);
   legendControl.sections = LegendConfig.sections;
   map.addControl(legendControl, "bottom-left");

--- a/src/americana.js
+++ b/src/americana.js
@@ -26,7 +26,9 @@ import {
 
 export function buildStyle() {
   var getUrl = window.location;
-  var baseUrl = getUrl.protocol + "//" + getUrl.host + getUrl.pathname;
+  var baseUrl = (getUrl.protocol + "//" + getUrl.host + getUrl.pathname)
+    //Trim trailing slashes from URL
+    .replace(/\/+$/, "");
   return Style.build(
     config.OPENMAPTILES_URL,
     `${baseUrl}/sprites/sprite`,

--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -2,7 +2,6 @@
 
 import { getDOMPixelRatio } from "@americana/maplibre-shield-generator";
 import * as Label from "../constants/label.js";
-import * as ShieldDef from "./shield_defs.js";
 
 import * as HighwayShieldLayers from "../layer/highway_shield.js";
 
@@ -20,6 +19,10 @@ function toSentenceCase(lowerCase, locale) {
 }
 
 export default class LegendControl {
+  constructor(shieldDefs) {
+    this._shieldDefs = shieldDefs;
+  }
+
   onAdd(map) {
     this._map = map;
 
@@ -467,7 +470,7 @@ export default class LegendControl {
       }
       let networkImages = imagesByNetwork[image.network];
 
-      let shieldDef = ShieldDef.shields[image.network];
+      let shieldDef = this._shieldDefs[image.network];
       if (image.ref && shieldDef?.overrideByRef?.[image.ref]) {
         // Store a different image for each override in the shield definition.
         if (!networkImages.overridesByRef[image.ref]) {
@@ -505,7 +508,7 @@ export default class LegendControl {
     // order as in the shield definitions, appending all the unrecognized
     // networks sorted in alphabetical order.
     let networks = [
-      ...Object.keys(ShieldDef.shields),
+      ...Object.keys(this._shieldDefs),
       ...[...unrecognizedNetworks.values()].sort(),
     ];
     let countries = new Set();


### PR DESCRIPTION
Fixes #871 

![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/3254090/4e7a226a-5a02-486e-a5b5-410a0ea1697c)

This fixes the github build scripts after the shield library PR, and enables a preview of a PR before deploying it.

This works by uploading the built deployment and transferring it via FTP to the tile server. It will post a comment with the preview links. I also removed (at least for now) the Chinese font stacks as it was taking way too long to run the build and upload. We can revisit that when we actually implement Han unification.

This also fixes the fact that legends were broken by #699, which is blocking other PRs :grimacing: 

This doesn't address other suggestions, such as using `tsc` to pre-compile typescript for better performance.