### PR TITLE
bump maplibre-shield-generator version to 0.0.5 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5578,7 +5578,7 @@
     },
     "shieldlib": {
       "name": "@americana/maplibre-shield-generator",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "CC0-1.0",
       "dependencies": {
         "@types/node": "^20.8.4",


### PR DESCRIPTION
This commit was just a run of `npm install`.