### PR TITLE
Move fontstack66 to font.americanamap.org

### DIFF
--- a/scripts/generate_style.js
+++ b/scripts/generate_style.js
@@ -22,7 +22,7 @@ let opts = program.opts();
 let style = Style.build(
   config.OPENMAPTILES_URL,
   "https://americanamap.org/sprites/sprite",
-  "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
+  "https://font.americanamap.org/{fontstack}/{range}.pbf",
   opts.locales
 );
 

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -70,7 +70,7 @@ const distDir = opts.directory;
 const style = Style.build(
   config.OPENMAPTILES_URL,
   "https://americanamap.org/sprites/sprite",
-  "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
+  "https://font.americanamap.org/{fontstack}/{range}.pbf",
   locales
 );
 

--- a/src/js/map_builder.ts
+++ b/src/js/map_builder.ts
@@ -33,7 +33,7 @@ export function buildStyle(): StyleSpecification {
     config.OPENMAPTILES_URL,
     `${baseUrl}/sprites/sprite`,
     config.FONT_URL ??
-      "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
+      "https://font.americanamap.org/{fontstack}/{range}.pbf",
     Label.getLocales()
   );
 }

--- a/src/js/map_builder.ts
+++ b/src/js/map_builder.ts
@@ -32,8 +32,7 @@ export function buildStyle(): StyleSpecification {
   return Style.build(
     config.OPENMAPTILES_URL,
     `${baseUrl}/sprites/sprite`,
-    config.FONT_URL ??
-      "https://font.americanamap.org/{fontstack}/{range}.pbf",
+    config.FONT_URL ?? "https://font.americanamap.org/{fontstack}/{range}.pbf",
     Label.getLocales()
   );
 }


### PR DESCRIPTION
I've installed font.americanamap.org on fontstack66.  This PR changes github.io URLs to point there.