### PR TITLE
Fix copy/paste typo on compressed JSON CI comparison

### DIFF
--- a/scripts/stats_compare.js
+++ b/scripts/stats_compare.js
@@ -32,7 +32,7 @@ const gzSizeRow = mdCompareRow(
   "Compressed StyleJSON Size (b)",
   stats1.gzipStyleSize,
   stats2.gzipStyleSize,
-  difference.styleSize
+  difference.gzipStyleSize
 );
 
 const shieldRow = mdCompareRow(
@@ -46,7 +46,7 @@ const gzShieldRow = mdCompareRow(
   "Compressed ShieldJSON Size (b)",
   stats1.gzipShieldJSONSize,
   stats2.gzipShieldJSONSize,
-  difference.shieldJSONSize
+  difference.gzipShieldJSONSize
 );
 
 const ss1xRow = mdCompareRow(


### PR DESCRIPTION
This fixes a copy/paste typo from #1075 - seen here in #1069:

![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/3254090/5dd80b8a-a3f0-4c73-8a89-b665a158a296)
