### PR TITLE
Update GitHub Pages URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -363,7 +363,7 @@ This style strives to draw representative highway shields wherever they are tagg
 For testing out changes across a variety of different shield designs and ref lengths there is a shield test gallery available:
 
 - In local development: http://localhost:1776/shieldtest.html
-- On the public demo site: https://zelonewolf.github.io/openstreetmap-americana/shieldtest.html
+- On the public demo site: https://americanamap.org/shieldtest.html
 
 This aims to display a table of all the unique shield designs in the style with some example refs from 1 to 6 characters. The `networks` and `refs` arrays can be modified for testing with a different set of either:
 

--- a/scripts/extract_layer.js
+++ b/scripts/extract_layer.js
@@ -23,7 +23,7 @@ const locales = opts.locales[0].split(",");
 
 const style = Style.build(
   config.OPENMAPTILES_URL,
-  "https://zelonewolf.github.io/openstreetmap-americana/sprites/sprite",
+  "https://americanamap.org/sprites/sprite",
   "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
   locales
 );

--- a/scripts/folder_diff.ts
+++ b/scripts/folder_diff.ts
@@ -81,7 +81,7 @@ fs.readdirSync(outputFolder)
       // Add an entry to the markdown table
       const loc = getLocationByName(basefile);
       mdContent +=
-        `| ${basefile}<br>${loc}<br>[Current Render](https://zelonewolf.github.io/openstreetmap-americana/#map=${loc})` +
+        `| ${basefile}<br>${loc}<br>[Current Render](https://americanamap.org/#map=${loc})` +
         `<br>[This PR](${urlBase}#map=${loc}) ` +
         `| ![Current Render](${urlBase}${outputFolder}/${basefile}_${sha}_before.png) |` +
         ` ![This PR](${urlBase}${outputFolder}/${basefile}_${sha}_after.png) |\n`;

--- a/scripts/generate_style.js
+++ b/scripts/generate_style.js
@@ -21,7 +21,7 @@ let opts = program.opts();
 
 let style = Style.build(
   config.OPENMAPTILES_URL,
-  "https://zelonewolf.github.io/openstreetmap-americana/sprites/sprite",
+  "https://americanamap.org/sprites/sprite",
   "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
   opts.locales
 );

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -69,7 +69,7 @@ const distDir = opts.directory;
 
 const style = Style.build(
   config.OPENMAPTILES_URL,
-  "https://zelonewolf.github.io/openstreetmap-americana/sprites/sprite",
+  "https://americanamap.org/sprites/sprite",
   "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
   locales
 );

--- a/scripts/taginfo.js
+++ b/scripts/taginfo.js
@@ -93,7 +93,7 @@ function addNetworkTags(project) {
         if (!fs.existsSync(save_filename)) {
           fs.writeFileSync(save_filename, shieldGfx.canvas.toBuffer());
         }
-        icon_url = `https://zelonewolf.github.io/openstreetmap-americana/shield-sample/shield_${network_filename_id}.svg`;
+        icon_url = `https://americanamap.org/shield-sample/shield_${network_filename_id}.svg`;
       } else if (
         icon !== undefined &&
         (shieldDef.colorLighten !== undefined ||
@@ -122,7 +122,7 @@ function addNetworkTags(project) {
         if (!fs.existsSync(save_filename)) {
           fs.writeFileSync(`${process.cwd()}/${save_filename}`, svgText);
         }
-        icon_url = `https://zelonewolf.github.io/openstreetmap-americana/shield-sample/shield_${network_filename_id}.svg`;
+        icon_url = `https://americanamap.org/shield-sample/shield_${network_filename_id}.svg`;
       } else {
         icon_url = `https://raw.githubusercontent.com/ZeLonewolf/openstreetmap-americana/main/icons/${icon}.svg`;
       }

--- a/shieldlib/README.md
+++ b/shieldlib/README.md
@@ -323,4 +323,4 @@ In addition to the stock drawing functions, a custom draw function can be specif
 
 ## Documentation
 
-See [TypeDoc generated documentation](https://zelonewolf.github.io/openstreetmap-americana/shield-docs/index.html) for detailed API information.
+See [TypeDoc generated documentation](https://americanamap.org/shield-docs/index.html) for detailed API information.


### PR DESCRIPTION
Replaced references to zelonewolf.github.io with americanamap.org. Although zelonewolf.github.io currently redirects to americanamap.org, Mapbox GL JS and MapLibre GL JS are apparently unable to follow the redirect due to [a CORS error](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMissingAllowOrigin). This doesn’t affect the main deployed application, but it does affect anyone who uses the published style.json. Every fork of this repository will need to make a similar change.