### PR TITLE
Add shields for Aruban road network

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3392,10 +3392,10 @@ export function loadShields() {
     34
   );
 
-  // Netherlands
+  // Netherlands, Kingdom of the (European Netherlands, Aruba, and Curacao)
   // https://wiki.openstreetmap.org/wiki/The_Netherlands_road_network
   shields["NL:A"] = roundedRectShield(Color.shields.red, Color.shields.white);
-  shields["NL:N"] = roundedRectShield(
+  shields["NL:N"] = shields["AW:route"] = roundedRectShield(
     Color.shields.yellow,
     Color.shields.black
   );
@@ -3417,7 +3417,7 @@ export function loadShields() {
     "Rotterdam",
     "Zaanstad",
   ].forEach((city) => (shields[`NL:S:${city}`] = nlCityRoute));
-  shields["NL:binnenstedelijke_ring"] = nlCityRoute; // for both Netherlands and Curacao
+  shields["NL:binnenstedelijke_ring"] = nlCityRoute; // for both European Netherlands and Curacao
   [
     "Ommen",
     "Schouwen",


### PR DESCRIPTION
This adds black-on-yellow shields for road routes on Aruba. The A- or B-suffix depends on the direction of travel.

Sample road signs:
* https://commons.wikimedia.org/wiki/File:Road_infrastructure_in_Aruba.jpeg
* https://commons.wikimedia.org/wiki/File:Road_infrastructure_in_Aruba_16_59_50_641000.jpeg

(Older road signs use white-on-blue instead of black-on-yellow.)