### PR TITLE
Plumb StyleImageMetadata through to the shield library

### DIFF
--- a/shieldlib/src/shield.js
+++ b/shieldlib/src/shield.js
@@ -3,11 +3,7 @@
 import * as ShieldText from "./shield_text";
 import * as ShieldDraw from "./shield_canvas_draw";
 import * as Gfx from "./screen_gfx";
-import {
-  drawBanners,
-  drawBannerHalos,
-  getBannerCount,
-} from "./shield_banner";
+import { drawBanners, drawBannerHalos, getBannerCount } from "./shield_banner";
 
 function compoundShieldSize(r, dimension, bannerCount) {
   return {
@@ -185,7 +181,7 @@ function storeSprite(r, id, ctx, update) {
       height: ctx.canvas.height,
       data: imgData.data,
     },
-    r.px(1),
+    { pixelRatio: r.px(1) },
     update
   );
 }

--- a/shieldlib/src/shield_renderer.d.ts
+++ b/shieldlib/src/shield_renderer.d.ts
@@ -1,4 +1,9 @@
-import { Map, MapStyleImageMissingEvent, StyleImage } from "maplibre-gl";
+import {
+  Map,
+  MapStyleImageMissingEvent,
+  StyleImage,
+  StyleImageMetadata,
+} from "maplibre-gl";
 import {
   Bounds,
   DebugOptions,
@@ -62,6 +67,11 @@ export declare class InMemorySpriteRepository implements SpriteRepository {
   sprites: {};
   getSprite(spriteID: string): StyleImage;
   hasSprite(spriteID: string): boolean;
-  putSprite(spriteID: string, image: ImageData): void;
+  putSprite(
+    spriteID: string,
+    image: ImageData,
+    options: StyleImageMetadata,
+    update: boolean
+  ): void;
 }
 export {};

--- a/shieldlib/src/shield_renderer.ts
+++ b/shieldlib/src/shield_renderer.ts
@@ -2,6 +2,7 @@ import {
   Map as MapLibre,
   MapStyleImageMissingEvent,
   StyleImage,
+  StyleImageMetadata,
 } from "maplibre-gl";
 import {
   Bounds,
@@ -66,14 +67,14 @@ class MaplibreGLSpriteRepository implements SpriteRepository {
   putSprite(
     spriteID: string,
     image: ImageData,
-    pixelRatio: number,
+    options: StyleImageMetadata,
     update: boolean
   ): void {
     if (update) {
       this.map.removeImage(spriteID);
       this.map.addImage(spriteID, image);
     } else {
-      this.map.addImage(spriteID, image, { pixelRatio: pixelRatio });
+      this.map.addImage(spriteID, image, options);
     }
   }
 }

--- a/shieldlib/src/types.ts
+++ b/shieldlib/src/types.ts
@@ -1,4 +1,4 @@
-import { StyleImage } from "maplibre-gl";
+import { StyleImage, StyleImageMetadata } from "maplibre-gl";
 
 /** Defines the set of routes that a shield applies to */
 export interface RouteDefinition {
@@ -138,7 +138,7 @@ export interface SpriteConsumer {
   putSprite(
     spriteID: string,
     image: ImageData,
-    pixelRatio: number,
+    options: StyleImageMetadata,
     update: boolean
   ): void;
 }


### PR DESCRIPTION
Fixes #1004

This PR adds internal plumbing for the shield library to accept more robust sprite inputs by passing in a StyleImageMetata object, instead of just a pixel ratio.  This will ultimately be needed for any shield library user that might want to use and SDF.

Additional work beyond this in `shield.js` would be needed to make use of other options in StyleImageMetadata.

This is a no-op change that reduces a little technical debt.