### PR TITLE
Replaces old dot_city icon reference with current place_dot

### DIFF
--- a/src/layer/road_label.js
+++ b/src/layer/road_label.js
@@ -157,7 +157,7 @@ export const bridgeSpacer = {
   layout: {
     "symbol-placement": "line",
     "symbol-spacing": 2,
-    "icon-image": "dot_city",
+    "icon-image": "place_dot",
     "icon-allow-overlap": true,
     "icon-size": 0.1,
   },

--- a/src/layer/transportation_label.js
+++ b/src/layer/transportation_label.js
@@ -184,7 +184,7 @@ export const bridgeSpacer = {
   layout: {
     "symbol-placement": "line",
     "symbol-spacing": 2,
-    "icon-image": "dot_city",
+    "icon-image": "place_dot",
     "icon-allow-overlap": true,
     "icon-size": 0.1,
   },


### PR DESCRIPTION
Visually this is a no-op, as the extant `dot_city` references are set to `opacity: 0` and just serve as bridge label buffers. But the missing image warnings in the console were bugging me, so this fixes them.