### PR TITLE
Desuperlatize the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,18 @@ _A quintessentially American map style_ [🗺 View the map](https://zelonewolf.g
 
 The purpose of the Americana style is to:
 
-- Promote collaboration and common purpose in the American mapping community
+- Promote collaboration and common purpose in OpenStreetMap’s American mapping community
 - Express the American experience through cartography, taking inspiration from the familiar features of North American paper maps
 - Challenge the status quo by showcasing innovation and invention
 
-The Americana style is the first digital map to achieve concurrent, state-specific highway shields arranged along the path of road. Representative highway shield rendering is of considerable cartographic importance to the American community. We do this proudly in an open source project using vector tile technology.
+Americana has pioneered several cartographic techniques of importance to Americans that we hope will someday become commonplace among OpenStreetMap-based map styles:
+
+- Nuanced line styles help you distinguish roads, raiload tracks, and waterways based on a variety of intuitive characteristics.
+- Highway routes are identified by shields that resemble the signs on the road, with special support for roads that carry multiple routes concurrently.
+- Place labels throughout the world appear in both your preferred language and the local language, reflecting linguistic diversity both in the U.S. and abroad.
+- A dynamic legend communicates these design choices intuitively, regardless of the visual language you’re accustomed to.
+
+We do this proudly in an open source project using vector tile technology.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The purpose of the Americana style is to:
 - Express the American experience through cartography, taking inspiration from the familiar features of North American paper maps
 - Challenge the status quo by showcasing innovation and invention
 
-Americana has pioneered several cartographic techniques of importance to Americans that we hope will someday become commonplace among OpenStreetMap-based map styles:
+Americana has demonstrated or pioneered several cartographic techniques of importance to Americans that we hope will someday become commonplace among OpenStreetMap-based map styles:
 
 - Nuanced line styles help you distinguish roads, raiload tracks, and waterways based on a variety of intuitive characteristics.
 - Highway routes are identified by shields that resemble the signs on the road, with special support for roads that carry multiple routes concurrently.


### PR DESCRIPTION
The readme’s [overly narrow superlative](https://tvtropes.org/pmwiki/pmwiki.php/Main/OverlyNarrowSuperlative) makes it sound like we’re scraping the bottom of the barrel for reasons to be notable enough for a Wikipedia article. This obscures the project’s actual accomplishments. I’ve probably left off a few. We may not be the first by some measures, but we’re proving that it can be done and it can even look good.

Much thanks to @pnorman for [pointing out](https://osmus.slack.com/archives/C01V02K52UX/p1688869438078429) this delicately worded claim to fame and @jleedev for giving me a word for one of my pet peeves.