### PR TITLE
Don't typecheck ts-node scripts/…

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
   },
   "ts-node": {
     "esm": true,
-    "experimentalSpecifierResolution": "node"
+    "experimentalSpecifierResolution": "node",
+    "transpileOnly": true
   },
   "include": ["src/**/*.ts", "shieldlib/src/headless_graphics.ts"]
 }


### PR DESCRIPTION
Running the TypeScript compiler with typechecking consumes a fair amount of memory and CPU, which is fairly inconvenient for interactive scripting use.

Either a build step should be added that compiles the scripts, or typechecking should be disabled for extra speed.

Besides, only _some_ typechecking is happening. Really, a test step should be added which runs tsc on every .ts file, not just the ones we happen to run.

Alternatives considered:

- Use the swc compiler, which ts-node can use with a flag. Fine, it's slightly faster, but we don't really need even more native dependencies.
- Use esbuild, which ts-node can only use if we write a small plugin. Extra work and seems to be slightly slower than tsc in this particular invocation.
- Use tsx, which can run .ts files via esbuild. Works, but it's different from ts-node and so requires editing all the script command lines.