### PR TITLE
Remove PR preview files when PRs are closed

### DIFF
--- a/.github/workflows/deploy-pr-checks.yml
+++ b/.github/workflows/deploy-pr-checks.yml
@@ -98,12 +98,14 @@ jobs:
           interval: 500
       - name: Generate Preview text
         run: |
-          echo "## PR Preview:
+          echo "## Live PR Preview:
           * [Map](https://preview.ourmap.us/pr/${{ env.PR_NUM }}/)
           * [Shield Test](https://preview.ourmap.us/pr/${{ env.PR_NUM }}/shieldtest.html)
           * [style.json](https://preview.ourmap.us/pr/${{ env.PR_NUM }}/style.json)
           * [shields.json](https://preview.ourmap.us/pr/${{ env.PR_NUM }}/shields.json)
           * [taginfo.json](https://preview.ourmap.us/pr/${{ env.PR_NUM }}/taginfo.json)
+
+          Live previews are automatically removed once the PR is merged.
 
           ## Sprite Sheets:
 

--- a/.github/workflows/s3-cleanup.yml
+++ b/.github/workflows/s3-cleanup.yml
@@ -1,0 +1,27 @@
+name: Delete S3 Files on PR Merged
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-s3-files:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Remove files from S3
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          aws s3 rm s3://${{ secrets.AWS_S3_BUCKET }}/pr/${PR_NUMBER}/ --recursive


### PR DESCRIPTION
This PR removes preview files from s3 once a PR is merged.  Images in the checks tab will still remain, since those are archived by GitHub's content system, including the image diffs which will be provided by #956. However, links to live previews of merged PRs will become dead.

While s3 is cheap, there's really no need to keep old previews around once a PR has been merged.