### PR TITLE
Upgrade the lint GitHub action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,12 +18,19 @@ jobs:
           # This is important to fetch the changes to the previous commit
           fetch-depth: 0
 
-      - name: Prettify code
-        uses: creyD/prettier_action@v3.3 # https://github.com/creyD/prettier_action
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
         with:
-          dry: true
-          prettier_options: --write .
-          # Setting only_changed to false picks up new files
-          only_changed: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          node-version: '16' # Specify the Node.js version
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Prettier
+        id: prettier
+        run: npx prettier --check .
+        continue-on-error: false
+
+      - name: Check if Prettier failed
+        if: steps.prettier.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18' # Specify the Node.js version
+          node-version: "18" # Specify the Node.js version
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16' # Specify the Node.js version
+          node-version: '18' # Specify the Node.js version
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
This PR upgrades the "lint" job to the latest version of prettier, forces Node 18, and ensures that the action fails on an error condition.