### PR TITLE
White shield border for Irish N-road and British A-road

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3320,6 +3320,7 @@ export function loadShields() {
 
   shields["omt-ie-national"] = roundedRectShield(
     Color.shields.green,
+    Color.shields.white,
     Color.shields.yellow
   );
 
@@ -3535,6 +3536,7 @@ export function loadShields() {
 
   shields["omt-gb-trunk"] = roundedRectShield(
     Color.shields.green,
+    Color.shields.white,
     Color.shields.yellow
   );
 


### PR DESCRIPTION
Irish N-roads and British A-roads, both with yellow-on-green shields, generally do not seem to have any shield border within destination signs. However, signs suggest that if there is a border, it should be white:

* [Irish N-road sign sample](https://www.mapillary.com/app/?lat=53.355769100001&lng=-6.3926856&z=17&pKey=841496307297972&focus=photo&x=0.687467098276902&y=0.4133253424463917&zoom=2.554162825690064)
* [British A-road sign sample](https://www.mapillary.com/app/?lat=51.104817954438005&lng=1.1717271642997957&z=16.374853020821515&pKey=2983916928521417&focus=photo&x=0.27545281307019026&y=0.4648809970842719&zoom=1.0961538461538458)

The shields on Wikimedia Commons also have white borders:

* [Irish N-road shields](https://commons.wikimedia.org/wiki/Category:Diagrams_of_national_road_number_signs_of_Ireland)
* [British A-road shields](https://commons.wikimedia.org/wiki/Category:SVG_diagrams_of_route_signs_in_the_United_Kingdom)

This PR therefore changes the shield border colour from yellow to white.