### PR TITLE
[demo] use Encode Sans Condensed web font on shields

### DIFF
--- a/shieldlib/src/screen_gfx.ts
+++ b/shieldlib/src/screen_gfx.ts
@@ -4,7 +4,7 @@ import rgba from "color-rgba";
 
 const defaultFontFamily = '"sans-serif-condensed", "Arial Narrow", sans-serif';
 export const shieldFont = (size: number, fontFamily: string) =>
-  `bold ${size}px ${fontFamily || defaultFontFamily}`;
+  `500 ${size}px ${fontFamily || defaultFontFamily}`;
 export const fontSizeThreshold = 12;
 
 // Replaces `sourceVal` with a blend of `lightenVal` and `darkenVal` proportional to the brightness;

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <title>OpenStreetMap Americana</title>
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Encode+Sans+Condensed:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <meta
       name="viewport"
       content="initial-scale=1,maximum-scale=1,user-scalable=no"

--- a/src/index.html
+++ b/src/index.html
@@ -102,6 +102,9 @@
   </head>
 
   <body>
+    <p style="font-family: 'Encode Sans Condensed'; font-weight: 500; visibility: hidden">
+      Invisible text so the font will load early
+    </p>
     <div id="map"></div>
     <div id="attribution-logo"></div>
     <a href="https://github.com/ZeLonewolf/openstreetmap-americana/"

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3753,7 +3753,8 @@ export function loadShields() {
       bannerTextHaloColor: Color.backgroundFill,
       bannerHeight: 9,
       bannerPadding: 1,
-      shieldFont: '"sans-serif-condensed", "Arial Narrow", sans-serif',
+      shieldFont:
+        '"Encode Sans Condensed", "sans-serif-condensed", "Arial Narrow", sans-serif',
       shieldSize: 20,
     },
   };

--- a/src/shieldtest.html
+++ b/src/shieldtest.html
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Overpass:wght@500&display=block"
+      href="https://fonts.googleapis.com/css2?family=Encode+Sans+Condensed:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <style>

--- a/src/shieldtest.html
+++ b/src/shieldtest.html
@@ -47,7 +47,7 @@
       </thead>
     </table>
 
-    <p style="font-family: Overpass; visibility: hidden">
+    <p style="font-family: 'Encode Sans Condensed'; font-weight: 500; visibility: hidden">
       Invisible text so the font will load early
     </p>
     <div id="map" style="display: none"></div>


### PR DESCRIPTION
PR for preview purposes only; see discussion [here](https://github.com/ZeLonewolf/openstreetmap-americana/discussions/954)