### PR TITLE
Update GitHub Pages URLs for glyphs

### DIFF
--- a/scripts/extract_layer.js
+++ b/scripts/extract_layer.js
@@ -24,7 +24,7 @@ const locales = opts.locales[0].split(",");
 const style = Style.build(
   config.OPENMAPTILES_URL,
   "https://americanamap.org/sprites/sprite",
-  "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
+  "https://font.americanamap.org/{fontstack}/{range}.pbf",
   locales
 );
 

--- a/scripts/generate_style.js
+++ b/scripts/generate_style.js
@@ -22,7 +22,7 @@ let opts = program.opts();
 let style = Style.build(
   config.OPENMAPTILES_URL,
   "https://americanamap.org/sprites/sprite",
-  "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
+  "https://font.americanamap.org/{fontstack}/{range}.pbf",
   opts.locales
 );
 

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -70,7 +70,7 @@ const distDir = opts.directory;
 const style = Style.build(
   config.OPENMAPTILES_URL,
   "https://americanamap.org/sprites/sprite",
-  "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
+  "https://font.americanamap.org/{fontstack}/{range}.pbf",
   locales
 );
 

--- a/src/js/map_builder.ts
+++ b/src/js/map_builder.ts
@@ -32,8 +32,7 @@ export function buildStyle(): StyleSpecification {
   return Style.build(
     config.OPENMAPTILES_URL,
     `${baseUrl}/sprites/sprite`,
-    config.FONT_URL ??
-      "https://osm-americana.github.io/fontstack66/{fontstack}/{range}.pbf",
+    config.FONT_URL ?? "https://font.americanamap.org/{fontstack}/{range}.pbf",
     Label.getLocales()
   );
 }


### PR DESCRIPTION
As of today, the [osm-americana/fontstack66](https://github.com/osm-americana/fontstack66/) repository publishes to font.americanamap.org instead of zelonewolf.github.io. This breaks everything except the main repository’s main deployment at americanamap.org, because nothing else has CORS permissions to the old location anymore to even see the redirect. This change updates glyphs to point to the new location.