### PR TITLE
Remove z4 park layer

### DIFF
--- a/src/layer/park.js
+++ b/src/layer/park.js
@@ -13,6 +13,7 @@ export const fill = {
     "fill-color": Color.parkFill,
   },
   source: "openmaptiles",
+  minzoom: 5,
   "source-layer": "park",
 };
 
@@ -24,6 +25,7 @@ export const outline = {
     "line-color": Color.parkOutline,
   },
   source: "openmaptiles",
+  minzoom: 5,
   metadata: {},
   "source-layer": "park",
 };


### PR DESCRIPTION
Follow-on from #1019 

This PR removes z4 rendering of the park layer until we can get a fix that doesn't conflate aboriginal_lands with parks at that zoom.