### PR TITLE
Downgrade shield library to ES2019

### DIFF
--- a/shieldlib/package.json
+++ b/shieldlib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@americana/maplibre-shield-generator",
   "description": "Generate highway shields for maplibre-gl-js maps",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "OpenStreetMap Americana Contributors",
   "type": "module",
   "keywords": [

--- a/shieldlib/tsconfig.json
+++ b/shieldlib/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "ES2019",
+    "module": "ES2020",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true


### PR DESCRIPTION
Fixes #890

This PR changes the shield library to ES2019 and bumps the version number for npm.