### PR TITLE
add Mississippi Scenic Route shields

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1424,6 +1424,11 @@ export function loadShields() {
 
   // Mississippi
   shields["US:MS"] = ovalShield(Color.shields.white, Color.shields.black);
+  shields["US:MS:Scenic"] = banneredShield(
+    ovalShield(Color.shields.white, Color.shields.blue),
+    ["SCEN"],
+    Color.shields.blue
+  );
   [
     "Alcorn",
     "Calhoun",


### PR DESCRIPTION
Scenic Routes of Mississippi have shields based on the State Route design, but blue instead of black, and with a "Scenic" banner.

The "SCEN" banner chosen here could potentially be omitted, but I don't think the blue and black contrast well enough to make the distinction clear without it.

[example](https://preview.ourmap.us/pr/1045/#map=12.09/34.39986/-89.82934)

![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/1732117/eef537f0-8e8a-4ae8-bf8c-bee0e3a3e8b1)