### PR TITLE
Change E-road shields to variable-width

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3146,9 +3146,7 @@ export function loadShields() {
   // EUROPE
   shields["e-road"] = roundedRectShield(
     Color.shields.green,
-    Color.shields.white,
-    Color.shields.white,
-    34
+    Color.shields.white
   );
 
   // Austria

--- a/test/sample_locations.json
+++ b/test/sample_locations.json
@@ -47,5 +47,13 @@
       "width": 400,
       "height": 400
     }
+  },
+  {
+    "location": "13.25/49.552/5.8107",
+    "name": "europe_e-road_routes",
+    "viewport": {
+      "width": 400,
+      "height": 400
+    }
   }
 ]


### PR DESCRIPTION
This removes the fixed 34px width for E-road shields.

Sample road signs showing the varying width of E-road shields depending on the number of digits:

* [Belgium](https://www.mapillary.com/app/?lat=51.20329868920501&lng=4.569039075956766&z=19.9&pKey=291857679060823&focus=photo)
* [France](https://www.mapillary.com/app/?lat=43.519699704724644&lng=5.434783935296764&z=14.1584486628159&pKey=838597040065990&focus=photo)
* [Netherlands](https://www.mapillary.com/app/?lat=52.162231516367&lng=5.420221004790392&z=17&pKey=2590843231212073&focus=photo)
* [Spain](https://www.mapillary.com/app/?lat=43.215992&lng=-2.8988025&z=8.255214393816056&pKey=625204049657591&focus=photo)
* [Sweden](https://www.mapillary.com/app/?lat=55.54692239971399&lng=12.993075773131977&z=17.49267533763249&pKey=1116709008849252&focus=photo)