### PR TITLE
Add Madagascar national route shields

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -124,6 +124,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .ve,
 .dz,
 .gh,
+.mg,
 .am,
 .bd,
 .cn,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2919,6 +2919,12 @@ export function loadShields() {
     shields["GH:regional"] =
       roundedRectShield(Color.shields.yellow, Color.shields.black);
 
+  // Madagascar
+  shields["MG:RN-road"] = roundedRectShield(
+    Color.shields.red,
+    Color.shields.white
+  );
+
   // ASIA
 
   // Armenia


### PR DESCRIPTION
According to [French Wikipedia](https://fr.wikipedia.org/wiki/Liste_des_routes_nationales_%C3%A0_Madagascar), national routes of Madagascar have white-on-red rectangular shields (a common scheme in areas of French influence).