### PR TITLE
Bump shieldlib version for release

### DIFF
--- a/shieldlib/package.json
+++ b/shieldlib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@americana/maplibre-shield-generator",
   "description": "Generate highway shields for maplibre-gl-js maps",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "OpenStreetMap Americana Contributors",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
This PR increments the shield library version so we can release it with #965.