### PR TITLE
Add shields for Ring of Antwerp, Belgium

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3196,6 +3196,10 @@ export function loadShields() {
     shields["BE:B-road"] =
     shields["BE:R-road"] =
       roundedRectShield(Color.shields.white, Color.shields.black);
+  shields["BE:VLG:Ring_Antwerpen"] = roundedRectShield(
+    Color.shields.yellow,
+    Color.shields.black
+  );
 
   // Bulgaria
   shields["bg:motorway"] = roundedRectShield(


### PR DESCRIPTION
Renders the yellow shields used for Ring 1 and Ring 2 of Antwerp, Belgium. This system is unique in Belgium and is explained [here](https://www.verkeerscentrum.be/veelgestelde-vragen/wat-betekenen-de-cijfercodes-r1-r2-ring-1-en-ring-2-op-de-ring-van-antwerpen) (includes road sign example).

![Screenshot](https://github.com/ZeLonewolf/openstreetmap-americana/assets/489845/6747c7bb-e950-4b34-9a33-853b9f37855b)
