### PR TITLE
Load map after font load

### DIFF
--- a/src/americana.js
+++ b/src/americana.js
@@ -41,18 +41,7 @@ const initializeMap = async () => {
   });
 };
 
-let map;
-
-if ("fonts" in document) {
-  document.fonts.ready.then(() => {
-    map = initializeMap();
-  });
-} else {
-  // Font Loading API not supported, run the code immediately
-  map = initializeMap();
-}
-
-export { map };
+export const map = await initializeMap();
 
 let options = {};
 

--- a/src/americana.js
+++ b/src/americana.js
@@ -28,15 +28,30 @@ upgradeLegacyHash();
 
 loadRTLPlugin();
 
-export const map = createMap(window, (shields) => shieldDefLoad(shields), {
-  container: "map", // container id
-  hash: "map",
-  antialias: true,
-  style: buildStyle(),
-  center: [-94, 40.5],
-  zoom: 4,
-  attributionControl: false,
-});
+const initializeMap = () => {
+  return createMap(window, (shields) => shieldDefLoad(shields), {
+    container: "map", // container id
+    hash: "map",
+    antialias: true,
+    style: buildStyle(),
+    center: [-94, 40.5],
+    zoom: 4,
+    attributionControl: false,
+  });
+};
+
+let map;
+
+if ("fonts" in document) {
+  document.fonts.ready.then(() => {
+    map = initializeMap();
+  });
+} else {
+  // Font Loading API not supported, run the code immediately
+  map = initializeMap();
+}
+
+export { map };
 
 let options = {};
 

--- a/src/americana.js
+++ b/src/americana.js
@@ -28,7 +28,8 @@ upgradeLegacyHash();
 
 loadRTLPlugin();
 
-const initializeMap = () => {
+const initializeMap = async () => {
+  await document.fonts?.ready;
   return createMap(window, (shields) => shieldDefLoad(shields), {
     container: "map", // container id
     hash: "map",

--- a/src/bare_americana.js
+++ b/src/bare_americana.js
@@ -20,18 +20,7 @@ const initializeMap = async () => {
   });
 };
 
-let map;
-
-if ("fonts" in document) {
-  document.fonts.ready.then(() => {
-    map = initializeMap();
-  });
-} else {
-  // Font Loading API not supported, run the code immediately
-  map = initializeMap();
-}
-
-export { map };
+export const map = await initializeMap();
 
 function shieldDefLoad() {
   if (window.top === window.self) {

--- a/src/bare_americana.js
+++ b/src/bare_americana.js
@@ -6,16 +6,31 @@ import { createMap, loadRTLPlugin, buildStyle } from "./js/map_builder.js";
 
 loadRTLPlugin();
 
-export const map = createMap(window, (shields) => shieldDefLoad(), {
-  container: "map", // container id
-  hash: "map",
-  antialias: true,
-  style: buildStyle(),
-  center: [-94, 40.5],
-  zoom: 4,
-  fadeDuration: 0,
-  attributionControl: false,
-});
+const initializeMap = () => {
+  return createMap(window, (shields) => shieldDefLoad(), {
+    container: "map", // container id
+    hash: "map",
+    antialias: true,
+    style: buildStyle(),
+    center: [-94, 40.5],
+    zoom: 4,
+    fadeDuration: 0,
+    attributionControl: false,
+  });
+};
+
+let map;
+
+if ("fonts" in document) {
+  document.fonts.ready.then(() => {
+    map = initializeMap();
+  });
+} else {
+  // Font Loading API not supported, run the code immediately
+  map = initializeMap();
+}
+
+export { map };
 
 function shieldDefLoad() {
   if (window.top === window.self) {

--- a/src/bare_americana.js
+++ b/src/bare_americana.js
@@ -6,8 +6,9 @@ import { createMap, loadRTLPlugin, buildStyle } from "./js/map_builder.js";
 
 loadRTLPlugin();
 
-const initializeMap = () => {
-  return createMap(window, (shields) => shieldDefLoad(), {
+const initializeMap = async () => {
+  await document.fonts?.ready;
+  return createMap(window, (shields) => shieldDefLoad(shields), {
     container: "map", // container id
     hash: "map",
     antialias: true,

--- a/src/bare_map.html
+++ b/src/bare_map.html
@@ -27,13 +27,6 @@
   </head>
 
   <body>
-    <p style="
-            font-family: 'Noto Sans Condensed';
-            font-weight: 500;
-            visibility: hidden;
-          ">
-      Invisible text so the font will load early
-    </p>
     <div id="map"></div>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -98,15 +98,6 @@
   </head>
 
   <body>
-    <p
-      style="
-        font-family: 'Noto Sans Condensed';
-        font-weight: 500;
-        visibility: hidden;
-      "
-    >
-      Invisible text so the font will load early
-    </p>
     <div id="map"></div>
     <div id="attribution-logo"></div>
     <a href="https://github.com/ZeLonewolf/openstreetmap-americana/"


### PR DESCRIPTION
This PR waits to load maplibre until web fonts have been downloaded.  The allows the shield library to generate shield sprites only after the necessary fonts are in place.