### PR TITLE
Migrate performance checks to privileged runner

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -63,16 +63,6 @@ jobs:
           echo '${{ env.MAIN_STATS }}'
           echo '${{ env.PR_STATS }}'
           npm exec ts-node scripts/stats_compare '${{ env.MAIN_STATS }}' '${{ env.PR_STATS }}' > pr/stats-difference.md
-      - name: Print Stats to GitHub Checks
-        uses: LouisBrunner/checks-action@v1.6.1
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Performance Metrics
-          conclusion: neutral
-          output: |
-            {"summary":"Style size changes introduced by this PR"}
-          output_text_description_file: pr/stats-difference.md
       - name: Upload Build artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -49,6 +49,11 @@ jobs:
           npm run style
           npm run shields
           cp src/configs/config.aws.js src/config.js
+      - name: Upload Build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: americana
+          path: dist/
       - name: Capture PR branch usage statistics
         id: pr-stats
         run: |
@@ -63,11 +68,6 @@ jobs:
           echo '${{ env.MAIN_STATS }}'
           echo '${{ env.PR_STATS }}'
           npm exec ts-node scripts/stats_compare '${{ env.MAIN_STATS }}' '${{ env.PR_STATS }}' > pr/stats-difference.md
-      - name: Upload Build artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: americana
-          path: dist/
       - name: Save PR artifacts
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy-pr-checks.yml
+++ b/.github/workflows/deploy-pr-checks.yml
@@ -126,6 +126,15 @@ jobs:
           conclusion: neutral
           output: |
             {"summary":"Preview map changes introduced by this PR", "title":"View live map and artifacts"}
-          images: |
-            [{"image_url":"https://preview.ourmap.us/pr/${{ env.PR_NUM }}/sprites/sprite.png", "caption":"Sprite Sheet", "alt":"1x Sprite Sheet"}]
           output_text_description_file: pr_preview.md
+      - name: Print Stats to GitHub Checks
+        uses: LouisBrunner/checks-action@v1.6.1
+        if: always()
+        with:
+          sha: ${{ env.PR_SHA }}
+          token: ${{ steps.checks_token.outputs.token }}
+          name: Style Performance
+          conclusion: neutral
+          output: |
+            {"summary":"Style size changes introduced by this PR", "title":"View metrics on style size changes"}
+          output_text_description_file: stats-difference.md


### PR DESCRIPTION
This PR migrates the performance checks to the privileged CI runner so that it works with outside forks.
I also removed the images array because it doesn't look good.