### PR TITLE
Force MacOS CI runner to x86_64

### DIFF
--- a/.github/workflows/test-build-mac-x64.yml
+++ b/.github/workflows/test-build-mac-x64.yml
@@ -1,4 +1,4 @@
-name: Test Build (MacOS)
+name: Test Build (MacOS x86_64)
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3

--- a/.github/workflows/test-build-macos-13.yml
+++ b/.github/workflows/test-build-macos-13.yml
@@ -1,4 +1,4 @@
-name: Test Build (MacOS x86_64)
+name: Test Build (MacOS 13)
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest-large
+    runs-on: macos-13
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR forces the MacOS runner to x64 architecture. #1051 tracks an issue to add arm64 support.