### PR TITLE
Add PR commit SHA to Checks Tab runner

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -45,10 +45,12 @@ jobs:
       - name: Save PR number
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.sha }}
         run: |
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number
-          echo "Saved PR# ${{ github.event.pull_request.number }} for upload"
+          echo $PR_SHA > ./pr/pr_sha
+          echo "Saved PR# ${{ github.event.pull_request.number }}, SHA# ${{ github.sha }} for upload"
       - name: Save PR#
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/s3-upload.yml
+++ b/.github/workflows/s3-upload.yml
@@ -59,8 +59,10 @@ jobs:
       - name: Set PR variable
         run: |
           PR_NUM=$(cat pr_number)
+          PR_SHA=$(cat pr_sha)
           echo "Configuring deployment for PR# $PR_NUM"
           echo "PR_NUM=$PR_NUM" >> $GITHUB_ENV
+          echo "PR_SHA=$PR_SHA" >> $GITHUB_ENV
       - name: Deploy via S3
         uses: jakejarvis/s3-sync-action@master
         with:
@@ -104,6 +106,7 @@ jobs:
         uses: LouisBrunner/checks-action@v1.6.1
         if: always()
         with:
+          sha: ${{ env.PR_SHA }}
           token: ${{ secrets.GITHUB_TOKEN }}
           name: PR Preview
           conclusion: neutral


### PR DESCRIPTION
This PR populates the SHA field of the checks tab runner, since this context is otherwise lost in the privileged context.