### PR TITLE
Move web-fonts github pages link to webfont.americanamap.org

### DIFF
--- a/src/fonts.css
+++ b/src/fonts.css
@@ -1,8 +1,8 @@
 @font-face {
   font-family: "Noto Sans Condensed";
-  src: url("https://osm-americana.github.io/web-fonts/noto/NotoSans-CondensedMedium-PropNums.woff2")
+  src: url("https://webfont.americanamap.org/noto/NotoSans-CondensedMedium-PropNums.woff2")
       format("woff2"),
-    url("https://osm-americana.github.io/web-fonts/noto/NotoSans-CondensedMedium-PropNums.woff")
+    url("https://webfont.americanamap.org/noto/NotoSans-CondensedMedium-PropNums.woff")
       format("woff");
   font-weight: 500;
   font-style: normal;
@@ -10,9 +10,9 @@
 }
 @font-face {
   font-family: "Noto Sans Armenian Condensed";
-  src: url("https://osm-americana.github.io/web-fonts/noto/NotoSansArmenian-CondensedMedium-PropNums.woff2")
+  src: url("https://webfont.americanamap.org/noto/NotoSansArmenian-CondensedMedium-PropNums.woff2")
       format("woff2"),
-    url("https://osm-americana.github.io/web-fonts/noto/NotoSansArmenian-CondensedMedium-PropNums.woff")
+    url("https://webfont.americanamap.org/noto/NotoSansArmenian-CondensedMedium-PropNums.woff")
       format("woff");
   font-weight: 500;
   font-style: normal;


### PR DESCRIPTION
Swap of URLs over to the americanamap.org domain.
Merge needs to happen simultaneously with connecting the domain name to github pages on the web-font repo side.  As we've learned.