### PR TITLE
Per-shield banner colors

### DIFF
--- a/shieldlib/README.md
+++ b/shieldlib/README.md
@@ -136,6 +136,8 @@ You should create one definition entry for each network. The entry key must matc
     }
   },
   "banners": ["ALT"],
+  "bannerTextColor": "#000",
+  "bannerTextHaloColor": "#FFF",
   "textLayout": {
     "constraintFunc": "roundedRect",
     "options": {
@@ -173,6 +175,8 @@ You should create one definition entry for each network. The entry key must matc
 
 ![Bannered routes near Downington, PA](https://wiki.openstreetmap.org/w/images/f/f8/Downington_bannered_routes_Americana.png)
 
+- **`bannerTextColor`**: specify the color of the banner text.
+- **`bannerTextHaloColor`**: specify the color of the banner knockout halo.
 - **`textLayout`**: specify how text should be inscribed within the padded bounds of the shield. The text will be drawn at the maximum size allowed by this constraint. See the [text layout functions](#text-layout-functions) section for text layout options.
 - **`colorLighten`**: specify that the shield artwork should be lightened (multiplied) by the specified color. This means that black areas will be recolor with this color and white areas will remain the same. Alpha values will remain unmodified.
 - **`colorDarken`**: specify that the shield artwork should be darkened by the specified color. This means that white areas will be recolor with this color and black areas will remain the same. Alpha values will remain unmodified.

--- a/shieldlib/src/custom_shields.ts
+++ b/shieldlib/src/custom_shields.ts
@@ -9,7 +9,7 @@ export function paBelt(
   r: ShieldRenderingContext,
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams
-) {
+): number {
   ShieldDraw.roundedRectangle(r, ctx, {
     fillColor: "white",
     strokeColor: "black",
@@ -38,7 +38,7 @@ export function paBelt(
 
   ctx.lineWidth = lineWidth;
   ctx.stroke();
-  return ctx;
+  return 20;
 }
 
 // Special case for Branson color-coded routes
@@ -46,7 +46,7 @@ export function bransonRoute(
   r: ShieldRenderingContext,
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams
-) {
+): number {
   ShieldDraw.roundedRectangle(r, ctx, {
     fillColor: "#006747",
     strokeColor: "white",
@@ -73,7 +73,7 @@ export function bransonRoute(
 
   ctx.lineWidth = lineWidth;
   ctx.stroke();
-  return ctx;
+  return 20;
 }
 
 export function loadCustomShields() {

--- a/shieldlib/src/screen_gfx.ts
+++ b/shieldlib/src/screen_gfx.ts
@@ -3,7 +3,7 @@ import { StyleImage } from "maplibre-gl";
 import rgba from "color-rgba";
 
 const defaultFontFamily = '"sans-serif-condensed", "Arial Narrow", sans-serif';
-export const shieldFont = (size: string, fontFamily: string) =>
+export const shieldFont = (size: number, fontFamily: string) =>
   `bold ${size}px ${fontFamily || defaultFontFamily}`;
 export const fontSizeThreshold = 12;
 

--- a/shieldlib/src/shield.js
+++ b/shieldlib/src/shield.js
@@ -1,20 +1,13 @@
 "use strict";
 
 import * as ShieldText from "./shield_text.js";
-import * as ShieldDraw from "./shield_canvas_draw";
+import * as ShieldDraw from "./shield_canvas_draw.js";
 import * as Gfx from "./screen_gfx.js";
-
-function drawBannerPart(r, ctx, shieldDef, drawFunc) {
-  if (shieldDef == null || typeof shieldDef.banners == "undefined") {
-    return ctx; //Unadorned shield
-  }
-
-  for (var i = 0; i < shieldDef.banners.length; i++) {
-    drawFunc(r, ctx, shieldDef.banners[i], i);
-  }
-
-  return ctx;
-}
+import {
+  drawBanners,
+  drawBannerHalos,
+  getBannerCount,
+} from "./shield_banner.js";
 
 function compoundShieldSize(r, dimension, bannerCount) {
   return {
@@ -27,19 +20,6 @@ function compoundShieldSize(r, dimension, bannerCount) {
 
 export function isValidRef(ref) {
   return ref !== null && ref.length !== 0 && ref.length <= 6;
-}
-
-/**
- * Get the number of banner placards associated with this shield
- *
- * @param {*} shield - Shield definition
- * @returns the number of banner placards that need to be drawn
- */
-function getBannerCount(shield) {
-  if (shield == null || typeof shield.banners == "undefined") {
-    return 0; //Unadorned shield
-  }
-  return shield.banners.length;
 }
 
 /**
@@ -359,7 +339,7 @@ export function generateShieldCtx(r, routeDef) {
   }
 
   // Add the halo around modifier plaque text
-  drawBannerPart(r, ctx, shieldDef, ShieldText.drawBannerHaloText);
+  drawBannerHalos(r, ctx, shieldDef);
 
   if (sourceSprite == null) {
     drawShield(r, ctx, shieldDef, routeDef);
@@ -378,7 +358,7 @@ export function generateShieldCtx(r, routeDef) {
   drawShieldText(r, ctx, shieldDef, routeDef);
 
   // Add modifier plaque text
-  drawBannerPart(r, ctx, shieldDef, ShieldText.drawBannerText);
+  drawBanners(r, ctx, shieldDef);
 
   return ctx;
 }

--- a/shieldlib/src/shield.js
+++ b/shieldlib/src/shield.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import * as ShieldText from "./shield_text.mjs";
+import * as ShieldText from "./shield_text.js";
 import * as ShieldDraw from "./shield_canvas_draw";
 import * as Gfx from "./screen_gfx.js";
 

--- a/shieldlib/src/shield_banner.ts
+++ b/shieldlib/src/shield_banner.ts
@@ -19,8 +19,8 @@ export function drawBanners(
   ctx: CanvasRenderingContext2D,
   shieldDef: ShieldDefinition
 ) {
-  if (shieldDef.bannerColor) {
-    ctx.fillStyle = shieldDef.bannerColor;
+  if (shieldDef.bannerTextColor) {
+    ctx.fillStyle = shieldDef.bannerTextColor;
   } else {
     ctx.fillStyle = r.options.bannerTextColor;
   }
@@ -39,8 +39,8 @@ export function drawBannerHalos(
   ctx: CanvasRenderingContext2D,
   shieldDef: ShieldDefinition
 ) {
-  if (shieldDef.bannerHaloColor) {
-    ctx.strokeStyle = ctx.shadowColor = shieldDef.bannerHaloColor;
+  if (shieldDef.bannerTextHaloColor) {
+    ctx.strokeStyle = ctx.shadowColor = shieldDef.bannerTextHaloColor;
   } else {
     ctx.strokeStyle = ctx.shadowColor = r.options.bannerTextHaloColor;
   }

--- a/shieldlib/src/shield_banner.ts
+++ b/shieldlib/src/shield_banner.ts
@@ -1,0 +1,171 @@
+import { shieldFont } from "./screen_gfx";
+import { ShieldRenderingContext } from "./shield_renderer";
+import { TextPlacement, layoutShieldText } from "./shield_text";
+import { Dimension, ShieldDefinition, TextLayout } from "./types";
+
+let bannerLayout: TextLayout = {
+  constraintFunc: "rect",
+};
+
+/**
+ * Add modifier plaque text
+ *
+ * @param r - Shield rendering context
+ * @param ctx - Canvas drawing context
+ * @param shieldDef - Shield definition
+ */
+export function drawBanners(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  shieldDef: ShieldDefinition
+) {
+  drawBannerPart(r, ctx, shieldDef, drawBannerText);
+}
+
+/**
+ * Add the halo around modifier plaque text
+ *
+ * @param r - Shield rendering context
+ * @param ctx - Canvas drawing context
+ * @param shieldDef - Shield definition
+ */
+export function drawBannerHalos(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  shieldDef: ShieldDefinition
+) {
+  drawBannerPart(r, ctx, shieldDef, drawBannerHaloText);
+}
+
+type BannerDrawComponentFunction = (
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  bannerIndex: number
+) => void;
+
+function drawBannerPart(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  shieldDef: ShieldDefinition,
+  drawFunc: BannerDrawComponentFunction
+): void {
+  if (shieldDef == null || typeof shieldDef.banners == "undefined") {
+    return; //Unadorned shield
+  }
+
+  for (var i = 0; i < shieldDef.banners.length; i++) {
+    drawFunc(r, ctx, shieldDef.banners[i], i);
+  }
+}
+
+/**
+ * Get the number of banner placards associated with this shield
+ *
+ * @param shield - Shield definition
+ * @returns the number of banner placards that need to be drawn
+ */
+export function getBannerCount(shield: ShieldDefinition): number {
+  if (shield == null || typeof shield.banners == "undefined") {
+    return 0; //Unadorned shield
+  }
+  return shield.banners.length;
+}
+
+/**
+ * Draw text on a modifier plate above a shield
+ *
+ * @param {*} r - rendering context
+ * @param {*} ctx - graphics context to draw to
+ * @param {*} text - text to draw
+ * @param {*} bannerIndex - plate position to draw, 0=top, incrementing
+ */
+export function drawBannerText(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  bannerIndex: number
+): void {
+  drawBannerTextComponent(r, ctx, text, bannerIndex, true);
+}
+
+/**
+ * Draw drop shadow for text on a modifier plate above a shield
+ *
+ * @param {*} r - rendering context
+ * @param {*} ctx - graphics context to draw to
+ * @param {*} text - text to draw
+ * @param {*} bannerIndex - plate position to draw, 0=top, incrementing
+ */
+export function drawBannerHaloText(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  bannerIndex: number
+): void {
+  drawBannerTextComponent(r, ctx, text, bannerIndex, false);
+}
+
+/**
+ * Banners are composed of two components: text on top, and a shadow beneath.
+ *
+ * @param {*} r - rendering context
+ * @param {*} ctx - graphics context to draw to
+ * @param {*} text - text to draw
+ * @param {*} bannerIndex - plate position to draw, 0=top, incrementing
+ * @param {*} textComponent - if true, draw the text.  If false, draw the halo
+ */
+function drawBannerTextComponent(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  bannerIndex: number,
+  textComponent: boolean
+): void {
+  const bannerPadding = {
+    top: r.options.bannerPadding,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  };
+
+  let bannerBounds: Dimension = {
+    width: ctx.canvas.width,
+    height: r.px(r.options.bannerHeight - r.options.bannerPadding),
+  };
+
+  let textLayout: TextPlacement = layoutShieldText(
+    r,
+    text,
+    bannerPadding,
+    bannerBounds,
+    bannerLayout
+  );
+
+  ctx.font = shieldFont(textLayout.fontPx, r.options.shieldFont);
+  ctx.textBaseline = "top";
+  ctx.textAlign = "center";
+
+  if (textComponent) {
+    ctx.fillStyle = r.options.bannerTextColor;
+    ctx.fillText(
+      text,
+      textLayout.xBaseline,
+      textLayout.yBaseline +
+        bannerIndex * r.px(r.options.bannerHeight - r.options.bannerPadding)
+    );
+  } else {
+    ctx.strokeStyle = ctx.shadowColor = r.options.bannerTextHaloColor;
+    ctx.shadowBlur = 0;
+    ctx.lineWidth = r.px(2);
+    ctx.strokeText(
+      text,
+      textLayout.xBaseline,
+      textLayout.yBaseline +
+        bannerIndex * r.px(r.options.bannerHeight - r.options.bannerPadding)
+    );
+
+    ctx.shadowColor = null;
+    ctx.shadowBlur = null;
+  }
+}

--- a/shieldlib/src/shield_banner.ts
+++ b/shieldlib/src/shield_banner.ts
@@ -19,6 +19,11 @@ export function drawBanners(
   ctx: CanvasRenderingContext2D,
   shieldDef: ShieldDefinition
 ) {
+  if (shieldDef.bannerColor) {
+    ctx.fillStyle = shieldDef.bannerColor;
+  } else {
+    ctx.fillStyle = r.options.bannerTextColor;
+  }
   drawBannerPart(r, ctx, shieldDef, drawBannerText);
 }
 
@@ -34,6 +39,11 @@ export function drawBannerHalos(
   ctx: CanvasRenderingContext2D,
   shieldDef: ShieldDefinition
 ) {
+  if (shieldDef.bannerHaloColor) {
+    ctx.strokeStyle = ctx.shadowColor = shieldDef.bannerHaloColor;
+  } else {
+    ctx.strokeStyle = ctx.shadowColor = r.options.bannerTextHaloColor;
+  }
   drawBannerPart(r, ctx, shieldDef, drawBannerHaloText);
 }
 
@@ -147,7 +157,6 @@ function drawBannerTextComponent(
   ctx.textAlign = "center";
 
   if (textComponent) {
-    ctx.fillStyle = r.options.bannerTextColor;
     ctx.fillText(
       text,
       textLayout.xBaseline,
@@ -155,7 +164,6 @@ function drawBannerTextComponent(
         bannerIndex * r.px(r.options.bannerHeight - r.options.bannerPadding)
     );
   } else {
-    ctx.strokeStyle = ctx.shadowColor = r.options.bannerTextHaloColor;
     ctx.shadowBlur = 0;
     ctx.lineWidth = r.px(2);
     ctx.strokeText(

--- a/shieldlib/src/shield_canvas_draw.ts
+++ b/shieldlib/src/shield_canvas_draw.ts
@@ -4,7 +4,7 @@
  * Shield blanks which are drawn rather built from raster shield blanks
  */
 
-import * as ShieldText from "./shield_text.js";
+import * as ShieldText from "./shield_text.mjs";
 import { loadCustomShields } from "./custom_shields";
 import { ShapeDrawFunction, ShieldRenderingContext } from "./shield_renderer";
 import { ShapeBlankParams } from "./types";
@@ -18,7 +18,7 @@ export function computeWidth(
   params: ShapeBlankParams,
   ref: string,
   shape?: string
-): number {
+) {
   if (fixedWidthDefinitions[shape] !== undefined) {
     return r.px(fixedWidthDefinitions[shape]);
   }
@@ -97,10 +97,7 @@ function ellipse(
   return width;
 }
 
-export function blank(
-  r: ShieldRenderingContext,
-  ref: string
-): CanvasRenderingContext2D {
+export function blank(r: ShieldRenderingContext, ref: string) {
   var shieldWidth =
     ShieldText.calculateTextWidth(r, ref, r.px(genericShieldFontSize)) +
     r.px(2);
@@ -166,7 +163,7 @@ function escutcheon(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
+): number {
   let yOffset = params.yOffset == undefined ? 0 : params.yOffset;
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
@@ -282,7 +279,7 @@ function triangle(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
+): number {
   let pointUp = params.pointUp == undefined ? false : params.pointUp;
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
@@ -348,7 +345,7 @@ function trapezoid(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
+): number {
   let shortSideUp =
     params.shortSideUp == undefined ? false : params.shortSideUp;
   let sideAngle = params.sideAngle == undefined ? 0 : params.sideAngle;
@@ -410,7 +407,7 @@ function diamond(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
+): number {
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
   let radius = params.radius == undefined ? 0 : params.radius;
@@ -479,7 +476,7 @@ function pentagon(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
+): number {
   let pointUp = params.pointUp == undefined ? true : params.pointUp;
   let yOffset = params.yOffset == undefined ? 0 : params.yOffset;
   let sideAngle = params.sideAngle == undefined ? 0 : params.sideAngle;
@@ -552,7 +549,7 @@ function hexagonVertical(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
+): number {
   let yOffset = params.yOffset == undefined ? 0 : params.yOffset;
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
@@ -606,17 +603,17 @@ function hexagonHorizontal(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
-  let angle = params.sideAngle == undefined ? 0 : params.sideAngle;
+): number {
+  let sideAngle = params.sideAngle == undefined ? 0 : params.sideAngle;
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
   let radius = params.radius == undefined ? 0 : params.radius;
   let outlineWidth = params.outlineWidth == undefined ? 1 : params.outlineWidth;
 
-  let sine = Math.sin(angle);
-  let cosine = Math.cos(angle);
-  let tangent = Math.tan(angle);
-  let halfComplementTangent = Math.tan(Math.PI / 4 - angle / 2);
+  let sine = Math.sin(sideAngle);
+  let cosine = Math.cos(sideAngle);
+  let tangent = Math.tan(sideAngle);
+  let halfComplementTangent = Math.tan(Math.PI / 4 - sideAngle / 2);
 
   let width = computeWidth(r, params, ref, "hexagonHorizontal");
 
@@ -672,7 +669,7 @@ function octagonVertical(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
+): number {
   let yOffset = params.yOffset == undefined ? 0 : params.yOffset;
   let sideAngle = params.sideAngle == undefined ? 0 : params.sideAngle;
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
@@ -769,7 +766,7 @@ export function draw(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
+): number {
   return drawFunctions[name](r, ctx, params, ref);
 }
 

--- a/shieldlib/src/shield_canvas_draw.ts
+++ b/shieldlib/src/shield_canvas_draw.ts
@@ -4,7 +4,7 @@
  * Shield blanks which are drawn rather built from raster shield blanks
  */
 
-import * as ShieldText from "./shield_text.mjs";
+import * as ShieldText from "./shield_text";
 import { loadCustomShields } from "./custom_shields";
 import { ShapeDrawFunction, ShieldRenderingContext } from "./shield_renderer";
 import { ShapeBlankParams } from "./types";

--- a/shieldlib/src/shield_canvas_draw.ts
+++ b/shieldlib/src/shield_canvas_draw.ts
@@ -4,7 +4,7 @@
  * Shield blanks which are drawn rather built from raster shield blanks
  */
 
-import * as ShieldText from "./shield_text.mjs";
+import * as ShieldText from "./shield_text.js";
 import { loadCustomShields } from "./custom_shields";
 import { ShapeDrawFunction, ShieldRenderingContext } from "./shield_renderer";
 import { ShapeBlankParams } from "./types";
@@ -18,7 +18,7 @@ export function computeWidth(
   params: ShapeBlankParams,
   ref: string,
   shape?: string
-) {
+): number {
   if (fixedWidthDefinitions[shape] !== undefined) {
     return r.px(fixedWidthDefinitions[shape]);
   }
@@ -65,7 +65,7 @@ function ellipse(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
+): number {
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
 
@@ -97,7 +97,10 @@ function ellipse(
   return width;
 }
 
-export function blank(r: ShieldRenderingContext, ref: string) {
+export function blank(
+  r: ShieldRenderingContext,
+  ref: string
+): CanvasRenderingContext2D {
   var shieldWidth =
     ShieldText.calculateTextWidth(r, ref, r.px(genericShieldFontSize)) +
     r.px(2);
@@ -116,7 +119,7 @@ export function roundedRectangle(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref?: string
-) {
+): number {
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
   let radius = params.radius == undefined ? 0 : params.radius;
@@ -220,7 +223,7 @@ function fishhead(
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
   ref: string
-) {
+): number {
   let pointUp = params.pointUp == undefined ? false : params.pointUp;
   let fill = params.fillColor == undefined ? "white" : params.fillColor;
   let outline = params.strokeColor == undefined ? "black" : params.strokeColor;
@@ -270,6 +273,8 @@ function fishhead(
     ctx.strokeStyle = outline;
     ctx.stroke();
   }
+
+  return width;
 }
 
 function triangle(

--- a/shieldlib/src/shield_helper.d.ts
+++ b/shieldlib/src/shield_helper.d.ts
@@ -141,5 +141,6 @@ export declare function pillShield(
 
 export function banneredShield(
   baseDef: ShieldDefinition,
-  banners: string[]
+  banners: string[],
+  bannerColor?: string
 ): ShieldDefinition;

--- a/shieldlib/src/shield_helper.ts
+++ b/shieldlib/src/shield_helper.ts
@@ -702,10 +702,12 @@ export function pillShield(
  */
 export function banneredShield(
   baseDef: ShieldDefinition,
-  banners: string[]
+  banners: string[],
+  bannerColor?: string
 ): ShieldDefinition {
   return {
     banners,
+    bannerColor,
     ...baseDef,
   };
 }

--- a/shieldlib/src/shield_helper.ts
+++ b/shieldlib/src/shield_helper.ts
@@ -707,7 +707,7 @@ export function banneredShield(
 ): ShieldDefinition {
   return {
     banners,
-    bannerColor,
+    bannerTextColor: bannerColor,
     ...baseDef,
   };
 }

--- a/shieldlib/src/shield_renderer.ts
+++ b/shieldlib/src/shield_renderer.ts
@@ -48,8 +48,8 @@ export type ShapeDrawFunction = (
   r: ShieldRenderingContext,
   ctx: CanvasRenderingContext2D,
   params: ShapeBlankParams,
-  ref: string
-) => void;
+  ref?: string
+) => number;
 
 class MaplibreGLSpriteRepository implements SpriteRepository {
   map: Map;

--- a/shieldlib/src/shield_text.ts
+++ b/shieldlib/src/shield_text.ts
@@ -102,11 +102,7 @@ function rectTextConstraint(
 function roundedRectTextConstraint(
   spaceBounds: Dimension,
   textBounds: Dimension,
-<<<<<<< HEAD
-  options
-=======
   options: TextLayoutParameters
->>>>>>> main
 ): TextTransform {
   //Shrink space bounds so that corners hit the arcs
   let constraintRadius = 2;

--- a/shieldlib/src/shield_text.ts
+++ b/shieldlib/src/shield_text.ts
@@ -1,14 +1,57 @@
 "use strict";
 
 import * as Gfx from "./screen_gfx.js";
+import { ShieldRenderingContext } from "./shield_renderer.js";
+import {
+  BoxPadding,
+  ShieldDefinition,
+  TextLayout,
+  TextLayoutParameters,
+} from "./types.js";
 
 const VerticalAlignment = {
   Middle: "middle",
   Top: "top",
   Bottom: "bottom",
+} as const;
+
+type VerticalAlignmentType =
+  (typeof VerticalAlignment)[keyof typeof VerticalAlignment];
+
+interface Dimension {
+  width: number;
+  height: number;
+}
+
+type TextLayoutScaler = (
+  availSize: Dimension,
+  textSize: Dimension,
+  options: TextLayoutParameters
+) => TextTransform;
+
+interface TextTransform {
+  scale: number;
+  valign: VerticalAlignmentType;
+}
+
+interface TextPlacement {
+  xBaseline: number;
+  yBaseline: number;
+  fontPx: number;
+}
+
+let noPadding: BoxPadding = {
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
 };
 
-function ellipseScale(spaceBounds, textBounds) {
+let bannerLayout: TextLayout = {
+  constraintFunc: "rectangle",
+};
+
+function ellipseScale(spaceBounds: Dimension, textBounds: Dimension): number {
   //Math derived from https://mathworld.wolfram.com/Ellipse-LineIntersection.html
   var a = spaceBounds.width;
   var b = spaceBounds.height;
@@ -19,14 +62,20 @@ function ellipseScale(spaceBounds, textBounds) {
   return (a * b) / Math.sqrt(a * a * y0 * y0 + b * b * x0 * x0);
 }
 
-function ellipseTextConstraint(spaceBounds, textBounds) {
+function ellipseTextConstraint(
+  spaceBounds: Dimension,
+  textBounds: Dimension
+): TextTransform {
   return {
     scale: ellipseScale(spaceBounds, textBounds),
     valign: VerticalAlignment.Middle,
   };
 }
 
-function southHalfEllipseTextConstraint(spaceBounds, textBounds) {
+function southHalfEllipseTextConstraint(
+  spaceBounds: Dimension,
+  textBounds: Dimension
+): TextTransform {
   return {
     scale: ellipseScale(spaceBounds, {
       //Turn ellipse 90 degrees
@@ -37,7 +86,10 @@ function southHalfEllipseTextConstraint(spaceBounds, textBounds) {
   };
 }
 
-function rectTextConstraint(spaceBounds, textBounds) {
+function rectTextConstraint(
+  spaceBounds: Dimension,
+  textBounds: Dimension
+): TextTransform {
   var scaleHeight = spaceBounds.height / textBounds.height;
   var scaleWidth = spaceBounds.width / textBounds.width;
 
@@ -47,7 +99,11 @@ function rectTextConstraint(spaceBounds, textBounds) {
   };
 }
 
-function roundedRectTextConstraint(spaceBounds, textBounds, options) {
+function roundedRectTextConstraint(
+  spaceBounds: Dimension,
+  textBounds: Dimension,
+  options
+): TextTransform {
   //Shrink space bounds so that corners hit the arcs
   let constraintRadius = 2;
   if (options !== undefined && options.radius !== undefined) {
@@ -63,7 +119,10 @@ function roundedRectTextConstraint(spaceBounds, textBounds, options) {
   );
 }
 
-function diamondTextConstraint(spaceBounds, textBounds) {
+function diamondTextConstraint(
+  spaceBounds: Dimension,
+  textBounds: Dimension
+): TextTransform {
   let a = spaceBounds.width;
   let b = spaceBounds.height;
 
@@ -76,7 +135,10 @@ function diamondTextConstraint(spaceBounds, textBounds) {
   };
 }
 
-function triangleDownTextConstraint(spaceBounds, textBounds) {
+function triangleDownTextConstraint(
+  spaceBounds: Dimension,
+  textBounds: Dimension
+): TextTransform {
   return {
     scale: diamondTextConstraint(spaceBounds, textBounds).scale,
     valign: VerticalAlignment.Top,
@@ -96,13 +158,13 @@ function triangleDownTextConstraint(spaceBounds, textBounds) {
  * @returns JOSN object containing (X,Y) draw position and font size
  */
 function layoutShieldText(
-  r,
-  text,
-  padding,
-  bounds,
-  textLayoutDef,
-  maxFontSize
-) {
+  r: ShieldRenderingContext,
+  text: string,
+  padding: BoxPadding,
+  bounds: Dimension,
+  textLayoutDef: TextLayout,
+  maxFontSize: number = 14
+): TextPlacement {
   var padTop = r.px(padding.top) || 0;
   var padBot = r.px(padding.bottom) || 0;
   var padLeft = r.px(padding.left) || 0;
@@ -147,7 +209,7 @@ function layoutShieldText(
   metrics = ctx.measureText(text);
   textHeight = metrics.actualBoundingBoxDescent;
 
-  var yBaseline;
+  let yBaseline: number;
 
   switch (textConstraint.valign) {
     case VerticalAlignment.Top:
@@ -163,18 +225,25 @@ function layoutShieldText(
   }
 
   return {
-    xBaseline: xBaseline,
-    yBaseline: yBaseline,
+    xBaseline,
+    yBaseline,
     fontPx: fontSize,
   };
 }
 
-const defaultDefForLayout = {
+const defaultDefForLayout: ShieldDefinition = {
   padding: {
     top: 0,
     bottom: 0,
     left: 0,
     right: 0,
+  },
+  shapeBlank: {
+    drawFunc: "rectangle",
+    params: {
+      fillColor: "white",
+      strokeColor: "black",
+    },
   },
 };
 
@@ -188,13 +257,18 @@ const defaultDefForLayout = {
  * @param {*} bounds - size of the overall graphics area
  * @returns JOSN object containing (X,Y) draw position and font size
  */
-export function layoutShieldTextFromDef(r, text, def, bounds) {
+export function layoutShieldTextFromDef(
+  r: ShieldRenderingContext,
+  text: string,
+  def: ShieldDefinition,
+  bounds: Dimension
+): TextPlacement {
   //FIX
   if (def == null) {
     def = defaultDefForLayout;
   }
 
-  var padding = def.padding || {};
+  var padding = def.padding || noPadding;
 
   var textLayoutDef = {
     constraintFunc: "rect",
@@ -221,7 +295,12 @@ export function layoutShieldTextFromDef(r, text, def, bounds) {
  * @param {*} text - text to draw
  * @param {*} textLayout - location to draw text
  */
-export function renderShieldText(r, ctx, text, textLayout) {
+export function renderShieldText(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  textLayout: TextPlacement
+): void {
   //Text color is set by fillStyle
   configureShieldText(r, ctx, textLayout);
 
@@ -236,11 +315,16 @@ export function renderShieldText(r, ctx, text, textLayout) {
  * @param {*} text - text to draw
  * @param {*} textLayout - location to draw text
  */
-export function drawShieldHaloText(r, ctx, text, textLayout) {
+export function drawShieldHaloText(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  textLayout: TextPlacement
+): void {
   //Stroke color is set by strokeStyle
   configureShieldText(r, ctx, textLayout);
 
-  ctx.shadowColor = ctx.strokeStyle;
+  ctx.shadowColor = ctx.strokeStyle.toString();
   ctx.shadowBlur = 0;
   ctx.lineWidth = r.px(2);
 
@@ -249,7 +333,11 @@ export function drawShieldHaloText(r, ctx, text, textLayout) {
   ctx.shadowBlur = null;
 }
 
-function configureShieldText(r, ctx, textLayout) {
+function configureShieldText(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  textLayout: TextPlacement
+): void {
   ctx.textAlign = "center";
   ctx.textBaseline = "top";
   ctx.font = Gfx.shieldFont(textLayout.fontPx, r.options.shieldFont);
@@ -263,7 +351,12 @@ function configureShieldText(r, ctx, textLayout) {
  * @param {*} text - text to draw
  * @param {*} bannerIndex - plate position to draw, 0=top, incrementing
  */
-export function drawBannerText(r, ctx, text, bannerIndex) {
+export function drawBannerText(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  bannerIndex: number
+): void {
   drawBannerTextComponent(r, ctx, text, bannerIndex, true);
 }
 
@@ -275,7 +368,12 @@ export function drawBannerText(r, ctx, text, bannerIndex) {
  * @param {*} text - text to draw
  * @param {*} bannerIndex - plate position to draw, 0=top, incrementing
  */
-export function drawBannerHaloText(r, ctx, text, bannerIndex) {
+export function drawBannerHaloText(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  bannerIndex: number
+): void {
   drawBannerTextComponent(r, ctx, text, bannerIndex, false);
 }
 
@@ -288,19 +386,32 @@ export function drawBannerHaloText(r, ctx, text, bannerIndex) {
  * @param {*} bannerIndex - plate position to draw, 0=top, incrementing
  * @param {*} textComponent - if true, draw the text.  If false, draw the halo
  */
-function drawBannerTextComponent(r, ctx, text, bannerIndex, textComponent) {
+function drawBannerTextComponent(
+  r: ShieldRenderingContext,
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  bannerIndex: number,
+  textComponent: boolean
+): void {
   const bannerPadding = {
-    padding: {
-      top: r.options.bannerPadding,
-      bottom: 0,
-      left: 0,
-      right: 0,
-    },
+    top: r.options.bannerPadding,
+    bottom: 0,
+    left: 0,
+    right: 0,
   };
-  var textLayout = layoutShieldTextFromDef(r, text, bannerPadding, {
+
+  let bannerBounds: Dimension = {
     width: ctx.canvas.width,
     height: r.px(r.options.bannerHeight - r.options.bannerPadding),
-  });
+  };
+
+  let textLayout: TextPlacement = layoutShieldText(
+    r,
+    text,
+    bannerPadding,
+    bannerBounds,
+    bannerLayout
+  );
 
   ctx.font = Gfx.shieldFont(textLayout.fontPx, r.options.shieldFont);
   ctx.textBaseline = "top";
@@ -330,14 +441,14 @@ function drawBannerTextComponent(r, ctx, text, bannerIndex, textComponent) {
   }
 }
 
-export function calculateTextWidth(r, text, fontSize) {
+export function calculateTextWidth(
+  r: ShieldRenderingContext,
+  text: string,
+  fontSize: number
+): number {
   var ctx = r.emptySprite(); //dummy canvas
   ctx.font = Gfx.shieldFont(fontSize, r.options.shieldFont);
   return Math.ceil(ctx.measureText(text).width);
-}
-
-export function drawText(name, options, ref) {
-  return drawTextFunctions[name](options, ref);
 }
 
 //Register text draw functions
@@ -349,7 +460,7 @@ const drawTextFunctions = {};
  * @param {*} name name of the function as referenced by the shield definition
  * @param {*} fxn callback to the implementing function. Takes two parameters, ref and options
  */
-function registerDrawTextFunction(name, fxn) {
+function registerDrawTextFunction(name: string, fxn: TextLayoutScaler): void {
   drawTextFunctions[name] = fxn;
 }
 

--- a/shieldlib/src/shield_text.ts
+++ b/shieldlib/src/shield_text.ts
@@ -4,6 +4,7 @@ import * as Gfx from "./screen_gfx.js";
 import { ShieldRenderingContext } from "./shield_renderer.js";
 import {
   BoxPadding,
+  Dimension,
   ShieldDefinition,
   TextLayout,
   TextLayoutParameters,
@@ -18,11 +19,6 @@ const VerticalAlignment = {
 type VerticalAlignmentType =
   (typeof VerticalAlignment)[keyof typeof VerticalAlignment];
 
-interface Dimension {
-  width: number;
-  height: number;
-}
-
 type TextLayoutScaler = (
   availSize: Dimension,
   textSize: Dimension,
@@ -34,7 +30,7 @@ interface TextTransform {
   valign: VerticalAlignmentType;
 }
 
-interface TextPlacement {
+export interface TextPlacement {
   xBaseline: number;
   yBaseline: number;
   fontPx: number;
@@ -45,10 +41,6 @@ let noPadding: BoxPadding = {
   bottom: 0,
   left: 0,
   right: 0,
-};
-
-let bannerLayout: TextLayout = {
-  constraintFunc: "rectangle",
 };
 
 function ellipseScale(spaceBounds: Dimension, textBounds: Dimension): number {
@@ -157,7 +149,7 @@ function triangleDownTextConstraint(
  * @param {*} maxFontSize - maximum font size
  * @returns JOSN object containing (X,Y) draw position and font size
  */
-function layoutShieldText(
+export function layoutShieldText(
   r: ShieldRenderingContext,
   text: string,
   padding: BoxPadding,
@@ -239,7 +231,7 @@ const defaultDefForLayout: ShieldDefinition = {
     right: 0,
   },
   shapeBlank: {
-    drawFunc: "rectangle",
+    drawFunc: "rect",
     params: {
       fillColor: "white",
       strokeColor: "black",
@@ -341,104 +333,6 @@ function configureShieldText(
   ctx.textAlign = "center";
   ctx.textBaseline = "top";
   ctx.font = Gfx.shieldFont(textLayout.fontPx, r.options.shieldFont);
-}
-
-/**
- * Draw text on a modifier plate above a shield
- *
- * @param {*} r - rendering context
- * @param {*} ctx - graphics context to draw to
- * @param {*} text - text to draw
- * @param {*} bannerIndex - plate position to draw, 0=top, incrementing
- */
-export function drawBannerText(
-  r: ShieldRenderingContext,
-  ctx: CanvasRenderingContext2D,
-  text: string,
-  bannerIndex: number
-): void {
-  drawBannerTextComponent(r, ctx, text, bannerIndex, true);
-}
-
-/**
- * Draw drop shadow for text on a modifier plate above a shield
- *
- * @param {*} r - rendering context
- * @param {*} ctx - graphics context to draw to
- * @param {*} text - text to draw
- * @param {*} bannerIndex - plate position to draw, 0=top, incrementing
- */
-export function drawBannerHaloText(
-  r: ShieldRenderingContext,
-  ctx: CanvasRenderingContext2D,
-  text: string,
-  bannerIndex: number
-): void {
-  drawBannerTextComponent(r, ctx, text, bannerIndex, false);
-}
-
-/**
- * Banners are composed of two components: text on top, and a shadow beneath.
- *
- * @param {*} r - rendering context
- * @param {*} ctx - graphics context to draw to
- * @param {*} text - text to draw
- * @param {*} bannerIndex - plate position to draw, 0=top, incrementing
- * @param {*} textComponent - if true, draw the text.  If false, draw the halo
- */
-function drawBannerTextComponent(
-  r: ShieldRenderingContext,
-  ctx: CanvasRenderingContext2D,
-  text: string,
-  bannerIndex: number,
-  textComponent: boolean
-): void {
-  const bannerPadding = {
-    top: r.options.bannerPadding,
-    bottom: 0,
-    left: 0,
-    right: 0,
-  };
-
-  let bannerBounds: Dimension = {
-    width: ctx.canvas.width,
-    height: r.px(r.options.bannerHeight - r.options.bannerPadding),
-  };
-
-  let textLayout: TextPlacement = layoutShieldText(
-    r,
-    text,
-    bannerPadding,
-    bannerBounds,
-    bannerLayout
-  );
-
-  ctx.font = Gfx.shieldFont(textLayout.fontPx, r.options.shieldFont);
-  ctx.textBaseline = "top";
-  ctx.textAlign = "center";
-
-  if (textComponent) {
-    ctx.fillStyle = r.options.bannerTextColor;
-    ctx.fillText(
-      text,
-      textLayout.xBaseline,
-      textLayout.yBaseline +
-        bannerIndex * r.px(r.options.bannerHeight - r.options.bannerPadding)
-    );
-  } else {
-    ctx.strokeStyle = ctx.shadowColor = r.options.bannerTextHaloColor;
-    ctx.shadowBlur = 0;
-    ctx.lineWidth = r.px(2);
-    ctx.strokeText(
-      text,
-      textLayout.xBaseline,
-      textLayout.yBaseline +
-        bannerIndex * r.px(r.options.bannerHeight - r.options.bannerPadding)
-    );
-
-    ctx.shadowColor = null;
-    ctx.shadowBlur = null;
-  }
 }
 
 export function calculateTextWidth(

--- a/shieldlib/src/types.d.ts
+++ b/shieldlib/src/types.d.ts
@@ -56,3 +56,8 @@ export interface GraphicsFactory {
    */
   pixelRatio(): number;
 }
+
+export interface Dimension {
+  width: number;
+  height: number;
+}

--- a/shieldlib/src/types.ts
+++ b/shieldlib/src/types.ts
@@ -218,3 +218,8 @@ export interface GraphicsFactory {
    */
   pixelRatio(): number;
 }
+
+export interface Dimension {
+  width: number;
+  height: number;
+}

--- a/shieldlib/src/types.ts
+++ b/shieldlib/src/types.ts
@@ -27,6 +27,8 @@ export interface ShieldDefinitionBase {
   banners?: string[];
   /** If true, no next should be drawn on this shield */
   notext?: boolean;
+  /** Specifies the maximum font size of text on this shield */
+  maxFontSize?: number;
 }
 
 /**
@@ -98,12 +100,16 @@ export interface ShapeBlankParams {
   sideAngle?: number;
 }
 
+/** Parameters for laying out text on a shield */
+export interface TextLayoutParameters {
+  /** Specify a corner radius to further constrain placement on rectangular shapes */
+  radius: number;
+}
+
 /** Parameters for laying out text on a shield background */
 export interface TextLayout {
   constraintFunc: string;
-  options?: {
-    radius: number;
-  };
+  options?: TextLayoutParameters;
 }
 
 /**

--- a/shieldlib/src/types.ts
+++ b/shieldlib/src/types.ts
@@ -20,9 +20,9 @@ export interface ShieldDefinitionBase {
   /** Color of text drawn on a shield */
   textColor?: string;
   /** Color of banner text */
-  bannerColor?: string;
+  bannerTextColor?: string;
   /** Color of banner text halo */
-  bannerHaloColor?: string;
+  bannerTextHaloColor?: string;
   /** Padding around shield text */
   padding?: BoxPadding;
   /** Algorithm for expanding text to fill a shield background */

--- a/shieldlib/src/types.ts
+++ b/shieldlib/src/types.ts
@@ -27,11 +27,7 @@ export interface ShieldDefinitionBase {
   banners?: string[];
   /** If true, no next should be drawn on this shield */
   notext?: boolean;
-<<<<<<< HEAD
-  /** Specifies the maximum font size of text on this shield */
-=======
   /** Maximum size of shield text */
->>>>>>> main
   maxFontSize?: number;
 }
 

--- a/shieldlib/src/types.ts
+++ b/shieldlib/src/types.ts
@@ -19,6 +19,10 @@ export type Exclusive<T, U> =
 export interface ShieldDefinitionBase {
   /** Color of text drawn on a shield */
   textColor?: string;
+  /** Color of banner text */
+  bannerColor?: string;
+  /** Color of banner text halo */
+  bannerHaloColor?: string;
   /** Padding around shield text */
   padding?: BoxPadding;
   /** Algorithm for expanding text to fill a shield background */

--- a/shieldlib/tsconfig.json
+++ b/shieldlib/tsconfig.json
@@ -11,5 +11,5 @@
     "experimentalSpecifierResolution": "node"
   },
   "exclude": ["node_modules", "**/*.json"],
-  "include": ["src/**/*.ts", "scripts/**.ts"]
+  "include": ["src/**/*.ts", "scripts/**.ts", "src/shield.js", "src/shield.js"]
 }

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -554,7 +554,11 @@ export function loadShields() {
     notext: true,
   };
 
-  shields["GLCT:Loop"] = banneredShield(shields["GLCT"], ["LOOP"]);
+  shields["GLCT:Loop"] = banneredShield(
+    shields["GLCT"],
+    ["LOOP"],
+    Color.shields.brown
+  );
 
   // Alaska
   shields["US:AK"] = {
@@ -766,7 +770,11 @@ export function loadShields() {
       bottom: 4,
     },
   };
-  shields["US:CA:Business"] = banneredShield(shields["US:CA"], ["BUS"]);
+  shields["US:CA:Business"] = banneredShield(
+    shields["US:CA"],
+    ["BUS"],
+    Color.shields.green
+  );
   shields["US:CA:CR"] = pentagonUpShield(
     3,
     15,
@@ -1171,7 +1179,8 @@ export function loadShields() {
       textColor: Color.shields.green,
       colorLighten: Color.shields.green,
     },
-    ["BUS"]
+    ["BUS"],
+    Color.shields.green
   );
 
   // Maine
@@ -1571,9 +1580,11 @@ export function loadShields() {
     spriteBlank: "shield_us_nj_ace_noref",
     notext: true,
   };
-  shields["US:NJ:ACE:Connector"] = banneredShield(shields["US:NJ:ACE"], [
-    "CONN",
-  ]);
+  shields["US:NJ:ACE:Connector"] = banneredShield(
+    shields["US:NJ:ACE"],
+    ["CONN"],
+    Color.shields.blue
+  );
   shields["US:NJ:GSP"] = {
     spriteBlank: "shield_us_nj_gsp_noref",
     notext: true,
@@ -1618,8 +1629,16 @@ export function loadShields() {
     Color.shields.white,
     Color.shields.black
   );
-  shields["US:NJ:CR:Spur"] = banneredShield(shields["US:NJ:CR"], ["SPUR"]);
-  shields["US:NJ:CR:Truck"] = banneredShield(shields["US:NJ:CR"], ["TRK"]);
+  shields["US:NJ:CR:Spur"] = banneredShield(
+    shields["US:NJ:CR"],
+    ["SPUR"],
+    Color.shields.blue
+  );
+  shields["US:NJ:CR:Truck"] = banneredShield(
+    shields["US:NJ:CR"],
+    ["TRK"],
+    Color.shields.blue
+  );
 
   // New Mexico
   shields["US:NM"] = pillShield(
@@ -2127,9 +2146,21 @@ export function loadShields() {
       bottom: 3,
     },
   };
-  shields["US:SC:Truck"] = banneredShield(shields["US:SC"], ["TRK"]);
-  shields["US:SC:Business"] = banneredShield(shields["US:SC"], ["BUS"]);
-  shields["US:SC:Alternate"] = banneredShield(shields["US:SC"], ["ALT"]);
+  shields["US:SC:Truck"] = banneredShield(
+    shields["US:SC"],
+    ["TRK"],
+    Color.shields.blue
+  );
+  shields["US:SC:Business"] = banneredShield(
+    shields["US:SC"],
+    ["BUS"],
+    Color.shields.blue
+  );
+  shields["US:SC:Alternate"] = banneredShield(
+    shields["US:SC"],
+    ["ALT"],
+    Color.shields.blue
+  );
 
   // South Dakota
   shields["US:SD"] = {
@@ -2266,7 +2297,8 @@ export function loadShields() {
       textColor: Color.shields.brown,
       colorLighten: Color.shields.brown,
     },
-    ["R"]
+    ["R"],
+    Color.shields.brown
   );
   shields["US:TX:NASA"] = banneredShield(shields["US:TX"], ["NASA"]);
 
@@ -2275,22 +2307,31 @@ export function loadShields() {
     Color.shields.blue,
     Color.shields.white
   );
-  shields["US:TX:Express:Toll"] = banneredShield(shields["US:TX:Toll"], [
-    "EXPR",
-  ]);
-  shields["US:TX:Loop:Toll"] = banneredShield(shields["US:TX:Toll"], ["LOOP"]);
-  shields["US:TX:Loop:Express:Toll"] = banneredShield(shields["US:TX:Toll"], [
-    "EXPR",
-    "LOOP",
-  ]);
+  shields["US:TX:Express:Toll"] = banneredShield(
+    shields["US:TX:Toll"],
+    ["EXPR"],
+    Color.shields.blue
+  );
+  shields["US:TX:Loop:Toll"] = banneredShield(
+    shields["US:TX:Toll"],
+    ["LOOP"],
+    Color.shields.blue
+  );
+  shields["US:TX:Loop:Express:Toll"] = banneredShield(
+    shields["US:TX:Toll"],
+    ["EXPR", "LOOP"],
+    Color.shields.blue
+  );
   shields["US:TX:CTRMA"] = roundedRectShield(
     Color.shields.blue,
     Color.shields.yellow,
     Color.shields.white
   );
-  shields["US:TX:CTRMA:Express"] = banneredShield(shields["US:TX:CTRMA"], [
-    "EXPR",
-  ]);
+  shields["US:TX:CTRMA:Express"] = banneredShield(
+    shields["US:TX:CTRMA"],
+    ["EXPR"],
+    Color.shields.blue
+  );
   shields["US:TX:Montgomery:MCTRA"] = homePlateDownShield(
     5,
     Color.shields.blue,
@@ -2375,11 +2416,13 @@ export function loadShields() {
   );
   shields["US:TX:Jackson"] = banneredShield(
     roundedRectShield(Color.shields.blue, Color.shields.white),
-    ["CR"]
+    ["CR"],
+    Color.shields.blue
   );
   shields["US:TX:Andrews:Andrews:Loop"] = banneredShield(
     roundedRectShield(Color.shields.white, Color.shields.blue),
-    ["LOOP"]
+    ["LOOP"],
+    Color.shields.blue
   );
 
   // Utah
@@ -3507,7 +3550,8 @@ export function loadShields() {
       );
       shields[`AU:${state_or_territory}:ALT`] = banneredShield(
         roundedRectShield(Color.shields.green, Color.shields.yellow),
-        ["ALT"]
+        ["ALT"],
+        Color.shields.green
       );
       shields[`AU:${state_or_territory}:ALT_NR`] = banneredShield(
         homePlateDownShield(5, Color.shields.white, Color.shields.black),
@@ -3515,7 +3559,8 @@ export function loadShields() {
       );
       shields[`AU:${state_or_territory}:ALT_S`] = banneredShield(
         fishheadDownShield(Color.shields.blue, Color.shields.white),
-        ["ALT"]
+        ["ALT"],
+        Color.shields.blue
       );
     }
   );

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -509,7 +509,8 @@ export function loadShields() {
       textColor: Color.shields.brown,
       colorLighten: Color.shields.brown,
     },
-    ["HIST"]
+    ["HIST"],
+    Color.shields.brown
   );
 
   // Federal Agencies

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2428,7 +2428,12 @@ export function loadShields() {
       bottom: 2,
     },
   };
-  shields["US:VT:Alternate"] = banneredShield(shields["US:VT"], ["ALT"]);
+  shields["US:VT:Alternate"] = banneredShield(
+    shields["US:VT"],
+    ["ALT"],
+    Color.shields.green
+  );
+
   // Vermont routes town maintained sections - black and white ovals
   shields["US:VT:Town"] = ovalShield(Color.shields.white, Color.shields.black);
 


### PR DESCRIPTION
Fixes #357

This PR allows the style to specify the color of a shield's banner on a per-shield basis.  If set, the color will apply to all banners on a shield. Additionally, the style can specify the halo knockout color on a per-shield basis.

Additionally:
* Banner rendering code was consolidated into a new file, `shield_banner.ts`, for improved code navigation and readability.
* Banner colors were implemented for Vermont alternate routes (green) and US Numbered Highway System historic routes (brown).

Samples:
![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/3254090/24f912c2-e033-47ac-98d0-0b7edd28104f)
![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/3254090/4eb4cb3e-5d73-432c-8a06-a895d2f3d8e2)
