### PR TITLE
Allow hard-coded ref values in shield definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,6 +316,8 @@ Additionally, **`refsByName`** is an object mapping way names to text that can b
 
 When using `overrideByRef` or `refsByName`, make sure to add a line to the Special Cases section of this page explaining why it is necessary, as they are only intended for use in special cases.
 
+In the case where all routes in a network should be drawn with the same shield text, set the text value in `ref`.
+
 ### Banners
 
 The shield definition supports a property **`banners`** which accepts an array of text strings which will be drawn atop each shield, in 10px height increments. This is used in cases where additional text is needed to differentiate shields with a common symbology, for example for [special routes of the US Numbered Highway System](https://en.wikipedia.org/wiki/List_of_special_routes_of_the_United_States_Numbered_Highway_System):

--- a/shieldlib/README.md
+++ b/shieldlib/README.md
@@ -182,6 +182,7 @@ You should create one definition entry for each network. The entry key must matc
 - **`colorDarken`**: specify that the shield artwork should be darkened by the specified color. This means that white areas will be recolor with this color and black areas will remain the same. Alpha values will remain unmodified.
 - **`overrideByRef`**: specify that a specific `ref` within a `network` should have different shield properties than other routes in the network, with one entry per special-case `ref`. Supported options are **`spriteBlank`**, **`textColor`**, and **`colorLighten`**.
 - **`refsByName`**: specify that a `name` with the specified key should be treated as a `ref` with the specified value.
+- **`ref`**: specify that all shields in this network should be drawn with the specified `ref` value.
 - **`overrideByName`**: specify that particular `name` should use a specific **`spriteBlank`** which differs from the rest of the network.
 
 ### Handling special case networks

--- a/shieldlib/src/shield.ts
+++ b/shieldlib/src/shield.ts
@@ -78,7 +78,7 @@ function getDrawFunc(shieldDef: ShieldDefinition): (r: ShieldRenderingContext, c
       );
   }
   console.warn(`Draw function not defined in:\n${shieldDef}`);
-  return (r: ShieldRenderingContext, ctx: CanvasRenderingContext2D, ref: string) => {};
+  return (r: ShieldRenderingContext, ctx: CanvasRenderingContext2D, ref: string) => { };
 }
 
 function getDrawHeight(r: ShieldRenderingContext, shieldDef: ShieldDefinition): number {
@@ -159,6 +159,9 @@ export function storeNoShield(r: ShieldRenderingContext, id: string): void {
 
 function refForDefs(routeDef: RouteDefinition, shieldDef: ShieldDefinition) {
   // Handle special case for manually-applied abbreviations
+  if (shieldDef.ref) {
+    return shieldDef.ref;
+  }
   if (
     shieldDef.refsByName &&
     routeDef.name &&
@@ -216,6 +219,7 @@ function getShieldDef(shields: ShieldDefinitions, routeDef: RouteDefinition): Sh
   if (
     !isValidRef(ref) &&
     !shieldDef.notext &&
+    !shieldDef.ref &&
     !(shieldDef.refsByName && routeDef.name)
   ) {
     return null;

--- a/shieldlib/src/types.ts
+++ b/shieldlib/src/types.ts
@@ -37,6 +37,8 @@ export interface ShieldDefinitionBase {
   maxFontSize?: number;
   /** ref values that can be mapped from names */
   refsByName?: Map<string, string>;
+  /** hard-code the shield text to this value */
+  ref?: string;
   /** Transpose numbering system, for example "roman" for Roman numerals */
   numberingSystem?: string;
   /** Reflect this shield vertically */


### PR DESCRIPTION
For cases like #1068, allow for a network to have a hard-coded ref value.

I tested this in the most American way I know how, by making all US highways Route 66:

![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/3254090/03686a12-5c89-40f8-9661-f08082781706)
