### PR TITLE
Prevent all test-runners from using node v18.17.0

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+      - name: Use Node.js 18.16.1
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 18.16.1 #18.17.0 is buggy
       - name: Save PR number
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+      - name: Use Node.js 18.16.1
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 18.16.1 #18.17.0 is buggy
       - name: Install and Build 🔧
         run: |
           npm ci --include=dev

--- a/.github/workflows/test-build-mac.yml
+++ b/.github/workflows/test-build-mac.yml
@@ -10,10 +10,13 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+# Node v18.17.0, introduced July 18, 2023, introduces an error in unicode processing that breaks test cases on Ubuntu.
+# See PR #905 and #908 for more details.
+# If this bug is resolved in node, these lines can revert to 18.x rather than 18.16.0.
+      - name: Use Node.js 18.16.1
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 18.16.1
       - name: Build Shield Library 🛡️
         run: |
           cd shieldlib

--- a/.github/workflows/test-build-ubuntu.yml
+++ b/.github/workflows/test-build-ubuntu.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+# Node v18.17.0, introduced July 18, 2023, introduces an error in unicode processing that breaks test cases on Ubuntu.
+# See PR #905 and #908 for more details.
+# If this bug is resolved in node, these lines can revert to 18.x rather than 18.16.0.
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test-build-ubuntu.yml
+++ b/.github/workflows/test-build-ubuntu.yml
@@ -13,10 +13,10 @@ jobs:
 # Node v18.17.0, introduced July 18, 2023, introduces an error in unicode processing that breaks test cases on Ubuntu.
 # See PR #905 and #908 for more details.
 # If this bug is resolved in node, these lines can revert to 18.x rather than 18.16.0.
-      - name: Use Node.js 18.x
+      - name: Use Node.js 18.16.0
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 18.16.0
       - name: Build Shield Library 🛡️
         run: |
           cd shieldlib

--- a/.github/workflows/test-build-ubuntu.yml
+++ b/.github/workflows/test-build-ubuntu.yml
@@ -12,11 +12,11 @@ jobs:
         uses: actions/checkout@v3
 # Node v18.17.0, introduced July 18, 2023, introduces an error in unicode processing that breaks test cases on Ubuntu.
 # See PR #905 and #908 for more details.
-# If this bug is resolved in node, these lines can revert to 18.x rather than 18.16.0.
-      - name: Use Node.js 18.16.0
+# If this bug is resolved in node, these lines can revert to 18.x rather than 18.16.1.
+      - name: Use Node.js 18.16.1
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.0
+          node-version: 18.16.1
       - name: Build Shield Library 🛡️
         run: |
           cd shieldlib


### PR DESCRIPTION
Node v18.17.0, released on July 18, 2023, introduced a bug which breaks one test case as shown in PR #905 and debugged in PR #908.

This PR forces node v18.16.0 in the Ubuntu CI runner.

I implemented this PR in two commits to demonstrate that the Ubuntu runner is in fact currently broken on node "18.x".