### PR TITLE
Restore OpenMapTiles "bleeding edge" endpoint

### DIFF
--- a/src/configs/config.aws.js
+++ b/src/configs/config.aws.js
@@ -3,7 +3,7 @@
 /*
 Planetiler tile server, hosted at AWS
 */
-const OPENMAPTILES_URL = "https://tile.ourmap.us/data/omt_3_15.json";
+const OPENMAPTILES_URL = "https://tile.ourmap.us/data/v3.json";
 
 /*
 The following two variables override the color of the bounding box and halo of


### PR DESCRIPTION
This PR restores the tile server endpoint to the 4-hour update bleeding-edge OpenMapTiles