### PR TITLE
Add Asotin County road shield

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3122,6 +3122,11 @@ export function loadShields() {
   shields["US:WA:Business"] = banneredShield(shields["US:WA"], ["BUS"]);
   shields["US:WA:Alternate"] = banneredShield(shields["US:WA"], ["ALT"]);
 
+  shields["US:WA:Asotin"] = roundedRectShield(
+    Color.shields.green,
+    Color.shields.white
+  );
+
   // Wisconsin
   shields["US:WI"] = {
     spriteBlank: ["shield_us_wi_2", "shield_us_wi_3"],


### PR DESCRIPTION
Added a simple green shield for county roads in Asotin County, Washington, tagged with `network=US:WA:Asotin` as on [this newly created route relation](https://www.openstreetmap.org/relation/16294559).

[![Asotin County Road 330](https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Asotin_County_Road_330_%28Silcott_Grade_Road%29.jpg/638px-Asotin_County_Road_330_%28Silcott_Grade_Road%29.jpg)](https://commons.wikimedia.org/wiki/File:Asotin_County_Road_330_%28Silcott_Grade_Road%29.jpg)