### PR TITLE
Guard against empty search results

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -202,6 +202,11 @@ function arrowNavigate(e) {
       e.preventDefault();
       break;
     case "Enter":
+      if (liveResults.children.length === 0) {
+        e.preventDefault();
+        return; // Do nothing if no results
+      }
+
       let navIndex = resultSelectIndex < 0 ? 0 : resultSelectIndex;
 
       goToResult(navIndex);


### PR DESCRIPTION
When pressing Enter in the search box, if there are no results (whether still loading or if there are no results) then unwanted things happen: The form submits and the page navigates, or the text box is sadly cleared without any other feedback (and an exception is thrown).

If there are no results, do nothing when Enter is pressed (leaving the typed entry intact).