### PR TITLE
Make code compatible with ES2019

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,5 +1,4 @@
 import { stat, copyFile, mkdir } from "node:fs/promises";
-import { pathToFileURL } from "node:url";
 
 import esbuild, { BuildContext, BuildOptions } from "esbuild";
 
@@ -83,4 +82,10 @@ export const build = (
   buildOptions: BuildOptions = {}
 ): Promise<BuildContext[]> => buildWith("build", buildOptions);
 
-await build();
+(async function () {
+  try {
+    await build();
+  } catch (error) {
+    console.error(error);
+  }
+})();

--- a/scripts/generate_style.js
+++ b/scripts/generate_style.js
@@ -4,7 +4,7 @@ import { Command } from "commander";
 import { validate } from "@maplibre/maplibre-gl-style-spec";
 
 import * as Style from "../src/js/style.js";
-import config from "../src/config.js";
+import { getConfig } from "../src/config.js";
 
 /**
  * Requires mapbox-gl-rtl-text:
@@ -19,21 +19,25 @@ program.parse(process.argv);
 
 let opts = program.opts();
 
-let style = Style.build(
-  config.OPENMAPTILES_URL,
-  "https://zelonewolf.github.io/openstreetmap-americana/sprites/sprite",
-  "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
-  opts.locales
-);
+getConfig()
+  .then((config) => {
+    let style = Style.build(
+      config.OPENMAPTILES_URL,
+      "https://zelonewolf.github.io/openstreetmap-americana/sprites/sprite",
+      "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
+      opts.locales
+    );
 
-const errors = validate(style);
-if (errors.length) {
-  console.error(errors.map((e) => e.message).join("\n"));
-  process.exit(1);
-}
+    const errors = validate(style);
+    if (errors.length) {
+      console.error(errors.map((e) => e.message).join("\n"));
+      process.exit(1);
+    }
 
-if (opts.outfile == "-") {
-  console.log("%j", style);
-} else {
-  fs.writeFileSync(opts.outfile, JSON.stringify(style));
-}
+    if (opts.outfile == "-") {
+      console.log("%j", style);
+    } else {
+      fs.writeFileSync(opts.outfile, JSON.stringify(style));
+    }
+  })
+  .catch((error) => console.error(error));

--- a/scripts/serve.ts
+++ b/scripts/serve.ts
@@ -5,12 +5,16 @@ import { buildContext } from "./build";
 
 const port = 1776;
 
-const [mainContext, shieldLibContext]: BuildContext[] = await buildContext({
-  define: { "window.LIVE_RELOAD": "true" },
-});
+async function startServer() {
+  const [mainContext, shieldLibContext]: BuildContext[] = await buildContext({
+    define: { "window.LIVE_RELOAD": "true" },
+  });
 
-await mainContext.watch();
-await shieldLibContext.watch();
-await mainContext.serve({ servedir: "dist", host: "::", port });
+  await mainContext.watch();
+  await shieldLibContext.watch();
+  await mainContext.serve({ servedir: "dist", host: "::", port });
 
-open(`http://localhost:${port}/`);
+  open(`http://localhost:${port}/`);
+}
+
+startServer();

--- a/src/config.js
+++ b/src/config.js
@@ -10,5 +10,11 @@ const importConfig = () => {
   }
 };
 
-const { default: config } = await importConfig();
-export { config as default };
+export async function getConfig() {
+  try {
+    const module = await importConfig();
+    return module.default;
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/src/shieldtest.js
+++ b/src/shieldtest.js
@@ -37,7 +37,13 @@ const once = (emitter, name, { signal } = {}) =>
     signal?.addEventListener("abort", reject);
   });
 
-await once(map, "load");
+(async function () {
+  try {
+    await once(map, "load");
+  } catch (error) {
+    console.error(error);
+  }
+})();
 
 let networks = [
   "default",
@@ -422,6 +428,12 @@ function mergeArrays(arr1, arr2) {
   return ret;
 }
 
-await renderAllShields().finally(() =>
-  document.querySelector("#progress-overlay").remove()
-);
+(async function () {
+  try {
+    await renderAllShields().finally(() =>
+      document.querySelector("#progress-overlay").remove()
+    );
+  } catch (error) {
+    console.error(error);
+  }
+})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "ES2019",
+    "module": "ES2020",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true
   },


### PR DESCRIPTION
Fixes #890

This PR changes the compatibility to ES2019 which is desired for compatibility reasons (see description in #890).  Mostly, this involved replacing top-level awaits with Promise code.

Open question: is this actually desirable in the main repo?  Should we make it so _only_the shield library is ES2019 instead?