### PR TITLE
update shield defs that use refsByName

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3739,23 +3739,13 @@ export function loadShields() {
   };
 
   shields["US:KY:Parkway"].refsByName = {
-    // FIXME: This object contains both spelled-out and abbreviated road
-    // names to accommodate both the abbreviated names from OpenMapTiles and
-    // the spelled-out names from Planetiler.
-    // https://github.com/onthegomap/planetiler/issues/14
     "Audubon Parkway": "AU",
     "Bluegrass Parkway": "BG",
-    "Bluegrass Pkwy": "BG",
     "Cumberland Parkway": "LN",
-    "Cumberland Pkwy": "LN",
     "Hal Rogers Parkway": "HR",
-    "Hal Rogers Pkwy": "HR",
     "Mountain Parkway": "MP",
-    "Mountain Pkwy": "MP",
     "Purchase Parkway": "JC",
-    "Purchase Pkwy": "JC",
     "Western Kentucky Parkway": "WK",
-    "Western Kentucky Pkwy": "WK",
   };
 
   shields["US:CT:Parkway"].overrideByName = {
@@ -3795,15 +3785,13 @@ export function loadShields() {
   };
 
   shields["US:NY:Parkway"].refsByName = {
-    "Bear Mountain Parkway": "BMP",
-    "Bronx and Pelham Parkway": "PP",
+    "Bear Mountain State Parkway": "BMP",
     "Bronx River Parkway": "BRP",
     "Cross County Parkway": "CCP",
     "Hutchinson River Parkway": "HRP",
     "Korean War Veterans Parkway": "KWVP",
     "Mosholu Parkway": "MP",
     "Niagara Scenic Parkway": "NSP",
-    "Pelham Parkway": "PP",
     "Saw Mill River Parkway": "SMP",
     "Sprain Brook Parkway": "SBP",
     "Taconic State Parkway": "TSP",
@@ -3823,14 +3811,7 @@ export function loadShields() {
     "Fort Bend Westpark Tollway": "WPT",
   };
   shields["US:TX:Harris:HCTRA"].refsByName = {
-    "East Sam Houston Tollway North": "SHT",
-    "East Sam Houston Tollway South": "SHT",
-    "North Sam Houston Tollway East": "SHT",
-    "North Sam Houston Tollway West": "SHT",
-    "South Sam Houston Tollway East": "SHT",
-    "South Sam Houston Tollway West": "SHT",
-    "West Sam Houston Tollway North": "SHT",
-    "West Sam Houston Tollway South": "SHT",
+    "Sam Houston Tollway": "SHT",
     "Fort Bend Toll Road": "FBTR",
     "Hardy Toll Road": "HTR",
     "Tomball Tollway": "TBT",


### PR DESCRIPTION
The Sam Houston Tollway and the Bear Mountain Parkway began displaying blank shields after #1032. This updates the shield defs to match the name found in each route relation. Several outdated definitions for Kentucky and New York parkways are removed as well.