### PR TITLE
add shields for Sierra County, CA and Washington County, UT

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -775,11 +775,14 @@ export function loadShields() {
     ["BUS"],
     Color.shields.green
   );
-  shields["US:CA:CR"] = pentagonUpShield(
-    3,
-    15,
-    Color.shields.blue,
-    Color.shields.yellow
+  ["CR", "Sierra"].forEach(
+    (county) =>
+      (shields[`US:CA:${county}`] = pentagonUpShield(
+        3,
+        15,
+        Color.shields.blue,
+        Color.shields.yellow
+      ))
   );
   shields["US:CA:Mendocino"] = roundedRectShield(
     Color.shields.green,
@@ -1141,8 +1144,8 @@ export function loadShields() {
     "Webster",
     "Winn",
   ].forEach(
-    (county) =>
-      (shields[`US:LA:${county}`] = pentagonUpShield(
+    (parish) =>
+      (shields[`US:LA:${parish}`] = pentagonUpShield(
         3,
         15,
         Color.shields.blue,
@@ -2484,11 +2487,14 @@ export function loadShields() {
       bottom: 5,
     },
   };
-  shields["US:UT:Wayne"] = pentagonUpShield(
-    3,
-    15,
-    Color.shields.blue,
-    Color.shields.yellow
+  ["Wayne", "Washington"].forEach(
+    (county) =>
+      (shields[`US:UT:${county}`] = pentagonUpShield(
+        3,
+        15,
+        Color.shields.blue,
+        Color.shields.yellow
+      ))
   );
 
   // Virginia


### PR DESCRIPTION
This PR adds blue pentagonal shields to [Sierra County, California](https://www.bing.com/maps?cp=39.44553%7E-120.096336&lvl=14.1&pi=-13.3&style=x&dir=13) and [Washington County, Utah](https://www.bing.com/maps?cp=37.001593%7E-113.915317&lvl=20.1&pi=-3&style=x&dir=48.1).

Also changes `county` to `parish` wrt Louisiana. I can't believe we let this through!