### PR TITLE
Move text on US interstate shields down 1 pixel

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -451,7 +451,7 @@ export function loadShields() {
       left: 4,
       right: 4,
       top: 6,
-      bottom: 4,
+      bottom: 5,
     },
   };
 

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -450,8 +450,8 @@ export function loadShields() {
     padding: {
       left: 4,
       right: 4,
-      top: 5,
-      bottom: 5,
+      top: 6,
+      bottom: 4,
     },
   };
 


### PR DESCRIPTION
The numbers on Interstate shields bump into the crown, I think they look a little nicer bumped down a pixel:

![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/3254090/f1a43a2f-ebe0-4e5c-9aaf-5855d26ad6d3)
