### PR TITLE
Improved render sample config

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,5 +1,4 @@
 import { stat, copyFile, mkdir } from "node:fs/promises";
-import { pathToFileURL } from "node:url";
 
 import esbuild, { BuildContext, BuildOptions } from "esbuild";
 
@@ -26,7 +25,7 @@ const buildWith = async (
   await mkdir("dist", { recursive: true });
 
   await Promise.all(
-    ["index.html", "shieldtest.html", "favicon.ico"].map((f) =>
+    ["index.html", "bare_map.html", "shieldtest.html", "favicon.ico"].map((f) =>
       copyFile(`src/${f}`, `dist/${f}`)
     )
   );
@@ -34,7 +33,11 @@ const buildWith = async (
   const localConfig = await maybeLocalConfig();
 
   const options = {
-    entryPoints: ["src/americana.js", "src/shieldtest.js"],
+    entryPoints: [
+      "src/americana.js",
+      "src/bare_americana.js",
+      "src/shieldtest.js",
+    ],
     format: "esm",
     bundle: true,
     minify: true,

--- a/scripts/generate_samples.ts
+++ b/scripts/generate_samples.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { chromium } from "@playwright/test";
-import { Map } from "maplibre-gl";
+import type * as maplibre from "maplibre-gl";
 
 // Declare a global augmentation for the Window interface
 declare global {

--- a/scripts/generate_samples.ts
+++ b/scripts/generate_samples.ts
@@ -1,12 +1,11 @@
 import fs from "node:fs";
 import { chromium } from "@playwright/test";
+import { Map } from "maplibre-gl";
 
 // Declare a global augmentation for the Window interface
 declare global {
   interface Window {
-    map?: {
-      loaded: () => boolean;
-    };
+    map?: Map;
   }
 }
 
@@ -67,7 +66,7 @@ async function createImage(screenshot: SampleSpecification) {
     });
 
     // Wait for 1.5 seconds on 3D model examples, since this takes longer to load.
-    const waitTime = 1500;
+    const waitTime = 500;
     console.log(`waiting for ${waitTime} ms`);
     await page.waitForTimeout(waitTime);
   } catch (e) {

--- a/scripts/generate_samples.ts
+++ b/scripts/generate_samples.ts
@@ -67,10 +67,6 @@ async function createImage(screenshot: SampleSpecification) {
     await page.waitForFunction(() => window.map?.loaded(), {
       timeout: 3000,
     });
-
-    const waitTime = 500;
-    console.log(`waiting for ${waitTime} ms`);
-    await page.waitForTimeout(waitTime);
   } catch (e) {
     console.log(`Timed out waiting for map load`);
   }

--- a/scripts/generate_samples.ts
+++ b/scripts/generate_samples.ts
@@ -5,7 +5,7 @@ import type * as maplibre from "maplibre-gl";
 // Declare a global augmentation for the Window interface
 declare global {
   interface Window {
-    map?: Map;
+    map?: maplibre.Map;
   }
 }
 

--- a/scripts/generate_samples.ts
+++ b/scripts/generate_samples.ts
@@ -68,7 +68,6 @@ async function createImage(screenshot: SampleSpecification) {
       timeout: 3000,
     });
 
-    // Wait for 1.5 seconds on 3D model examples, since this takes longer to load.
     const waitTime = 500;
     console.log(`waiting for ${waitTime} ms`);
     await page.waitForTimeout(waitTime);

--- a/scripts/generate_samples.ts
+++ b/scripts/generate_samples.ts
@@ -9,21 +9,20 @@ declare global {
   }
 }
 
-type LocationClip = {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-};
-
 type SampleSpecification = {
+  /** location on the map, a string in the format "z/lat/lon" */
   location: string;
+  /** name of this screenshot, used for the filename */
   name: string;
+  /** Size in pixels of the clip */
   viewport: {
+    /** Width of the clip */
     width: number;
+    /** height of the clip */
     height: number;
   };
-  clip: LocationClip;
+  /** If true, include the Americana demo map controls in the screenshot */
+  controls?: boolean;
 };
 
 // Load list of locations to take map screenshots
@@ -57,7 +56,11 @@ for (const screenshot of screenshots) {
 }
 
 async function createImage(screenshot: SampleSpecification) {
-  await page.goto(`http://localhost:1776/#map=${screenshot.location}`);
+  const pagePath: string = screenshot.controls ? "" : "bare_map.html";
+
+  await page.goto(
+    `http://localhost:1776/${pagePath}#map=${screenshot.location}`
+  );
 
   // Wait for map to load, then wait two more seconds for images, etc. to load.
   try {
@@ -77,7 +80,6 @@ async function createImage(screenshot: SampleSpecification) {
     await page.screenshot({
       path: `${sampleFolder}/${screenshot.name}.png`,
       type: "png",
-      clip: screenshot.clip,
     });
     console.log(`Created ${sampleFolder}/${screenshot.name}.png`);
   } catch (err) {

--- a/src/americana.js
+++ b/src/americana.js
@@ -15,7 +15,7 @@ import * as LegendConfig from "./js/legend_config.js";
 import SampleControl from "openmapsamples-maplibre/OpenMapSamplesControl.js";
 import { default as OpenMapTilesSamples } from "openmapsamples/samples/OpenMapTiles/index.js";
 
-import { createMap, loadRTLPlugin } from "./js/map_builder.js";
+import { createMap, loadRTLPlugin, buildStyle } from "./js/map_builder.js";
 
 function upgradeLegacyHash() {
   let hash = window.location.hash.substr(1);
@@ -28,12 +28,15 @@ upgradeLegacyHash();
 
 loadRTLPlugin();
 
-export const map = createMap(
-  window,
-  (shields) => shieldDefLoad(shields),
-  [-94, 40.5],
-  4
-);
+export const map = createMap(window, (shields) => shieldDefLoad(shields), {
+  container: "map", // container id
+  hash: "map",
+  antialias: true,
+  style: buildStyle(),
+  center: [-94, 40.5],
+  zoom: 4,
+  attributionControl: false,
+});
 
 let options = {};
 

--- a/src/americana.js
+++ b/src/americana.js
@@ -3,9 +3,6 @@
 import config from "./config.js";
 
 import * as Label from "./constants/label.js";
-import * as Style from "./js/style.js";
-
-import * as Poi from "./js/poi.js";
 
 import * as languageLabel from "./js/language_label.js";
 
@@ -17,26 +14,8 @@ import LegendControl from "./js/legend_control.js";
 import * as LegendConfig from "./js/legend_config.js";
 import SampleControl from "openmapsamples-maplibre/OpenMapSamplesControl.js";
 import { default as OpenMapTilesSamples } from "openmapsamples/samples/OpenMapTiles/index.js";
-import { URLShieldRenderer } from "@americana/maplibre-shield-generator";
-import {
-  shieldPredicate,
-  networkPredicate,
-  routeParser,
-} from "./js/shield_format.js";
 
-export function buildStyle() {
-  var getUrl = window.location;
-  var baseUrl = (getUrl.protocol + "//" + getUrl.host + getUrl.pathname)
-    //Trim trailing slashes from URL
-    .replace(/\/+$/, "");
-  return Style.build(
-    config.OPENMAPTILES_URL,
-    `${baseUrl}/sprites/sprite`,
-    config.FONT_URL ??
-      "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
-    Label.getLocales()
-  );
-}
+import { createMap, loadRTLPlugin } from "./js/map_builder.js";
 
 function upgradeLegacyHash() {
   let hash = window.location.hash.substr(1);
@@ -47,22 +26,14 @@ function upgradeLegacyHash() {
 }
 upgradeLegacyHash();
 
-maplibregl.setRTLTextPlugin(
-  "https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.min.js",
-  null,
-  true
-);
+loadRTLPlugin();
 
-window.maplibregl = maplibregl;
-export const map = (window.map = new maplibregl.Map({
-  container: "map", // container id
-  hash: "map",
-  antialias: true,
-  style: buildStyle(),
-  center: [-94, 40.5], // starting position [lng, lat]
-  zoom: 4, // starting zoom
-  attributionControl: false,
-}));
+export const map = createMap(
+  window,
+  (shields) => shieldDefLoad(shields),
+  [(-94, 40.5)],
+  4
+);
 
 let options = {};
 
@@ -78,12 +49,6 @@ OpenMapTilesSamples.forEach((sample, i) => {
 });
 
 let legendControl;
-
-const shieldRenderer = new URLShieldRenderer("shields.json", routeParser)
-  .filterImageID(shieldPredicate)
-  .filterNetwork(networkPredicate)
-  .renderOnMaplibreGL(map)
-  .onShieldDefLoad((shields) => shieldDefLoad(shields));
 
 function shieldDefLoad(shields) {
   legendControl = new LegendControl(shields);
@@ -127,19 +92,6 @@ function shieldDefLoad(shields) {
     );
   }
 }
-
-map.on("styleimagemissing", function (e) {
-  switch (e.id.split("\n")[0]) {
-    case "shield":
-      break;
-    case "poi":
-      Poi.missingIconHandler(shieldRenderer, map, e);
-      break;
-    default:
-      console.warn("Image id not recognized:", JSON.stringify(e.id));
-      break;
-  }
-});
 
 function hotReloadMap() {
   map.setStyle(buildStyle());

--- a/src/americana.js
+++ b/src/americana.js
@@ -31,7 +31,7 @@ loadRTLPlugin();
 export const map = createMap(
   window,
   (shields) => shieldDefLoad(shields),
-  [(-94, 40.5)],
+  [-94, 40.5],
   4
 );
 

--- a/src/bare_americana.js
+++ b/src/bare_americana.js
@@ -2,7 +2,7 @@
 
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import { createMap } from "./js/map_builder.js";
+import { createMap, loadRTLPlugin } from "./js/map_builder.js";
 
 loadRTLPlugin();
 

--- a/src/bare_americana.js
+++ b/src/bare_americana.js
@@ -2,16 +2,20 @@
 
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import { createMap, loadRTLPlugin } from "./js/map_builder.js";
+import { createMap, loadRTLPlugin, buildStyle } from "./js/map_builder.js";
 
 loadRTLPlugin();
 
-export const map = createMap(
-  window,
-  (shields) => shieldDefLoad(),
-  [-94, 40.5],
-  4
-);
+export const map = createMap(window, (shields) => shieldDefLoad(), {
+  container: "map", // container id
+  hash: "map",
+  antialias: true,
+  style: buildStyle(),
+  center: [-94, 40.5],
+  zoom: 4,
+  fadeDuration: 0,
+  attributionControl: false,
+});
 
 function shieldDefLoad() {
   if (window.top === window.self) {

--- a/src/bare_americana.js
+++ b/src/bare_americana.js
@@ -1,0 +1,27 @@
+"use strict";
+
+import "maplibre-gl/dist/maplibre-gl.css";
+
+import { createMap } from "./js/map_builder.js";
+
+loadRTLPlugin();
+
+export const map = createMap(
+  window,
+  (shields) => shieldDefLoad(),
+  [-94, 40.5],
+  4
+);
+
+function shieldDefLoad() {
+  if (window.top === window.self) {
+    // if not embedded in an iframe, autofocus canvas to enable keyboard shortcuts
+    map.getCanvas().focus();
+  }
+
+  if (window.LIVE_RELOAD) {
+    new EventSource("/esbuild").addEventListener("change", () =>
+      location.reload()
+    );
+  }
+}

--- a/src/bare_map.html
+++ b/src/bare_map.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>OpenStreetMap Americana</title>
+    <meta
+      name="viewport"
+      content="initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #map {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 100%;
+      }
+    </style>
+    <script type="module" src="bare_americana.js"></script>
+    <link rel="stylesheet" href="americana.css" />
+  </head>
+
+  <body>
+    <div id="map"></div>
+  </body>
+</html>

--- a/src/js/map_builder.ts
+++ b/src/js/map_builder.ts
@@ -16,7 +16,7 @@ import {
 import * as Poi from "../js/poi.js";
 import * as Label from "../constants/label.js";
 import * as Style from "../js/style.js";
-import maplibregl, { LngLatLike, Map, StyleSpecification } from "maplibre-gl";
+import maplibregl, { Map, MapOptions, StyleSpecification } from "maplibre-gl";
 
 export function buildStyle(): StyleSpecification {
   var getUrl = window.location;
@@ -56,19 +56,10 @@ export function loadRTLPlugin(): void {
 export function createMap(
   window,
   shieldDefCallback: (shields: ShieldDefinitions) => void,
-  center: LngLatLike,
-  zoom: number
+  options: MapOptions
 ): Map {
   window.maplibregl = maplibregl;
-  let map: Map = (window.map = new maplibregl.Map({
-    container: "map", // container id
-    hash: "map",
-    antialias: true,
-    style: buildStyle(),
-    center, // starting position [lng, lat]
-    zoom, // starting zoom
-    attributionControl: false,
-  }));
+  let map: Map = (window.map = new maplibregl.Map(options));
 
   const shieldRenderer = new URLShieldRenderer("shields.json", routeParser)
     .filterImageID(shieldPredicate)

--- a/src/js/map_builder.ts
+++ b/src/js/map_builder.ts
@@ -1,0 +1,92 @@
+/**
+ * Functions for assembling user-facing map components
+ */
+import {
+  ShieldDefinitions,
+  URLShieldRenderer,
+} from "@americana/maplibre-shield-generator";
+import config from "../config.js";
+
+import {
+  shieldPredicate,
+  networkPredicate,
+  routeParser,
+} from "../js/shield_format.js";
+
+import * as Poi from "../js/poi.js";
+import * as Label from "../constants/label.js";
+import * as Style from "../js/style.js";
+import maplibregl, { LngLatLike, Map, StyleSpecification } from "maplibre-gl";
+
+export function buildStyle(): StyleSpecification {
+  var getUrl = window.location;
+  var baseUrl = (
+    getUrl.protocol +
+    "//" +
+    getUrl.host +
+    removeAfterLastSlash(getUrl.pathname)
+  )
+    //Trim trailing slashes from URL
+    .replace(/\/+$/, "");
+  return Style.build(
+    config.OPENMAPTILES_URL,
+    `${baseUrl}/sprites/sprite`,
+    config.FONT_URL ??
+      "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
+    Label.getLocales()
+  );
+}
+
+function removeAfterLastSlash(str: string): string {
+  const lastSlashIndex = str.lastIndexOf("/");
+  if (lastSlashIndex === -1) {
+    return str; // return the original string if no slash is found
+  }
+  return str.substring(0, lastSlashIndex + 1);
+}
+
+export function loadRTLPlugin(): void {
+  maplibregl.setRTLTextPlugin(
+    "https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.min.js",
+    null,
+    true
+  );
+}
+
+export function createMap(
+  window,
+  shieldDefCallback: (shields: ShieldDefinitions) => void,
+  center: LngLatLike,
+  zoom: number
+): Map {
+  window.maplibregl = maplibregl;
+  let map: Map = (window.map = new maplibregl.Map({
+    container: "map", // container id
+    hash: "map",
+    antialias: true,
+    style: buildStyle(),
+    center, // starting position [lng, lat]
+    zoom, // starting zoom
+    attributionControl: false,
+  }));
+
+  const shieldRenderer = new URLShieldRenderer("shields.json", routeParser)
+    .filterImageID(shieldPredicate)
+    .filterNetwork(networkPredicate)
+    .renderOnMaplibreGL(map)
+    .onShieldDefLoad(shieldDefCallback);
+
+  map.on("styleimagemissing", function (e) {
+    switch (e.id.split("\n")[0]) {
+      case "shield":
+        break;
+      case "poi":
+        Poi.missingIconHandler(shieldRenderer, map, e);
+        break;
+      default:
+        console.warn("Image id not recognized:", JSON.stringify(e.id));
+        break;
+    }
+  });
+  return map;
+}

--- a/test/sample_locations.json
+++ b/test/sample_locations.json
@@ -6,12 +6,7 @@
       "width": 600,
       "height": 250
     },
-    "clip": {
-      "x": 0,
-      "y": 0,
-      "width": 600,
-      "height": 250
-    }
+    "controls": true
   },
   {
     "location": "13/40.01264/-75.70446",
@@ -19,12 +14,6 @@
     "viewport": {
       "width": 600,
       "height": 600
-    },
-    "clip": {
-      "x": 100,
-      "y": 100,
-      "width": 400,
-      "height": 400
     }
   },
   {
@@ -33,12 +22,6 @@
     "viewport": {
       "width": 600,
       "height": 600
-    },
-    "clip": {
-      "x": 100,
-      "y": 100,
-      "width": 400,
-      "height": 400
     }
   }
 ]


### PR DESCRIPTION
Fixes #944

In #942, we added the ability to generate render samples.  This PR improves the render sample functionality by replacing the "clip" function with a boolean that lets you configure whether or not to include the Americana controls in the sample clip.

This required the `americana.js` to be refactored in order to create "bare" and "fully featured" html versions of the map.  Then, when a user specifies whether to use the controls, the screenshot generator simply invokes either the "bare" or "fully featured" html pages as needed.

I created a "bare" version of `americana.js` and `index.html`, and refactored out common code into `src/js/map_builder.ts`.

One additional improvements to render samples not included in this PR that I would like to explore is an event-driven way to check that the map has loaded, rather than a fixed 500ms delay, which has a timeout risk.

The following files are samples generate with the new version of the script:

![full_window](https://github.com/ZeLonewolf/openstreetmap-americana/assets/3254090/7e76b028-cb45-4198-abc7-121afeb562ad)
![downingtown_alt_trk_bus](https://github.com/ZeLonewolf/openstreetmap-americana/assets/3254090/938212bf-4297-49f4-88b1-a739591bcd65)
![historic_us66_oklahoma](https://github.com/ZeLonewolf/openstreetmap-americana/assets/3254090/fc81b97a-9a44-41c8-9f83-cdc761d48c99)
