### PR TITLE
Add post offices

### DIFF
--- a/icons/poi_envelope.svg
+++ b/icons/poi_envelope.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 2,4 v 1 l 8,5 8,-5 V 4 Z m 0,3 v 9 H 18 V 7 l -8,5 z" style="stroke:#fff;stroke-width:2;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stroke-linejoin:miter;stroke-linecap:round"/>
+</svg>

--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -488,6 +488,14 @@
       "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/icons/poi_town_hall.svg"
     },
     {
+      "key": "amenity",
+      "value": "post_office",
+      "object_types": ["node", "area"],
+      "description": "Post offices are marked by an icon representing an envelope.",
+      "doc_url": "https://openmaptiles.org/schema/#poi",
+      "icon_url": "https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/icons/poi_envelope.svg"
+    },
+    {
       "key": "tourism",
       "value": "guest_house",
       "object_types": ["node", "area"],

--- a/src/layer/poi.js
+++ b/src/layer/poi.js
@@ -140,6 +140,14 @@ var iconDefs = {
     color: Color.poi.infrastructure,
     description: "Police station",
   },
+  post_office: {
+    classes: {
+      post: ["post_office"],
+    },
+    sprite: "poi_envelope",
+    color: Color.poi.infrastructure,
+    description: "Post office",
+  },
   pow_buddhist: {
     classes: {
       place_of_worship: ["buddhist"],
@@ -331,6 +339,7 @@ export const poi = {
         "college",
         "library",
         "townhall",
+        ...getSubclasses(iconDefs.post_office),
         ...getSubclasses(iconDefs.pow_christian),
         ...getSubclasses(iconDefs.pow_buddhist),
         ...getSubclasses(iconDefs.pow_hindu),
@@ -361,6 +370,7 @@ export const poi = {
         "museum",
         "police",
         ...getSubclasses(iconDefs.fuel),
+        ...getSubclasses(iconDefs.post_office),
         ...getSubclasses(iconDefs.pow_buddhist),
         ...getSubclasses(iconDefs.pow_christian),
         ...getSubclasses(iconDefs.pow_hindu),


### PR DESCRIPTION
Makes progress on #435 and #692. Renders post offices (`amenity=post_office`, aka in OMT `class=post` + `subclass=post_office`) with an envelope icon. This is quite similar to the [Carto](https://github.com/gravitystorm/openstreetmap-carto/blob/master/symbols/amenity/post_office.svg) and [Maki](https://github.com/mapbox/maki/blob/main/icons/post.svg) approaches.
<img width="162" alt="Screen Shot 2024-02-18 at 6 07 04 PM" src="https://github.com/ZeLonewolf/openstreetmap-americana/assets/58491489/34231ee1-9cb8-483a-a1a4-fb6a0f5de745">

I've sometimes seen American maps render an envelope with the bottom folds as well, making more of an 'x' shape. See e.g. [the NPS](https://www.nps.gov/npgallery/GetAsset/cd253093-6813-471e-9d16-042c2a373a97) or [the MUTCD](https://wiki.openstreetmap.org/wiki/File:MUTCD_RS-026.svg). I'm open to this style of envelope, but in the end I didn't think that the extra visual clutter made it that much more identifiable.

The icon comes in at z15, the same as other 'community anchor' POIs. I went with blue color, since I see post offices as more of a community service provider than a consumer destination.
<img width="1073" alt="Screen Shot 2024-02-18 at 9 13 48 AM" src="https://github.com/ZeLonewolf/openstreetmap-americana/assets/58491489/1274de6f-081c-40ed-b08c-1b6472716f29">

Unfortunately, in my opinion, there is no information in the tiles we can reliably use to distinguish public post offices (like the USPS) from private ones (UPS Stores, etc), as mentioned in https://github.com/ZeLonewolf/openstreetmap-americana/issues/435#issue-1275881342. So this PR renders them both identically, although I see distinguishing them in the future as desirable. This would be a good use case for using `operator:type` or `operator:wikidata` were those tags to be exposed in OMT, similar to what's been discussed more broadly for supporting brand logos (#809).
<img width="474" alt="Screen Shot 2024-02-18 at 9 14 19 AM" src="https://github.com/ZeLonewolf/openstreetmap-americana/assets/58491489/53d05702-91db-4f03-ba94-79aead06feb9">
