### PR TITLE
Aerialway station in taginfo

### DIFF
--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -529,6 +529,14 @@
       "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/icons/poi_rail.svg"
     },
     {
+      "key": "aerialway",
+      "value": "station",
+      "object_types": ["node", "area"],
+      "description": "Aerialway stations are marked by an icon depicting an aerial tramway car.",
+      "doc_url": "https://openmaptiles.org/schema/#poi",
+      "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/icons/poi_aerialway_circle.svg"
+    },
+    {
       "key": "railway",
       "value": "tram_stop",
       "object_types": ["node"],


### PR DESCRIPTION
Adds `aerialway=station` as a supported tagging to the project taginfo file. This was omitted in #855, which originally added rendering aerialway stations.