### PR TITLE
Add VT Truck route support

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2490,6 +2490,11 @@ export function loadShields() {
     ["ALT"],
     Color.shields.green
   );
+  shields["US:VT:Truck"] = banneredShield(
+    shields["US:VT"],
+    ["TRK"],
+    Color.shields.green
+  );
 
   // Vermont routes town maintained sections - black and white ovals
   shields["US:VT:Town"] = ovalShield(Color.shields.white, Color.shields.black);

--- a/src/shieldtest.js
+++ b/src/shieldtest.js
@@ -214,6 +214,7 @@ let networks = [
   "US:LA:Business",
   "US:MD:Business",
   "US:VT:Alternate",
+  "US:VT:Truck",
   "US:MO:Spur",
   "US:NC:Bypass",
   "US:ND:Alternate",


### PR DESCRIPTION
I added the first `network=US:VT:Truck` route.  Here's the definition to support shield rendering for it.  
https://www.openstreetmap.org/relation/16617445
https://www.mapillary.com/app/?pKey=905552603342258


