### PR TITLE
feat: add Regional boundaries (`admin_level=5`)

### DIFF
--- a/src/layer/boundary.js
+++ b/src/layer/boundary.js
@@ -85,8 +85,8 @@ export const regionCasing = {
     "line-color": Color.borderCasing,
     "line-width": {
       stops: [
-        [11, 5],
-        [12, 6],
+        [8, 5],
+        [9, 6],
       ],
     },
   },

--- a/src/layer/boundary.js
+++ b/src/layer/boundary.js
@@ -78,6 +78,57 @@ export const county = {
   "source-layer": "boundary",
 };
 
+export const regionCasing = {
+  id: "boundary_region_casing",
+  type: "line",
+  paint: {
+    "line-color": Color.borderCasing,
+    "line-width": {
+      stops: [
+        [11, 5],
+        [12, 6],
+      ],
+    },
+  },
+  filter: [
+    "all",
+    ["==", ["get", "admin_level"], 5],
+    ["==", ["get", "disputed"], 0],
+    ["==", ["get", "maritime"], 0],
+  ],
+  minzoom: 8,
+  layout: {
+    "line-join": "round",
+    visibility: "visible",
+  },
+  source: "openmaptiles",
+  "source-layer": "boundary",
+};
+
+export const region = {
+  id: "boundary_region",
+  type: "line",
+  paint: {
+    "line-color": Color.border,
+    "line-dasharray": [5, 4],
+    "line-width": 1,
+    "line-offset": 0,
+  },
+  filter: [
+    "all",
+    ["==", ["get", "admin_level"], 5],
+    ["==", ["get", "disputed"], 0],
+    ["==", ["get", "maritime"], 0],
+  ],
+  minzoom: 6,
+  layout: {
+    "line-join": "round",
+    visibility: "visible",
+  },
+  source: "openmaptiles",
+  "source-layer": "boundary",
+};
+
 export const stateCasing = {
   id: "boundary_state_casing",
   type: "line",
@@ -321,6 +372,10 @@ export const legendEntries = [
   {
     description: "County or county-equivalent",
     layers: [county.id, countyCasing.id],
+  },
+  {
+    description: "Region",
+    layers: [region.id, regionCasing.id],
   },
   {
     description: "City, town, or village",

--- a/src/layer/index.js
+++ b/src/layer/index.js
@@ -37,6 +37,7 @@ export function build(locales) {
     lyrPark.parkFill,
 
     lyrBoundary.countyCasing,
+    lyrBoundary.regionCasing,
     lyrBoundary.stateCasing,
     lyrBoundary.countryCasing,
 
@@ -52,6 +53,7 @@ export function build(locales) {
 
     lyrBoundary.city,
     lyrBoundary.county,
+    lyrBoundary.region,
     lyrBoundary.state,
     lyrBoundary.country,
 


### PR DESCRIPTION
Fixes part of https://github.com/ZeLonewolf/openstreetmap-americana/issues/481

I based the style off of the county styles and gave them a bigger dashing

These boundaries only show up in the tiles from zoom index 9

Zoom 9:
![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/4595477/4f665e9c-f10b-4430-9cc6-38b0b5a17d44)

Zoom 12:
![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/4595477/35e38a23-49f3-468a-948c-1419bb893595)

Intersection of county, city and regional boundaries
![image](https://github.com/ZeLonewolf/openstreetmap-americana/assets/4595477/6f52dd12-6268-4e2b-ae2f-2f1375906152)

Let me know of any feedback